### PR TITLE
Skru av LF-normalisering på API-dok

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 
 # Generert API-dokumentasjon har kun <LF> som linjeskift, også i Windows.
 # Dette gjør at git tror alle filer er endret hver gang vi genererer dokumentasjon
-doc/*.md text eol=lf
+doc/nve*.md text eol=lf

--- a/doc/.gitattributes
+++ b/doc/.gitattributes
@@ -1,0 +1,6 @@
+# Bytt ut <CR><LF> i alle tekstfiler i Windows med kun <LF> før de pushes (såkalt "LF normalization")
+* text=auto eof=lf
+
+# Generert API-dokumentasjon har kun <LF> som linjeskift, også i Windows.
+# Dette gjør at git tror alle filer er endret hver gang vi genererer dokumentasjon
+doc/*.md text eol=lf


### PR DESCRIPTION
API-dokumentasjonen får automatisk kun LF som linjeskift, i motsetning til de fleste andre tekstfiler i Windows, som får CR+LF som linjeskift.
I Github lagres alle tekstfiler kun med LF som linjeskift, men Git-klienten på Windows bytter ut alle LF med CR+LF. Dette kalles LF-normalisering. 
Men scriptet som genererer API-dok-filene lagrer filene med kun LF som linjeskift, derfor tror Git at alle api-dok-filer er endret hver gang man genererer dokumentasjon, men i mange tilfeller er det bare linjeskiftene som er endret.
Denne innstillingen skal fikse på det.
Mer info:
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings