### PR TITLE
Tatt bort reflect = true på alle properties

### DIFF
--- a/src/components/nve-input/nve-input.ts
+++ b/src/components/nve-input/nve-input.ts
@@ -20,7 +20,7 @@ export class NveInput extends SlInput {
   /**
    * Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard.
    */
-  @property({ reflect: true }) requiredLabel = '*Obligatorisk';
+  @property() requiredLabel = '*Obligatorisk';
 
   constructor() {
     super();

--- a/src/components/nve-label/nve-label.ts
+++ b/src/components/nve-label/nve-label.ts
@@ -20,22 +20,22 @@ export class NveLabel extends LitElement {
   /**
    * Teksten som skal vises
    */
-  @property({ reflect: true }) value = '';
+  @property() value = '';
 
   /**
    * Størrelse
    */
-  @property({ reflect: true }) size: 'x-small' | 'small' | 'medium' | 'large' = 'small';
+  @property() size: 'x-small' | 'small' | 'medium' | 'large' = 'small';
 
   /**
    * Sett denne hvis du vil ha litt lettere skriftvekt
    */
-  @property({ type: Boolean, reflect: true }) light = false;
+  @property({ type: Boolean }) light = false;
 
   /**
    * Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet
    */
-  @property({ reflect: true }) tooltip?: string = undefined;
+  @property() tooltip?: string = undefined;
 
   static styles = [styles];
 


### PR DESCRIPTION
Fikk denne feilmeldinga da jeg brukte nve-label i Abonner:
```
reactive-element.ts:1394  Uncaught (in promise) Error: The following properties on element nve-label will not trigger updates as expected because they are set using class fields: value, size, light, tooltip. Native class fields and some compiled output will overwrite accessors used for detecting changes. See https://lit.dev/msg/class-field-shadowing for more information.
    at NveLabel.performUpdate (reactive-element.ts:1394:17)
```

Prøver å fjerne reflect = true på alle properties for å se om dette hjelper.
