### PR TITLE
Viser tekst i nve-label selv om tooltip ligger i slot

### DIFF
--- a/src/components/nve-label/nve-label.styles.ts
+++ b/src/components/nve-label/nve-label.styles.ts
@@ -6,38 +6,35 @@ import { css } from 'lit';
 export const styles = css`
   :host {
     color: var(--neutrals-foreground-primary);
-  }
-
-  /* light-varianter for de forskjellige størrelsene */
-  :host([light]),
-  :host([size='x-small']) {
-    font: var(--label-x-small-light);
-  }
-  :host([light]),
-  :host([size='small']) {
-    font: var(--label-small-light);
-  }
-  :host([light]),
-  :host([size='medium']) {
-    font: var(--label-medium-light);
-  }
-  :host([light]),
-  :host([size='large']) {
-    font: var(--label-large-light);
-  }
-
-  /* størrelser men uten "light" */
-  :host([size='x-small']) {
-    font: var(--label-x-small);
-  }
-  :host([size='small']) {
     font: var(--label-small);
   }
-  :host([size='medium']) {
-    font: var(--label-medium);
+
+    /* skriftstørrelser */
+    :host([size='x-small']) {
+      font: var(--label-x-small);
+    }
+    :host([size='medium']) {
+      font: var(--label-medium);
+    }
+    :host([size='large']) {
+      font: var(--label-large);
+    }
+  
+  
+  /* light-variant i standard størrelse */
+  :host([light]) {
+    font: var(--label-small-light);
   }
-  :host([size='large']) {
-    font: var(--label-large);
+
+  /* light-varianter for de andre størrelsene */
+  :host([light][size='x-small']) {
+    font: var(--label-x-small-light);
+  }
+  :host([light][size='medium']) {
+    font: var(--label-medium-light);
+  }
+  :host([light][size='large']) {
+    font: var(--label-large-light);
   }
 
   .nve-info-icon {

--- a/src/components/nve-label/nve-label.ts
+++ b/src/components/nve-label/nve-label.ts
@@ -12,6 +12,7 @@ import '../nve-tooltip/nve-tooltip';
  * @slot tooltip - innhold i denne blir vist som en tooltip hvis man svever over info-ikonet
  *
  * TODO: Skal være litt mer plass mellom tekst og info-ikon
+ * TODO: Hvis du angir både value og innhold i slot, er det value som vises. Det bør være motsatt.
  */
 @customElement('nve-label')
 export class NveLabel extends LitElement {
@@ -60,7 +61,7 @@ export class NveLabel extends LitElement {
       // For å vise label i slot INNI tooltip-slot, må label-slot ha et navn
       return html`
       <label part="form-control-label" class="form-control__label" aria-hidden="false">
-        <slot name="sillyRandomName">${this.value}</slot>
+        <slot name="label">${this.value}</slot>
       </label>`
     } else {
       // Vis evt. slot-innhold i stedet

--- a/src/components/nve-label/nve-label.ts
+++ b/src/components/nve-label/nve-label.ts
@@ -56,28 +56,25 @@ export class NveLabel extends LitElement {
 
   private renderValueProperty() {
     if (this.value.length) {
+      // Vis value-property
+      // For å vise label i slot INNI tooltip-slot, må label-slot ha et navn
       return html`
       <label part="form-control-label" class="form-control__label" aria-hidden="false">
-        <slot name="label">${this.value}</slot>
+        <slot name="sillyRandomName">${this.value}</slot>
+      </label>`
+    } else {
+      // Vis evt. slot-innhold i stedet
+      return html`
+      <label part="form-control-label" class="form-control__label" aria-hidden="false">
+        <slot></slot>
       </label>`
     }
-    return html``; // value-property er ikke satt, så vi viser ikke denne delen
   }
 
-  private renderSlottedContent() {
-    if (!this.value.length) {
-      return html`
-      <label part="form-control-label" class="form-control__label" aria-hidden="false">
-        <slot>${this.value}</slot>
-      </label>`
-    }
-    return html``; // det er ikke innhold i slot, så vi viser ikke denne delen
-  }
 
   render() {
     return html`
       ${this.renderValueProperty()}
-      ${this.renderSlottedContent()}
       ${this.renderInfoIconWithTooltip()}
     `;
   }


### PR DESCRIPTION
Fant en feil som gjorde at nve-label med tooltip-slot ikke ble vist. For at dette skulle virke:
```
<nve-label value="Ledetekst">
    <div slot="tooltip">Hjelpetekst</div>
</nve-label>
```
måtte vi gi slot'en som inneholdt ledeteksten et (tilfeldig) navn. "Default" slot ble ikke vist.