### PR TITLE
AVN-223: nve-input

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,6 +17,10 @@ const config: StorybookConfig = {
   ${head}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/themes/light.css" />
   <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/source-sans-pro" />
+  <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+    />
   <link rel="stylesheet" href="${varsomCSSPath}" />
   <link rel="stylesheet" href="${globalCSSPath}" />
 `,

--- a/doc/components.md
+++ b/doc/components.md
@@ -2,6 +2,9 @@
 
 Komponenter i alfabetisk rekkefølge:
 
-- [button](./nve-button.md)
-- [icon](./nve-icon.md)
-- [spinner](./nve-spinner.md)
+- [nve-button](./nve-button.md)
+- [nve-icon](./nve-icon.md)
+- [nve-input](./nve-input.md)
+- [nve-label](./nve-label.md)
+- [nve-spinner](./nve-spinner.md)
+- [nve-tooltip](./nve-tooltip.md)

--- a/doc/nve-button.md
+++ b/doc/nve-button.md
@@ -1,6 +1,6 @@
 # nve-button
 
-En Shoelace-knapp i NVE-forkledning
+En Shoelace-knapp i NVE-forkledning.
 Se https://shoelace.style/components/button
 
 TODO: Beskriv hvilke properties / attributter og varianter vi ikke skal bruke

--- a/doc/nve-input.md
+++ b/doc/nve-input.md
@@ -1,0 +1,121 @@
+# nve-input
+
+En sl-input i NVE-forkledning.
+Mer info: https://shoelace.style/components/input
+
+Vil du ha info-ikon med hjelpetekst etter ledeteksten, putt en nve-label i label-slot.
+
+Disse attributtene skal ikke brukes:
+- pill
+
+TODO: Utropstegn-ikon ved valideringsfeil
+TODO: Vise valideringsfeil med rød tekst under tekstfeltet
+
+## Properties
+
+| Property            | Attribute       | Modifiers | Type                                             | Default         | Description                                      |
+|---------------------|-----------------|-----------|--------------------------------------------------|-----------------|--------------------------------------------------|
+| `autocapitalize`    |                 |           | `"off" \| "none" \| "on" \| "sentences" \| "words" \| "characters"` |                 | Controls whether and how text input is automatically capitalized as it is entered by the user. |
+| `autocomplete`      |                 |           | `string`                                         |                 | Specifies what permission the browser has to provide assistance in filling out form field values. Refer to<br />[this page on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for available values. |
+| `autocorrect`       |                 |           | `"off" \| "on"`                                  |                 | Indicates whether the browser's autocorrect feature is on or off. |
+| `autofocus`         |                 |           | `boolean`                                        |                 | Indicates that the input should receive focus on page load. |
+| `checkValidity`     |                 |           | `() => boolean`                                  |                 |                                                  |
+| `clearable`         |                 |           | `boolean`                                        |                 | Adds a clear button when the input is not empty. |
+| `defaultChecked`    |                 |           | `boolean \| undefined`                           |                 |                                                  |
+| `defaultValue`      |                 |           | `string`                                         |                 | The default value of the form control. Primarily used for resetting the form control. |
+| `dir`               |                 |           | `string`                                         |                 |                                                  |
+| `disabled`          |                 |           | `boolean`                                        |                 | Disables the input.                              |
+| `enterkeyhint`      |                 |           | `"enter" \| "done" \| "go" \| "next" \| "previous" \| "search" \| "send"` |                 | Used to customize the label or icon of the Enter key on virtual keyboards. |
+| `filled`            |                 |           | `boolean`                                        |                 | Draws a filled input.                            |
+| `form`              |                 |           | `string`                                         |                 | By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you<br />to place the form control outside of a form and associate it with the form that has this `id`. The form must be in<br />the same document or shadow root for this to work. |
+| `getForm`           |                 |           | `() => HTMLFormElement \| null`                  |                 |                                                  |
+| `helpText`          |                 |           | `string`                                         |                 | The input's help text. If you need to display HTML, use the `help-text` slot instead. |
+| `input`             |                 |           | `HTMLInputElement`                               |                 |                                                  |
+| `inputmode`         |                 |           | `"text" \| "none" \| "search" \| "decimal" \| "numeric" \| "tel" \| "email" \| "url"` |                 | Tells the browser what type of data will be entered by the user, allowing it to display the appropriate virtual<br />keyboard on supportive devices. |
+| `label`             |                 |           | `string`                                         |                 | The input's label. If you need to display HTML, use the `label` slot instead. |
+| `lang`              |                 |           | `string`                                         |                 |                                                  |
+| `max`               |                 |           | `string \| number`                               |                 | The input's maximum value. Only applies to date and number input types. |
+| `maxlength`         |                 |           | `number`                                         |                 | The maximum length of input that will be considered valid. |
+| `min`               |                 |           | `string \| number`                               |                 | The input's minimum value. Only applies to date and number input types. |
+| `minlength`         |                 |           | `number`                                         |                 | The minimum length of input that will be considered valid. |
+| `name`              |                 |           | `string`                                         |                 | The name of the input, submitted as a name/value pair with form data. |
+| `noSpinButtons`     |                 |           | `boolean`                                        |                 | Hides the browser's built-in increment/decrement spin buttons for number inputs. |
+| `passwordToggle`    |                 |           | `boolean`                                        |                 | Adds a button to toggle the password's visibility. Only applies to password types. |
+| `passwordVisible`   |                 |           | `boolean`                                        |                 | Determines whether or not the password is currently visible. Only applies to password input types. |
+| `pattern`           |                 |           | `string`                                         |                 | A regular expression pattern to validate input against. |
+| `pill`              |                 |           | `boolean`                                        |                 | Draws a pill-style input with rounded edges.     |
+| `placeholder`       |                 |           | `string`                                         |                 | Placeholder text to show as a hint when the input is empty. |
+| `readonly`          |                 |           | `boolean`                                        |                 | Makes the input readonly.                        |
+| `reportValidity`    |                 |           | `() => boolean`                                  |                 |                                                  |
+| `required`          |                 |           | `boolean`                                        |                 | Makes the input a required field.                |
+| `requiredLabel`     | `requiredLabel` |           | `string`                                         | "*Obligatorisk" | Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard. |
+| `setCustomValidity` |                 |           | `(message: string) => void`                      |                 |                                                  |
+| `size`              |                 |           | `"small" \| "medium" \| "large"`                 |                 | The input's size.                                |
+| `spellcheck`        |                 |           | `boolean`                                        |                 | Enables spell checking on the input.             |
+| `step`              |                 |           | `number \| "any"`                                |                 | Specifies the granularity that the value must adhere to, or the special value `any` which means no stepping is<br />implied, allowing any numeric value. Only applies to date and number input types. |
+| `title`             |                 |           | `string`                                         |                 |                                                  |
+| `type`              |                 |           | `"number" \| "text" \| "search" \| "tel" \| "email" \| "url" \| "date" \| "datetime-local" \| "password" \| "time"` |                 | The type of input. Works the same as a native `<input>` element, but only a subset of types are supported. Defaults<br />to `text`. |
+| `validationMessage` |                 | readonly  | `string`                                         |                 | Gets the validation message                      |
+| `validity`          |                 | readonly  | `ValidityState`                                  |                 | Gets the validity state object                   |
+| `value`             |                 |           | `string`                                         |                 | The current value of the input, submitted as a name/value pair with form data. |
+| `valueAsDate`       |                 |           | `Date \| null`                                   |                 | Gets or sets the current value as a `Date` object. Returns `null` if the value can't be converted. This will use the native `<input type="{{type}}">` implementation and may result in an error. |
+| `valueAsNumber`     |                 |           | `number`                                         |                 | Gets or sets the current value as a number. Returns `NaN` if the value can't be converted. |
+
+## Methods
+
+| Method                 | Type                                             | Description                                      |
+|------------------------|--------------------------------------------------|--------------------------------------------------|
+| `blur`                 | `(): void`                                       | Removes focus from the input.                    |
+| `checkValidity`        | `(): boolean`                                    | Checks for validity but does not show a validation message. Returns `true` when valid and `false` when invalid. |
+| `emit`                 | `{ <T extends "submit" \| "reset" \| "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| ... 112 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<...` | Emits a custom event with more convenient defaults. |
+| `focus`                | `(options?: FocusOptions \| undefined): void`    | Sets focus on the input.                         |
+| `getForm`              | `(): HTMLFormElement \| null`                    | Gets the associated form, if one exists.         |
+| `handleDisabledChange` | `(): void`                                       |                                                  |
+| `handleStepChange`     | `(): void`                                       |                                                  |
+| `handleValueChange`    | `(): Promise<void>`                              |                                                  |
+| `reportValidity`       | `(): boolean`                                    | Checks for validity and shows the browser's validation message if the control is invalid. |
+| `select`               | `(): void`                                       | Selects all the text in the input.               |
+| `setCustomValidity`    | `(message: string): void`                        | Sets a custom validation message. Pass an empty string to restore validity. |
+| `setRangeText`         | `(replacement: string, start?: number \| undefined, end?: number \| undefined, selectMode?: "select" \| "start" \| "end" \| "preserve" \| undefined): void` | Replaces a range of text with a new string.      |
+| `setSelectionRange`    | `(selectionStart: number, selectionEnd: number, selectionDirection?: "none" \| "forward" \| "backward" \| undefined): void` | Sets the start and end positions of the text selection (0-based). |
+| `showPicker`           | `(): void`                                       | Displays the browser picker for an input element (only works if the browser supports it for the input type). |
+| `stepDown`             | `(): void`                                       | Decrements the value of a numeric input type by the value of the step attribute. |
+| `stepUp`               | `(): void`                                       | Increments the value of a numeric input type by the value of the step attribute. |
+
+## Events
+
+| Event        | Description                                      |
+|--------------|--------------------------------------------------|
+| `sl-blur`    | Emitted when the control loses focus.            |
+| `sl-change`  | Emitted when an alteration to the control's value is committed by the user. |
+| `sl-clear`   | Emitted when the clear button is activated.      |
+| `sl-focus`   | Emitted when the control gains focus.            |
+| `sl-input`   | Emitted when the control receives input.         |
+| `sl-invalid` | Emitted when the form control has been checked for validity and its constraints aren't satisfied. |
+
+## Slots
+
+| Name                 | Description                                      |
+|----------------------|--------------------------------------------------|
+| `clear-icon`         | An icon to use in lieu of the default clear icon. |
+| `help-text`          | Text that describes how to use the input. Alternatively, you can use the `help-text` attribute. |
+| `hide-password-icon` | An icon to use in lieu of the default hide password icon. |
+| `label`              | The input's label. Alternatively, you can use the `label` attribute. |
+| `prefix`             | Used to prepend a presentational icon or similar element to the input. |
+| `show-password-icon` | An icon to use in lieu of the default show password icon. |
+| `suffix`             | Used to append a presentational icon or similar element to the input. |
+
+## CSS Shadow Parts
+
+| Part                     | Description                                      |
+|--------------------------|--------------------------------------------------|
+| `base`                   | The component's base wrapper.                    |
+| `clear-button`           | The clear button.                                |
+| `form-control`           | The form control that wraps the label, input, and help text. |
+| `form-control-help-text` | The help text's wrapper.                         |
+| `form-control-input`     | The input's wrapper.                             |
+| `form-control-label`     | The label's wrapper.                             |
+| `input`                  | The internal `<input>` control.                  |
+| `password-toggle-button` | The password toggle button.                      |
+| `prefix`                 | The container that wraps the prefix.             |
+| `suffix`                 | The container that wraps the suffix.             |

--- a/doc/nve-label.md
+++ b/doc/nve-label.md
@@ -1,0 +1,19 @@
+# nve-label
+
+Ledetekst med valgfritt info-ikon
+
+## Properties
+
+| Property  | Attribute | Type                                          | Default | Description                                      |
+|-----------|-----------|-----------------------------------------------|---------|--------------------------------------------------|
+| `light`   | `light`   | `boolean`                                     | false   | Sett denne hvis du vil ha litt lettere skriftvekt |
+| `size`    | `size`    | `"small" \| "medium" \| "large" \| "x-small"` | "small" | Størrelse                                        |
+| `tooltip` | `tooltip` | `string`                                      | ""      | Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet |
+| `value`   | `value`   | `string`                                      | ""      | Teksten som skal vises                           |
+
+## Slots
+
+| Name      | Description                                      |
+|-----------|--------------------------------------------------|
+| `label`   | teksten som skal vises. Eller du kan bruke label-attributtet |
+| `tooltip` | innhold i denne blir vist som en tooltip hvis man svever over info-ikonet<br /><br />TODO: Skal være litt mer plass mellom tekst og info-ikon |

--- a/doc/nve-tooltip.md
+++ b/doc/nve-tooltip.md
@@ -1,0 +1,65 @@
+# nve-tooltip
+
+En sl-tooltip i NVE-uniform. TODO: Denne har ingen NVE-styling ennå.
+
+## Properties
+
+| Property      | Type                                             | Description                                      |
+|---------------|--------------------------------------------------|--------------------------------------------------|
+| `body`        | `HTMLElement`                                    |                                                  |
+| `content`     | `string`                                         | The tooltip's content. If you need to display HTML, use the `content` slot instead. |
+| `defaultSlot` | `HTMLSlotElement`                                |                                                  |
+| `dir`         | `string`                                         |                                                  |
+| `disabled`    | `boolean`                                        | Disables the tooltip so it won't show when triggered. |
+| `distance`    | `number`                                         | The distance in pixels from which to offset the tooltip away from its target. |
+| `hoist`       | `boolean`                                        | Enable this option to prevent the tooltip from being clipped when the component is placed inside a container with<br />`overflow: auto\|hidden\|scroll`. Hoisting uses a fixed positioning strategy that works in many, but not all,<br />scenarios. |
+| `lang`        | `string`                                         |                                                  |
+| `open`        | `boolean`                                        | Indicates whether or not the tooltip is open. You can use this in lieu of the show/hide methods. |
+| `placement`   | `"top" \| "top-start" \| "top-end" \| "right" \| "right-start" \| "right-end" \| "bottom" \| "bottom-start" \| "bottom-end" \| "left" \| "left-start" \| "left-end"` | The preferred placement of the tooltip. Note that the actual placement may vary as needed to keep the tooltip<br />inside of the viewport. |
+| `popup`       | `SlPopup`                                        |                                                  |
+| `skidding`    | `number`                                         | The distance in pixels from which to offset the tooltip along its target. |
+| `trigger`     | `string`                                         | Controls how the tooltip is activated. Possible options include `click`, `hover`, `focus`, and `manual`. Multiple<br />options can be passed by separating them with a space. When manual is used, the tooltip must be activated<br />programmatically. |
+
+## Methods
+
+| Method                 | Type                                             | Description                                      |
+|------------------------|--------------------------------------------------|--------------------------------------------------|
+| `emit`                 | `{ <T extends "submit" \| "reset" \| "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| ... 112 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<...` | Emits a custom event with more convenient defaults. |
+| `handleDisabledChange` | `(): void`                                       |                                                  |
+| `handleOpenChange`     | `(): Promise<void>`                              |                                                  |
+| `handleOptionsChange`  | `(): Promise<void>`                              |                                                  |
+| `hide`                 | `(): Promise<void>`                              | Hides the tooltip                                |
+| `show`                 | `(): Promise<void>`                              | Shows the tooltip.                               |
+
+## Events
+
+| Event           | Description                                      |
+|-----------------|--------------------------------------------------|
+| `sl-after-hide` | Emitted after the tooltip has hidden and all animations are complete. |
+| `sl-after-show` | Emitted after the tooltip has shown and all animations are complete. |
+| `sl-hide`       | Emitted when the tooltip begins to hide.         |
+| `sl-show`       | Emitted when the tooltip begins to show.         |
+
+## Slots
+
+| Name      | Description                                      |
+|-----------|--------------------------------------------------|
+|           | The tooltip's target element. Avoid slotting in more than one element, as subsequent ones will be ignored. |
+| `content` | The content to render in the tooltip. Alternatively, you can use the `content` attribute. |
+
+## CSS Shadow Parts
+
+| Part          | Description                                      |
+|---------------|--------------------------------------------------|
+| `base`        | The component's base wrapper, an `<sl-popup>` element. |
+| `base__arrow` | The popup's exported `arrow` part. Use this to target the tooltip's arrow. |
+| `base__popup` | The popup's exported `popup` part. Use this to target the tooltip's popup container. |
+| `body`        | The tooltip's body where its content is rendered. |
+
+## CSS Custom Properties
+
+| Property       | Description                                      |
+|----------------|--------------------------------------------------|
+| `--hide-delay` | The amount of time to wait before hiding the tooltip when hovering. |
+| `--max-width`  | The maximum width of the tooltip before its content will wrap. |
+| `--show-delay` | The amount of time to wait before showing the tooltip when hovering. |

--- a/index.html
+++ b/index.html
@@ -4,29 +4,16 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Lit + TS</title>
+    <title>NVE DS test-app</title>
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
-    <link rel="stylesheet" href="./build/css/varsom.css" />
-    <script
-      type="module"
-      src="/src/components/nve-button/nve-button.ts"
-    ></script>
-    <script
-      type="module"
-      src="/src/components/nve-spinner/nve-spinner.ts"
-    ></script>
-    <script type="module" src="/src/components/nve-icon/nve-icon.ts"></script>
+    <script type="module" src="/src/components/index.ts"></script>
   </head>
   <body>
     <div id="app"></div>
-    <nve-button
-    trailing-icon
-    ></nve-button>
     <!-- This div serves as a container for your Lit app -->
-
     <!-- Import your Vite-generated JS entry point -->
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,7 @@
+/** Alle komponenter som er tilgjengelige, i alfabetisk rekkefølge. */
+export * from './nve-button/nve-button';
+export * from './nve-label/nve-label';
+export * from './nve-icon/nve-icon';
+export * from './nve-input/nve-input';
+export * from './nve-spinner/nve-spinner';
+export * from './nve-tooltip/nve-tooltip';

--- a/src/components/nve-button/nve-button-demo.ts
+++ b/src/components/nve-button/nve-button-demo.ts
@@ -1,0 +1,89 @@
+import { html } from 'lit';
+
+/**
+ * Demonstrasjon av nve-input
+ */
+const table = html`
+    <hr/>
+    <h3 id="nve-button">nve-button</h3>
+    <table class="demo">
+    <thead>
+    <th>Variant</th>
+  <th>Primary</th>
+  <th>Secondary</th>
+  <th>Outlined</th>
+  <th>Ghost</th>
+</thead>
+  <tr>
+    <td>medium</td>
+    <td>
+      <nve-button size="medium" variant="primary" disabled="">I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="medium" variant="default">I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="medium" variant="neutral" outline>I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="medium" variant="neutral">I'm a NVE-butotn</nve-button>
+    </td>
+  </tr>
+  <tr>
+    <td>large</td>
+    <td>
+      <nve-button size="large" variant="primary">I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="large" variant="default">I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="large" variant="neutral" outline>I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="large" variant="neutral">I'm a NVE-butotn</nve-button>
+    </td>
+  </tr>
+  <tr>
+    <td>small</td>
+    <td>
+      <nve-button size="small" variant="primary">I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="small" variant="default">I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="small" variant="neutral" outline>I'm a NVE-butotn</nve-button>
+    </td>
+    <td>
+      <nve-button size="small" variant="neutral">I'm a NVE-butotn</nve-button>
+    </td>
+  </tr>
+  <tr>
+    <td>neutral</td>
+    <td colspan="4"><nve-button variant="neutral" outline> im a butotn</nve-button></td>
+  </tr>
+  <tr>
+    <td>loading</td>
+    <td colspan="4">
+      <nve-button colspan="4" variant="neutral" outline loading> im a butotn</nve-button>
+    </td>
+  </tr>
+  <tr>
+    <td>loading with slot</td>
+    <td colspan="4">
+      <nve-button variant="neutral" outline>
+        im a butotn
+        <!-- Hvis vi vil ha både label og spinner kan vi ikke bruke loading property på knappen og span med suffix må renders kondisjonelt -->
+        <span slot="suffix"><nve-spinner></nve-spinner></span>
+      </nve-button>
+      <nve-button variant="neutral" outline>
+        im a butotn
+        <span slot="prefix"> <nve-icon name="search"></nve-icon></span>
+        <span slot="suffix"><nve-spinner></nve-spinner></span>
+      </nve-button>
+    </td>
+  </tr>
+</table> `;
+
+export default table;

--- a/src/components/nve-icon/nve-icon.ts
+++ b/src/components/nve-icon/nve-icon.ts
@@ -21,11 +21,11 @@ export class NveIcon extends LitElement {
   
     /* we need it to center the icon */
     :is(span) {
-      display: flex;
+      display: inline-flex;
     }
   `;
   render() {
-    return html` <span class="material-symbols-outlined">${this.name}</span> `;
+    return html`<span class="material-symbols-outlined">${this.name}</span>`;
   }
 }
 declare global {

--- a/src/components/nve-input/nve-input-demo.ts
+++ b/src/components/nve-input/nve-input-demo.ts
@@ -1,0 +1,162 @@
+import { html } from 'lit';
+
+/**
+ * Demonstrasjon av nve-input
+ */
+const table = html`
+  <hr />
+  <h3 id="nve-input">nve-input</h3>
+  <table class="demo">
+    <thead>
+      <tr>
+        <th></th>
+        <th>filled = false</th>
+        <th>filled = true</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Standard</td>
+        <td>
+          <nve-input label="Label" value="Tekst"></nve-input>
+        </td>
+        <td>
+          <nve-input filled label="Label" value="Tekst"></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Med info-ikon og verktøyhint</td>
+        <td>
+          <nve-input value="Tekst">
+            <nve-label value="Svev over ikonet" slot="label" tooltip="Hjelpetekst"></nve-label>
+          </nve-input>
+        </td>
+        <td>
+          <nve-input filled value="Tekst">
+            <nve-label value="Svev over ikonet" slot="label" tooltip="Hjelpetekst"></nve-label>
+          </nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Aktiv</td>
+        <td>
+          <nve-input clearable value="Tekst"></nve-input>
+        </td>
+        <td>
+          <nve-input filled clearable value="Tekst"></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Deaktivert</td>
+        <td>
+          <nve-input disabled value="Tekst"></nve-input>
+        </td>
+        <td>
+          <nve-input filled disabled value="Tekst"></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Deaktivert med ikon</td>
+        <td>
+          <nve-input disabled value="Tekst">
+            <nve-icon slot="suffix" name="Lock"></nve-icon>
+          </nve-input>
+        </td>
+        <td>
+          <nve-input filled disabled value="Tekst">
+            <nve-icon slot="suffix" name="Lock"></nve-icon>
+          </nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Skrivebeskyttet</td>
+        <td>
+          <nve-input readonly value="Tekst"></nve-input>
+        </td>
+        <td>
+          <nve-input filled readonly value="Tekst"></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Valideringsfeil</td>
+        <td>
+          <nve-input type="number" value="41" min="42" max="42"></nve-input>
+        </td>
+        <td>
+          <nve-input filled type="number" value="41" min="42" max="42"></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Passord</td>
+        <td><nve-input type="password" password-toggle="true" value="hemmelig"></nve-input></td>
+        <td><nve-input filled type="password" password-toggle="true" value="hemmelig"></nve-input></td>
+      </tr>
+      <tr>
+        <td>Obligatorisk</td>
+        <td>
+          <nve-input required value="">
+            <nve-label slot="label" label="Label"></nve-label>
+          </nve-input>
+        </td>
+        <td>
+          <nve-input filled required label="Label" value=""></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Obligatorisk med engelsk tekst</td>
+        <td>
+          <nve-input required requiredLabel="*Required" value="">
+            <nve-label slot="label" label="Label"></nve-label>
+          </nve-input>
+        </td>
+        <td>
+          <nve-input filled required requiredLabel="*Required" label="Label" value=""></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Tall</td>
+        <td><nve-input type="number" value="42"></nve-input></td>
+        <td><nve-input filled type="number" value="42"></nve-input></td>
+      </tr>
+      <tr>
+        <td>Dato</td>
+        <td><nve-input type="date"></nve-input></td>
+        <td><nve-input filled type="date"></nve-input></td>
+      </tr>
+      <tr>
+        <td>Dato og tid</td>
+        <td><nve-input type="datetime-local"></nve-input></td>
+        <td><nve-input filled type="datetime-local"></nve-input></td>
+      </tr>
+      <tr>
+        <td>Størrelse: Liten</td>
+        <td>
+          <nve-input size="small" label="small" value="small"></nve-input>
+        </td>
+        <td>
+          <nve-input filled size="small" label="small" value="small"></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Størrelse: Middels (standard)</td>
+        <td>
+          <nve-input label="medium" value="medium"></nve-input>
+        </td>
+        <td>
+          <nve-input filled label="medium" value="medium"></nve-input>
+        </td>
+      </tr>
+      <tr>
+        <td>Størrelse: Stor</td>
+        <td>
+          <nve-input size="large" label="large" value="large"></nve-input>
+        </td>
+        <td>
+          <nve-input filled size="large" label="large" value="large"></nve-input>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+`;
+
+export default table;

--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -1,0 +1,84 @@
+import { css } from 'lit';
+
+export default css`
+  :host {
+    /* Overstyring av shoelace-token-verdier */
+
+    --sl-input-border-width: var(--border-width-default);
+
+    --sl-spacing-3x-small: var(--spacing-xx-small);
+    --sl-input-spacing-small: var(--spacing-x-small);
+    --sl-input-spacing-medium: var(--spacing-x-small);
+    --sl-input-spacing-large: var(--spacing-x-small);
+
+    --sl-input-required-content: '*Obligatorisk';
+    --sl-input-required-content-offset: -2px;
+    --sl-input-required-content-color: var(--brand-deep);
+  }
+
+  .input {
+    font: var(--body-small);
+    border-radius: var(--border-radius-small);
+  }
+
+  .input--filled {
+    border: 1px solid var(--neutrals-background-secondary);
+  }
+
+  /* Justering av skriftstørrelse og hjørner for andre størrelser av tekstfeltet */
+  .input--small {
+    font: var(--body-xsmall);
+  }
+  .input--large {
+    border-radius: var(--border-radius-large);
+    font: var(--body-large);
+  }
+
+  .form-control label {
+    font: var(--label-medium);
+  }
+
+  /* Riktig fokus-markering også i filled-modus */
+  .input--standard.input--focused:not(.input--disabled) { 
+    outline: var(--sl-focus-ring); 
+    outline-offset: var(--sl-focus-ring-offset); 
+    box-shadow: unset; 
+  }
+
+  /* Riktige farger når skrivebeskyttet */
+  :host([readonly]) .input {
+    border: none;
+    background: var(--neutrals-background-secondary);
+  }
+  :host([readonly]) {
+    border-color: var(--interactive-secondary-background-default);
+    background: var(--neutrals-background-secondary);
+    color: var(--interactive-secondary-foreground-default);
+  }
+
+  /** Gir rød ramme ved valideringsfeil  */
+  :host([data-invalid])::part(base),
+  :host([data-user-invalid])::part(base) {
+    border-color: var(--feedback-background-emphasized-error);
+  }
+  :host([data-invalid])::part(input),
+  :host([data-user-invalid])::part(input) {
+    color: var(--feedback-background-emphasized-error);
+  }
+
+  :host([required-label])::part(form-control-label) {
+
+  }
+
+  /* Formaterer "*Obligatorisk" over input-felt og til høyre riktig når required er satt */
+  .form-control--has-label .form-control__label {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    margin-inline-start: unset;
+  }
+  ::after {
+    font-weight: var(--font-weight-regular);
+    margin-inline-start: unset;
+  }
+`;

--- a/src/components/nve-input/nve-input.ts
+++ b/src/components/nve-input/nve-input.ts
@@ -1,0 +1,42 @@
+import { customElement, property } from 'lit/decorators.js';
+import { SlInput } from '@shoelace-style/shoelace';
+import styles from './nve-input.styles';
+
+/**
+ * En sl-input i NVE-forkledning.
+ * Mer info: https://shoelace.style/components/input
+ *
+ * Vil du ha info-ikon med hjelpetekst etter ledeteksten, putt en nve-label i label-slot.
+ *
+ * Disse attributtene skal ikke brukes:
+ * - pill
+ *
+ * TODO: Utropstegn-ikon ved valideringsfeil
+ * TODO: Vise valideringsfeil med rød tekst under tekstfeltet
+ */
+@customElement('nve-input')
+export class NveInput extends SlInput {
+
+  /**
+   * Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard.
+   */
+  @property({ reflect: true }) requiredLabel = '*Obligatorisk';
+
+  constructor() {
+    super();
+  }
+
+  static styles = [SlInput.styles, styles];
+
+  updated(changedProperties: Map<string, unknown>) {
+    if (changedProperties.has('requiredLabel')) {
+      this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-input': NveInput;
+  }
+}

--- a/src/components/nve-label/nve-label-demo.ts
+++ b/src/components/nve-label/nve-label-demo.ts
@@ -1,0 +1,80 @@
+import { html } from 'lit';
+
+/**
+ * Demonstrasjon av nve-label
+ */
+const table = html`
+  <hr />
+  <h3 id="nve-label">nve-label</h3>
+  <table class="demo">
+    <thead>
+      <tr>
+        <th></th>
+        <th></th>
+        <th>light</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Størrelse: x-small</td>
+        <td>
+          <nve-label size="x-small" value="En helt vanlig ledetekst"></nve-label>
+        </td>
+        <td>
+          <nve-label light size="x-small" value="En helt vanlig ledetekst"></nve-label>
+        </td>
+      </tr>
+      <tr>
+        <td>Størrelse: small (standard)</td>
+        <td>
+          <nve-label value="En helt vanlig ledetekst"></nve-label>
+        </td>
+        <td>
+          <nve-label light value="En helt vanlig ledetekst"></nve-label>
+        </td>
+      </tr>
+      <tr>
+        <td>Størrelse: medium</td>
+        <td>
+          <nve-label size="medium" value="En helt vanlig ledetekst"></nve-label>
+        </td>
+        <td>
+          <nve-label light size="medium" value="En helt vanlig ledetekst"></nve-label>
+        </td>
+      </tr>
+      <tr>
+        <td>Størrelse: large</td>
+        <td>
+          <nve-label size="large" value="En helt vanlig ledetekst"></nve-label>
+        </td>
+        <td>
+          <nve-label light size="large" value="En helt vanlig ledetekst"></nve-label>
+        </td>
+      </tr>
+      <tr>
+        <td>Med info-ikon og verktøyhint</td>
+        <td>
+          <nve-label value="Svev over ikonet" tooltip="Hjelpetekst"></nve-label>
+        </td>
+        <td>
+          <nve-label light value="Svev over ikonet" tooltip="Hjelpetekst"></nve-label>
+        </td>
+      </tr>
+      <tr>
+        <td>Med info-ikon og verktøyhint i html</td>
+        <td>
+          <nve-label value="Svev over ikonet">
+            <div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>
+          </nve-label>
+        </td>
+        <td>
+          <nve-label light value="Svev over ikonet">
+            <div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>
+          </nve-label>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+`;
+
+export default table;

--- a/src/components/nve-label/nve-label.styles.ts
+++ b/src/components/nve-label/nve-label.styles.ts
@@ -1,0 +1,45 @@
+import { css } from 'lit';
+
+/**
+ * Stiler til nve-label
+ */
+export const styles = css`
+  /* light-varianter for de forskjellige størrelsene */
+  :host([light]),
+  :host([size='x-small']) {
+    font: var(--label-x-small-light);
+  }
+  :host([light]),
+  :host([size='small']) {
+    font: var(--label-small-light);
+  }
+  :host([light]),
+  :host([size='medium']) {
+    font: var(--label-medium-light);
+  }
+  :host([light]),
+  :host([size='large']) {
+    font: var(--label-large-light);
+  }
+
+  /* størrelser men uten "light" */
+  :host([size='x-small']) {
+    font: var(--label-x-small);
+  }
+  :host([size='small']) {
+    font: var(--label-small);
+  }
+  :host([size='medium']) {
+    font: var(--label-medium);
+  }
+  :host([size='large']) {
+    font: var(--label-large);
+  }
+
+  .nve-info-icon {
+    color: var(--neutrals-foreground-subtle);
+    align-items: center;
+    vertical-align: bottom;
+    cursor: pointer;
+  }
+`;

--- a/src/components/nve-label/nve-label.ts
+++ b/src/components/nve-label/nve-label.ts
@@ -1,0 +1,69 @@
+import { customElement, property } from 'lit/decorators.js';
+import { html, LitElement } from 'lit';
+import { styles } from './nve-label.styles';
+import { HasSlotController } from '../../utils/slot';
+
+/**
+ * Ledetekst med valgfritt info-ikon
+ *
+ * @slot label - teksten som skal vises. Eller du kan bruke label-attributtet
+ * @slot tooltip - innhold i denne blir vist som en tooltip hvis man svever over info-ikonet
+ *
+ * TODO: Skal være litt mer plass mellom tekst og info-ikon
+ */
+@customElement('nve-label')
+export class NveLabel extends LitElement {
+  private readonly hasSlotController = new HasSlotController(this, 'tooltip');
+
+  /**
+   * Teksten som skal vises
+   */
+  @property({ reflect: true }) value = '';
+
+  /**
+   * Størrelse
+   */
+  @property({ reflect: true }) size: 'x-small' | 'small' | 'medium' | 'large' = 'small';
+
+  /**
+   * Sett denne hvis du vil ha litt lettere skriftvekt
+   */
+  @property({ type: Boolean, reflect: true }) light = false;
+
+  /**
+   * Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet
+   */
+  @property({ reflect: true }) tooltip = '';
+
+  static styles = [styles];
+
+  private renderInfoIconWithTooltip() {
+    let tooltipContent: ChildNode | string | null = this.tooltip;
+    if (!tooltipContent.length) {
+      // tooltip-property er ikke satt, vi prøver å se om vi har tooltip i slot i stedet
+      tooltipContent = this.hasSlotController.get('tooltip');
+    }
+    if (tooltipContent) {
+      return html`<nve-tooltip>
+        <div slot="content">${tooltipContent}</div>
+        <nve-icon class="nve-info-icon" name="Info"></nve-icon>
+      </nve-tooltip>`;
+    }
+    return html``; // tooltip er ikke spesifisert, så vi viser ikke denne delen
+  }
+
+  render() {
+    return html`
+      <label part="form-control-label" class="form-control__label" aria-hidden="false">
+        <slot name="label">${this.value}</slot>
+      </label>
+      ${this.renderInfoIconWithTooltip()}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-label': NveLabel;
+  }
+}

--- a/src/components/nve-label/nve-label.ts
+++ b/src/components/nve-label/nve-label.ts
@@ -44,7 +44,7 @@ export class NveLabel extends LitElement {
       tooltipContent = this.hasSlotController.get('tooltip');
     }
     if (tooltipContent) {
-      return html`<nve-tooltip>
+      return html`<nve-tooltip placement="top">
         <div slot="content">${tooltipContent}</div>
         <nve-icon class="nve-info-icon" name="Info"></nve-icon>
       </nve-tooltip>`;

--- a/src/components/nve-tooltip/nve-tooltip-demo.ts
+++ b/src/components/nve-tooltip/nve-tooltip-demo.ts
@@ -1,0 +1,38 @@
+import { html } from 'lit';
+
+/**
+ * Demonstrasjon av nve-tooltip
+ */
+const table = html`
+  <hr />
+  <h3 id="nve-tooltip">nve-tooltip</h3>
+  <table class="demo">
+    <thead>
+      <tr>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Med tekst-innhold</td>
+        <td>
+          <nve-tooltip content="Hjelpetekst">
+            <nve-button>Svev over meg</nve-button>
+          </nve-tooltip>
+        </td>
+      </tr>
+      <tr>
+        <td>Med HTML-innhold</td>
+        <td>
+          <nve-tooltip>
+            <div slot="content">Hjelpetekst i <strong>HTML</strong></div>
+            <nve-button>Svev over meg</nve-button>
+          </nve-tooltip>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+`;
+
+export default table;

--- a/src/components/nve-tooltip/nve-tooltip.ts
+++ b/src/components/nve-tooltip/nve-tooltip.ts
@@ -1,0 +1,19 @@
+import { customElement } from 'lit/decorators.js';
+import { SlTooltip } from '@shoelace-style/shoelace';
+
+/**
+ * En sl-tooltip i NVE-uniform. TODO: Denne har ingen NVE-styling ennå.
+ */
+@customElement('nve-tooltip')
+export class NveTooltip extends SlTooltip {
+  constructor() {
+    super();
+  }
+  static styles = [SlTooltip.styles];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-tooltip': NveTooltip;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import './styles/imports.css';
 import '../build/css/varsom.css';
 import './styles/global.css';
 import './styles/testsite.css';
+import './styles/imports.css';
 
 /* Importer demo-side for hver komponent du vil vise her og sett det i render-funksjonen */
 import buttonDemo from './components/nve-button/nve-button-demo';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,86 +1,14 @@
-// main.ts (or main.js if using JavaScript)
-import { html, render } from 'lit';
+// test-applikasjon for komponentbiblioteket
+import { render } from 'lit';
 import './styles/imports.css';
+import '../build/css/varsom.css';
 import './styles/global.css';
+import './styles/testsite.css';
 
-const app = html`<table>
-  <hr />
-  <th>Variant</th>
-  <th>Primary</th>
-  <th>Secondary</th>
-  <th>Outlined</th>
-  <th>Ghost</th>
-  <hr />
-  <tr>
-    <td>medium</td>
-    <td>
-      <nve-button size="medium" variant="primary" disabled="">I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="medium" variant="default">I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="medium" variant="neutral" outline>I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="medium" variant="neutral">I'm a NVE-butotn</nve-button>
-    </td>
-  </tr>
-  <tr>
-    <td>large</td>
-    <td>
-      <nve-button size="large" variant="primary">I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="large" variant="default">I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="large" variant="neutral" outline>I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="large" variant="neutral">I'm a NVE-butotn</nve-button>
-    </td>
-  </tr>
-  <tr>
-    <td>small</td>
-    <td>
-      <nve-button size="small" variant="primary">I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="small" variant="default">I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="small" variant="neutral" outline>I'm a NVE-butotn</nve-button>
-    </td>
-    <td>
-      <nve-button size="small" variant="neutral">I'm a NVE-butotn</nve-button>
-    </td>
-  </tr>
-  <tr>
-    <td>neutral</td>
-    <td><nve-button variant="neutral" outline> im a butotn</nve-button></td>
-  </tr>
-  <tr>
-    <td>loading</td>
-    <td>
-      <nve-button variant="neutral" outline loading> im a butotn</nve-button>
-    </td>
-  </tr>
-  <tr>
-    <td>loading with slot</td>
-    <td>
-      <nve-button variant="neutral" outline>
-        im a butotn
-        <!-- Hvis vi vil ha både label og spinner kan vi ikke bruke loading property på knappen og span med suffix må renders kondisjonelt -->
-        <span slot="suffix"><nve-spinner></nve-spinner></span>
-      </nve-button>
-    </td>
-    <td>
-      <nve-button variant="neutral" outline>
-        im a butotn
-        <span slot="prefix"> <nve-icon name="search"></nve-icon></span>
-      </nve-button>
-    </td>
-  </tr>
-</table> `;
-render(app, document.getElementById('app')!); // Render the Lit app in the specified container
+/* Importer demo-side for hver komponent du vil vise her og sett det i render-funksjonen */
+import buttonDemo from './components/nve-button/nve-button-demo';
+import tooltipDemo from './components/nve-tooltip/nve-tooltip-demo';
+import labelDemo from './components/nve-label/nve-label-demo';
+import inputDemo from './components/nve-input/nve-input-demo';
+
+render([buttonDemo, tooltipDemo, labelDemo, inputDemo], document.getElementById('app')!); // Render the Lit app in the specified container

--- a/src/stories/NveButton.stories.ts
+++ b/src/stories/NveButton.stories.ts
@@ -23,13 +23,14 @@ const meta = {
     docs: {
       description: {
         component: `<div>
+        <a href="https://github.com/doc/nve-button.md">API-dokumentasjon</a>
         <p>Knappeelementer brukes for å gi en enkel og tilgjengelig opplevelse for brukerne. 
         Et knappeelement skal brukes når en handling utføres av brukeren.
         </div>`
       }
     }
   }
-  
+
 } satisfies Meta<NveButtonProps>;
 
 export default meta;

--- a/src/stories/NveInput.stories.ts
+++ b/src/stories/NveInput.stories.ts
@@ -1,0 +1,50 @@
+import '../components/nve-input/nve-input';
+import '../components/nve-label/nve-label';
+import { StoryObj } from '@storybook/web-components';
+import { NveInput } from './NveInput';
+import type { NveInputProps } from './NveInput';
+
+
+const meta = {
+  title: 'Nve/NveInput',
+  tags: ['autodocs'],
+  render: (args: NveInputProps) => NveInput(args),
+  parameters: {
+    docs: {
+      description: {
+        component: '<h2><nve-input> | NveInput</h2><a href="https://github.com/doc/nve-input.md">API-dokumentasjon</a>',
+      }
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<NveInputProps>;
+
+export const standard: Story = {
+  args: {
+    filled: false,
+    label: 'Ledetekst',
+    value: 'Tekst',
+    required: false,
+    requiredLabel: '*Obligatorisk',
+  },
+};
+
+export const filled: Story = {
+  args: {
+    filled: true,
+    label: 'Ledetekst',
+    value: 'Tekst',
+  },
+};
+
+export const obligatorisk: Story = {
+  args: {
+    filled: true,
+    label: 'Ledetekst',
+    value: '',
+    required: true,
+    requiredLabel: '*Obligatorisk',
+  },
+};

--- a/src/stories/NveInput.ts
+++ b/src/stories/NveInput.ts
@@ -1,0 +1,22 @@
+import { html } from 'lit';
+
+export interface NveInputProps {
+  filled: boolean,
+  label: string;
+  value: string,
+  required: boolean,
+  requiredLabel: string
+}
+
+export const NveInput = (props: NveInputProps) => {
+  return html`
+      <nve-input
+        ?filled=${props.filled}
+        label=${props.label}
+        value=${props.value}
+        ?required=${props.required}
+        requiredLabel=${props.requiredLabel}
+      >
+      </nve-input>
+    `;
+};

--- a/src/stories/NveLabel.stories.ts
+++ b/src/stories/NveLabel.stories.ts
@@ -46,7 +46,7 @@ export const light: Story = {
   },
 };
 
-export const medVerktøyHint: Story = {
+export const medVerktoyHint: Story = {
   args: {
     value: 'Svev over meg',
     size: 'small',

--- a/src/stories/NveLabel.stories.ts
+++ b/src/stories/NveLabel.stories.ts
@@ -1,0 +1,56 @@
+import '../components/nve-icon/nve-icon';
+import '../components/nve-tooltip/nve-tooltip';
+import '../components/nve-label/nve-label';
+import { StoryObj } from '@storybook/web-components';
+import type { NveLabelProps } from './NveLabel';
+import { NveLabel } from './NveLabel';
+
+
+const meta = {
+  title: 'Nve/NveLabel',
+  tags: ['autodocs'],
+  render: (args: NveLabelProps) => NveLabel(args),
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['x-small', 'small', 'medium', 'large'],
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: '<h2><nve-label> | NveLabel</h2><a href="https://github.com/doc/nve-label.md">API-dokumentasjon</a>',
+      }
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<NveLabelProps>;
+
+export const standard: Story = {
+  args: {
+    value: 'Ledetekst',
+    size: 'small',
+    light: false,
+    tooltip: '',
+  },
+};
+
+export const light: Story = {
+  args: {
+    value: 'Ledetekst',
+    size: 'small',
+    light: true,
+    tooltip: '',
+  },
+};
+
+export const medVerktøyHint: Story = {
+  args: {
+    value: 'Svev over meg',
+    size: 'small',
+    light: true,
+    tooltip: 'verktøyhint',
+  },
+};

--- a/src/stories/NveLabel.ts
+++ b/src/stories/NveLabel.ts
@@ -1,0 +1,21 @@
+import { html } from 'lit';
+
+export interface NveLabelProps {
+  value: string,
+  size: 'x-small' | 'small' | 'medium' | 'large';
+  light: boolean,
+  tooltip: string,
+}
+
+export const NveLabel = (props: NveLabelProps) => {
+  let size = props.size ?? 'small';
+  return html`
+      <nve-label
+        value=${props.value}
+        size=${size}
+        ?light=${props.light}
+        tooltip=${props.tooltip}
+      >
+      </nve-label>
+    `;
+};

--- a/src/styles/testsite.css
+++ b/src/styles/testsite.css
@@ -1,0 +1,54 @@
+/** Stiler som bare brukes i test-applikasjonen */
+
+/* sett class="demo" på table for å få stiplete linjer rundt tabell*/
+.demo table {
+  border-collapse: separate;
+  border-spacing: 0;
+  position: relative;
+}
+
+.demo th,
+.demo td {
+  padding: 1rem;
+}
+
+.demo td:not(:first-child) {
+  border-bottom: 1px dashed black;
+  border-right: 1px dashed black;
+}
+
+.demo tr:first-child td:first-child {
+  width: 150px;
+}
+
+/* første og siste rad */
+.demo tr:first-child td:not(:first-child) {
+  border-top: none;
+}
+
+.demo tr:last-child td:not(:first-child) {
+  border-bottom: none;
+}
+
+/* ta bort siste høyre */
+.demo td:last-child {
+  border-right: none;
+}
+
+/* gruppe-ramme */
+.demo tbody:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 11.4rem;
+  right: 0;
+  bottom: 0;
+  border: 1px dashed black;
+  border-radius: 10px;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.demo tbody {
+  position: relative;
+}

--- a/src/utils/slot.ts
+++ b/src/utils/slot.ts
@@ -1,0 +1,113 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+/** 
+ * A reactive controller that determines when slots exist. 
+ * Denne kan du bruke til å sjekke om komponent har en slot og vise det slot'en inneholder. 
+ * Kopiert fra kildekoden til Shoelace og lettere modifisert. 
+ */
+export class HasSlotController implements ReactiveController {
+  host: ReactiveControllerHost & Element;
+  slotNames: string[] = [];
+
+  constructor(host: ReactiveControllerHost & Element, ...slotNames: string[]) {
+    (this.host = host).addController(this);
+    this.slotNames = slotNames;
+  }
+
+  private hasDefaultSlot() {
+    return [...this.host.childNodes].some((node) => {
+      if (node.nodeType === node.TEXT_NODE && node.textContent!.trim() !== '') {
+        return true;
+      }
+
+      if (node.nodeType === node.ELEMENT_NODE) {
+        const el = node as HTMLElement;
+        const tagName = el.tagName.toLowerCase();
+
+        // Ignore visually hidden elements since they aren't rendered
+        if (tagName === 'sl-visually-hidden') {
+          return false;
+        }
+
+        // If it doesn't have a slot attribute, it's part of the default slot
+        if (!el.hasAttribute('slot')) {
+          return true;
+        }
+      }
+
+      return false;
+    });
+  }
+
+  private hasNamedSlot(name: string): boolean {
+    return this.get(name) !== null;
+  }
+
+  /**
+   * @returns en slot med gitt navn eller null om den ikke finnes
+   */
+  get(slotName: string): ChildNode | null {
+    return this.host.querySelector(`:scope > [slot="${slotName}"]`);
+  }
+
+  test(slotName: string): boolean {
+    return slotName === '[default]' ? this.hasDefaultSlot() : this.hasNamedSlot(slotName);
+  }
+
+  hostConnected() {
+    this.host.shadowRoot!.addEventListener('slotchange', this.handleSlotChange);
+  }
+
+  hostDisconnected() {
+    this.host.shadowRoot!.removeEventListener('slotchange', this.handleSlotChange);
+  }
+
+  private handleSlotChange = (event: Event) => {
+    const slot = event.target as HTMLSlotElement;
+
+    if ((this.slotNames.includes('[default]') && !slot.name) || (slot.name && this.slotNames.includes(slot.name))) {
+      this.host.requestUpdate();
+    }
+  };
+}
+
+/**
+ * Given a slot, this function iterates over all of its assigned element and text nodes and returns the concatenated
+ * HTML as a string. This is useful because we can't use slot.innerHTML as an alternative.
+ */
+export function getInnerHTML(slot: HTMLSlotElement): string {
+  const nodes = slot.assignedNodes({ flatten: true });
+  let html = '';
+
+  [...nodes].forEach((node) => {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      html += (node as HTMLElement).outerHTML;
+    }
+
+    if (node.nodeType === Node.TEXT_NODE) {
+      html += node.textContent;
+    }
+  });
+
+  return html;
+}
+
+/**
+ * Given a slot, this function iterates over all of its assigned text nodes and returns the concatenated text as a
+ * string. This is useful because we can't use slot.textContent as an alternative.
+ */
+export function getTextContent(slot: HTMLSlotElement | undefined | null): string {
+  if (!slot) {
+    return '';
+  }
+  const nodes = slot.assignedNodes({ flatten: true });
+  let text = '';
+
+  [...nodes].forEach((node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      text += node.textContent;
+    }
+  });
+
+  return text;
+}


### PR DESCRIPTION
Da er nve-input klar til slakt.
Med på kjøpet får du også nve-label og nve-tooltip, siden nve-input trenger begge disse.
nve-tooltip har ingen nve-styling ennå da den ikke er ferdig i Figma. Jeg har heller ikke laget storybook for denne.
Takk til @Citaborg for god hjelp!

Jeg har rappet test-opplegget til Lars Thomas i #17. Synes dette er lett å jobbe med når man utvikler komponenter, og jeg tror det gir en bra demo for utviklere som skal bruke komponentene også, når vi får til å publisere test-appen. 
Ellers er det "bare" å kjøre `npm run dev` og åpne testsida i en nettleser  for dem som har utviklingsmiljø.

For å vise slot-innhold i tooltip (slik at vi kan vise noe annet enn ren tekst), har jeg "lånt" en klasse fra Shoelace og modifisert denne litt. Vi må gjerne diskutere hvordan vi kan gjøre dette enklere / smartere.