### PR TITLE
PR: avn-253 test storybook app on pr

### DIFF
--- a/.github/workflows/azure-static-web-app-kind-mushroom-03c272603.yml
+++ b/.github/workflows/azure-static-web-app-kind-mushroom-03c272603.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - task/avn-253/create-test-app-on-pr
+      - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - task/avn-253/create-test-app-on-pr
+      - main
 
 jobs:
   # Run when a pull request is created or updated

--- a/.github/workflows/azure-static-web-app-kind-mushroom-03c272603.yml
+++ b/.github/workflows/azure-static-web-app-kind-mushroom-03c272603.yml
@@ -1,0 +1,47 @@
+name: Azure Static Web Apps CI/CD
+
+on:
+  push:
+    branches:
+      - task/avn-253/create-test-app-on-pr
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - task/avn-253/create-test-app-on-pr
+
+jobs:
+  # Run when a pull request is created or updated
+  build_and_deploy_pull_request:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    name: Build and Deploy Pull Request
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN  }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          action: 'upload'
+          app_location: '/'
+          output_location: 'storybook-static'
+          app_build_command: 'npm run build-storybook'
+          ###### End of Repository/Build Configurations ######
+          close_pull_request_job:
+
+  close_pull_request_job:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: 'close'

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,19 +1,24 @@
 import type { StorybookConfig } from '@storybook/web-components-vite';
 
+const globalCSSPath = process.env.NODE_ENV === 'production' ? '/assets/global.css' : '../src/styles/global.css';
+
+const varsomCSSPath = process.env.NODE_ENV === 'production' ? '/assets/varsom.css' : '../../../build/css/varsom.css';
+
+// we have to add another styling files after they will be in use
+
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: [
-    '@storybook/addon-links',
-    '@storybook/addon-essentials'
-  ],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   framework: {
     name: '@storybook/web-components-vite',
     options: {},
   },
   previewHead: (head) => `
   ${head}
-  <link rel="stylesheet" href="../src/styles/global.css" />
-  <link rel="stylesheet" href="../../../build/css/varsom.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/themes/light.css" />
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/source-sans-pro" />
+  <link rel="stylesheet" href="${varsomCSSPath}" />
+  <link rel="stylesheet" href="${globalCSSPath}" />
 `,
   docs: {
     autodocs: 'tag',

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
     "preview": "vite preview",
     "lint": "eslint \"**/*.{js,ts}\"",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "storybook build  && npm run copy-files-storybook",
     "build:light": "node transform.js light",
     "build:dark": "node transform.js dark",
     "build:varsom_light": "node transform.js varsom",
     "build:varsom_dark": "node transform.js varsom_dark",
     "tokenbuild": "npm run build:light && npm run build:dark && npm run build:varsom_light && npm run build:varsom_dark",
-    "copy-files": "cpy \"./build/css/*\" dist/css/"
+    "copy-files": "cpy \"./build/css/*\" dist/css/",
+    "copy-files-storybook": "cpy \"./build/css/*\" \"./src/styles/*\" storybook-static/assets"
   },
   "dependencies": {
     "@shoelace-style/shoelace": "^2.11.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 // main.ts (or main.js if using JavaScript)
 import { html, render } from 'lit';
+import './styles/imports.css';
 import './styles/global.css';
+
 const app = html`<table>
   <hr />
   <th>Variant</th>
@@ -18,9 +20,7 @@ const app = html`<table>
       <nve-button size="medium" variant="default">I'm a NVE-butotn</nve-button>
     </td>
     <td>
-      <nve-button size="medium" variant="neutral" outline
-        >I'm a NVE-butotn</nve-button
-      >
+      <nve-button size="medium" variant="neutral" outline>I'm a NVE-butotn</nve-button>
     </td>
     <td>
       <nve-button size="medium" variant="neutral">I'm a NVE-butotn</nve-button>
@@ -35,9 +35,7 @@ const app = html`<table>
       <nve-button size="large" variant="default">I'm a NVE-butotn</nve-button>
     </td>
     <td>
-      <nve-button size="large" variant="neutral" outline
-        >I'm a NVE-butotn</nve-button
-      >
+      <nve-button size="large" variant="neutral" outline>I'm a NVE-butotn</nve-button>
     </td>
     <td>
       <nve-button size="large" variant="neutral">I'm a NVE-butotn</nve-button>
@@ -52,9 +50,7 @@ const app = html`<table>
       <nve-button size="small" variant="default">I'm a NVE-butotn</nve-button>
     </td>
     <td>
-      <nve-button size="small" variant="neutral" outline
-        >I'm a NVE-butotn</nve-button
-      >
+      <nve-button size="small" variant="neutral" outline>I'm a NVE-butotn</nve-button>
     </td>
     <td>
       <nve-button size="small" variant="neutral">I'm a NVE-butotn</nve-button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,3 @@
-@import '@shoelace-style/shoelace/dist/themes/light.css';
-@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;700&display=swap');
-
 :root {
   --sl-focus-ring-color: var(--interactive-links-focus);
   --sl-focus-ring-style: solid;

--- a/src/styles/imports.css
+++ b/src/styles/imports.css
@@ -1,0 +1,2 @@
+@import '@shoelace-style/shoelace/dist/themes/light.css';
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;700&display=swap');


### PR DESCRIPTION
Lagt til en yml script til å lage en azure static app som skal hoste test storybook applikasjoner når man lager en PR.
I .storybook/main.ts måtte jeg reorganisere ting lit. Storybook bundler alle static filer når de importeres i storybook/main.ts men da jeg prøvde med vår css med variabler den klaga at den ikke skjønte :root syntaksen. Derfor måtte jeg bruke previewHead til det. Storybook skjønte ikke heller import i css files derfor må jeg importere fonter og shoelace styles via cdn.  Måtte også endre pathen til css filer før og etter bygg. 
Jeg vet ikke om vi skal fortsatt bruke copy-files derfor lagde jeg en separat npm script copy-files-storybook som kopierer css filer til storybook bygg mappe. 
Siden vi ikke trenger (og kan) importere css filer i andre css filer, splitta jeg global.css til imports.css hvor vi kan legge alle css imports når det trengs og global.css hvor vi kan sette global styling. 