### PR TITLE
Fjernet tooltip-property i nve-label fra DOM hvis den ikke brukes

### DIFF
--- a/doc/nve-label.md
+++ b/doc/nve-label.md
@@ -4,12 +4,12 @@ Ledetekst med valgfritt info-ikon
 
 ## Properties
 
-| Property  | Attribute | Type                                          | Default | Description                                      |
-|-----------|-----------|-----------------------------------------------|---------|--------------------------------------------------|
-| `light`   | `light`   | `boolean`                                     | false   | Sett denne hvis du vil ha litt lettere skriftvekt |
-| `size`    | `size`    | `"small" \| "medium" \| "large" \| "x-small"` | "small" | Størrelse                                        |
-| `tooltip` | `tooltip` | `string`                                      | ""      | Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet |
-| `value`   | `value`   | `string`                                      | ""      | Teksten som skal vises                           |
+| Property  | Attribute | Type                                          | Default     | Description                                      |
+|-----------|-----------|-----------------------------------------------|-------------|--------------------------------------------------|
+| `light`   | `light`   | `boolean`                                     | false       | Sett denne hvis du vil ha litt lettere skriftvekt |
+| `size`    | `size`    | `"small" \| "medium" \| "large" \| "x-small"` | "small"     | Størrelse                                        |
+| `tooltip` | `tooltip` | `string \| undefined`                         | "undefined" | Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet |
+| `value`   | `value`   | `string`                                      | ""          | Teksten som skal vises                           |
 
 ## Slots
 

--- a/src/components/nve-label/nve-label.ts
+++ b/src/components/nve-label/nve-label.ts
@@ -33,13 +33,13 @@ export class NveLabel extends LitElement {
   /**
    * Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet
    */
-  @property({ reflect: true }) tooltip = '';
+  @property({ reflect: true }) tooltip?: string = undefined;
 
   static styles = [styles];
 
   private renderInfoIconWithTooltip() {
-    let tooltipContent: ChildNode | string | null = this.tooltip;
-    if (!tooltipContent.length) {
+    let tooltipContent: ChildNode | string | undefined | null = this.tooltip;
+    if (!tooltipContent?.length) {
       // tooltip-property er ikke satt, vi prøver å se om vi har tooltip i slot i stedet
       tooltipContent = this.hasSlotController.get('tooltip');
     }


### PR DESCRIPTION
Siden tooltip-property var initialisert med '', ble den tatt med i DOM selv om den ikke brukes:
![image](https://github.com/NVE/Designsystem/assets/71138449/8ab4906f-19e1-4bbf-aaf5-0aa44c525581)

Nå har jeg satt tooltip-property valgfri.
Takk til @amish1188 som tipset meg om dette!
