### PR TITLE
Fiks av farge, runde hjørner og imports på nve-label og nve-input

### DIFF
--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -15,14 +15,13 @@ export default css`
     --sl-input-required-content-offset: -2px;
     --sl-input-required-content-color: var(--brand-deep);
   }
-
-  .input {
+  :host::part(input) {
     font: var(--body-small);
     border-radius: var(--border-radius-small);
   }
 
   .input--filled {
-    border: 1px solid var(--neutrals-background-secondary);
+    border: var(--border-width-default) solid var(--neutrals-background-secondary);
   }
 
   /* Justering av skriftstørrelse og hjørner for andre størrelser av tekstfeltet */
@@ -45,18 +44,13 @@ export default css`
     box-shadow: unset; 
   }
 
-  /* Riktige farger når skrivebeskyttet */
-  :host([readonly]) .input {
-    border: none;
+  /* Annen bakgrunnsfarge og ingen ramme når skrivebeskyttet */
+  :host([readonly])::part(base) {
+    border-color: var(--neutrals-background-secondary);
     background: var(--neutrals-background-secondary);
-  }
-  :host([readonly]) {
-    border-color: var(--interactive-secondary-background-default);
-    background: var(--neutrals-background-secondary);
-    color: var(--interactive-secondary-foreground-default);
   }
 
-  /** Gir rød ramme ved valideringsfeil  */
+  /* Gir rød ramme ved valideringsfeil  */
   :host([data-invalid])::part(base),
   :host([data-user-invalid])::part(base) {
     border-color: var(--feedback-background-emphasized-error);
@@ -64,10 +58,6 @@ export default css`
   :host([data-invalid])::part(input),
   :host([data-user-invalid])::part(input) {
     color: var(--feedback-background-emphasized-error);
-  }
-
-  :host([required-label])::part(form-control-label) {
-
   }
 
   /* Formaterer "*Obligatorisk" over input-felt og til høyre riktig når required er satt */

--- a/src/components/nve-label/nve-label-demo.ts
+++ b/src/components/nve-label/nve-label-demo.ts
@@ -73,6 +73,19 @@ const table = html`
           </nve-label>
         </td>
       </tr>
+      <tr>
+        <td>Innhold i slot</td>
+        <td>
+          <nve-label>
+            Ledetekst i <i>HTML</i>
+          </nve-label>
+        </td>
+        <td>
+          <nve-label light>
+            Ledetekst i <i>HTML</i>
+          </nve-label>
+        </td>
+      </tr>
     </tbody>
   </table>
 `;

--- a/src/components/nve-label/nve-label.styles.ts
+++ b/src/components/nve-label/nve-label.styles.ts
@@ -4,6 +4,10 @@ import { css } from 'lit';
  * Stiler til nve-label
  */
 export const styles = css`
+  :host {
+    color: var(--neutrals-foreground-primary);
+  }
+
   /* light-varianter for de forskjellige størrelsene */
   :host([light]),
   :host([size='x-small']) {

--- a/src/components/nve-label/nve-label.ts
+++ b/src/components/nve-label/nve-label.ts
@@ -6,9 +6,9 @@ import '../nve-icon/nve-icon';
 import '../nve-tooltip/nve-tooltip';
 
 /**
- * Ledetekst med valgfritt info-ikon
+ * Ledetekst med valgfritt verktøy-hint (og tilhørende info-ikon)
  *
- * @slot label - teksten som skal vises. Eller du kan bruke label-attributtet
+ * @slot (default) - teksten som skal vises. Eller du kan bruke value-attributtet
  * @slot tooltip - innhold i denne blir vist som en tooltip hvis man svever over info-ikonet
  *
  * TODO: Skal være litt mer plass mellom tekst og info-ikon
@@ -54,11 +54,30 @@ export class NveLabel extends LitElement {
     return html``; // tooltip er ikke spesifisert, så vi viser ikke denne delen
   }
 
-  render() {
-    return html`
+  private renderValueProperty() {
+    if (this.value.length) {
+      return html`
       <label part="form-control-label" class="form-control__label" aria-hidden="false">
         <slot name="label">${this.value}</slot>
-      </label>
+      </label>`
+    }
+    return html``; // value-property er ikke satt, så vi viser ikke denne delen
+  }
+
+  private renderSlottedContent() {
+    if (!this.value.length) {
+      return html`
+      <label part="form-control-label" class="form-control__label" aria-hidden="false">
+        <slot>${this.value}</slot>
+      </label>`
+    }
+    return html``; // det er ikke innhold i slot, så vi viser ikke denne delen
+  }
+
+  render() {
+    return html`
+      ${this.renderValueProperty()}
+      ${this.renderSlottedContent()}
       ${this.renderInfoIconWithTooltip()}
     `;
   }

--- a/src/components/nve-label/nve-label.ts
+++ b/src/components/nve-label/nve-label.ts
@@ -2,6 +2,8 @@ import { customElement, property } from 'lit/decorators.js';
 import { html, LitElement } from 'lit';
 import { styles } from './nve-label.styles';
 import { HasSlotController } from '../../utils/slot';
+import '../nve-icon/nve-icon';
+import '../nve-tooltip/nve-tooltip';
 
 /**
  * Ledetekst med valgfritt info-ikon


### PR DESCRIPTION
Diverse småfiks:

- Label må importere nve-tooltip og nve-icon siden den bruker dette internt
- Label hadde feil farge
- Label kan nå også vise innhold som ligger i standard-slot
- Skrivebeskytta input skal også ha runde hjørner selv om ramma ikke er synlig