### PR TITLE
Har lagt inn link til alle komponentene vi har i "API-dok-menyen" + litt småfiks i JsDoc + generert API-dok på nytt

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -2,13 +2,19 @@
 
 Komponenter i alfabetisk rekkefølge:
 
+- [nve-alert](./nve-alert.md)
 - [nve-button](./nve-button.md)
 - [nve-checkbox](./nve-checkbox.md)
 - [nve-checkbox-group](./nve-checkbox-group.md)
+- [nve-dialog](./nve-dialog.md)
+- [nve-divider](./nve-divider.md)
+- [nve-dropdown](./nve-dropdown.md)
 - [nve-icon](./nve-icon.md)
 - [nve-input](./nve-input.md)
 - [nve-label](./nve-label.md)
-- [nve-radio](./nve-radio.md)
+- [nve-menu-item](./nve-menu-item.md)
+- [nve-menu](./nve-menu.md)
+- [nve-radio-button](./nve-radio-button.md)
 - [nve-radio-group](./nve-radio-group.md)
 - [nve-spinner](./nve-spinner.md)
 - [nve-tooltip](./nve-tooltip.md)

--- a/doc/nve-alert.md
+++ b/doc/nve-alert.md
@@ -1,0 +1,54 @@
+# nve-alert
+
+## Properties
+
+| Property     | Attribute    | Type                                             | Default | Description                                      |
+|--------------|--------------|--------------------------------------------------|---------|--------------------------------------------------|
+| `base`       |              | `HTMLElement`                                    |         |                                                  |
+| `closable`   |              | `boolean`                                        |         | Enables a close button that allows the user to dismiss the alert. |
+| `dir`        |              | `string`                                         |         |                                                  |
+| `duration`   |              | `number`                                         |         | The length of time, in milliseconds, the alert will show before closing itself. If the user interacts with<br />the alert before it closes (e.g. moves the mouse over it), the timer will restart. Defaults to `Infinity`, meaning<br />the alert will not close on its own. |
+| `emphasized` | `emphasized` | `boolean`                                        | false   |                                                  |
+| `lang`       |              | `string`                                         |         |                                                  |
+| `leftStroke` | `leftStroke` | `boolean`                                        | false   |                                                  |
+| `open`       |              | `boolean`                                        |         | Indicates whether or not the alert is open. You can toggle this attribute to show and hide the alert, or you can<br />use the `show()` and `hide()` methods and this attribute will reflect the alert's open state. |
+| `text`       | `text`       | `string`                                         | ""      |                                                  |
+| `title`      | `title`      | `string`                                         | ""      |                                                  |
+| `variant`    |              | `"primary" \| "success" \| "neutral" \| "warning" \| "danger"` |         | The alert's theme variant.                       |
+
+## Methods
+
+| Method                 | Type                                             | Description                                      |
+|------------------------|--------------------------------------------------|--------------------------------------------------|
+| `emit`                 | `{ <T extends "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| "canplaythrough" \| ... 113 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<.....` | Emits a custom event with more convenient defaults. |
+| `handleDurationChange` | `(): void`                                       |                                                  |
+| `handleOpenChange`     | `(): Promise<void>`                              |                                                  |
+| `hide`                 | `(): Promise<void>`                              | Hides the alert                                  |
+| `show`                 | `(): Promise<void>`                              | Shows the alert.                                 |
+| `toast`                | `(): Promise<void>`                              | Displays the alert as a toast notification. This will move the alert out of its position in the DOM and, when<br />dismissed, it will be removed from the DOM completely. By storing a reference to the alert, you can reuse it by<br />calling this method again. The returned promise will resolve after the alert is hidden. |
+
+## Events
+
+| Event           | Description                                      |
+|-----------------|--------------------------------------------------|
+| `sl-after-hide` | Emitted after the alert closes and all animations are complete. |
+| `sl-after-show` | Emitted after the alert opens and all animations are complete. |
+| `sl-hide`       | Emitted when the alert closes.                   |
+| `sl-show`       | Emitted when the alert opens.                    |
+
+## Slots
+
+| Name   | Description                                      |
+|--------|--------------------------------------------------|
+|        | The alert's main content.                        |
+| `icon` | An icon to show in the alert. Works best with `<sl-icon>`. |
+
+## CSS Shadow Parts
+
+| Part                 | Description                                      |
+|----------------------|--------------------------------------------------|
+| `base`               | The component's base wrapper.                    |
+| `close-button`       | The close button, an `<sl-icon-button>`.         |
+| `close-button__base` | The close button's exported `base` part.         |
+| `icon`               | The container that wraps the optional icon.      |
+| `message`            | The container that wraps the alert's main content. |

--- a/doc/nve-button.md
+++ b/doc/nve-button.md
@@ -3,7 +3,12 @@
 En Shoelace-knapp i NVE-forkledning.
 Se https://shoelace.style/components/button
 
-TODO: Beskriv hvilke properties / attributter og varianter vi ikke skal bruke
+For å lage en lenke knapp legg til href på nve-button og den skal automatisk bli gjort om til <a>
+
+Vi skal ikke bruke properties:
+- circle
+- caret
+- pill
 
 ## Properties
 
@@ -45,11 +50,11 @@ TODO: Beskriv hvilke properties / attributter og varianter vi ikke skal bruke
 | `step`              |           | `number \| "any" \| undefined`                   |                                                  |
 | `target`            |           | `"_self" \| "_blank" \| "_parent" \| "_top"`     | Tells the browser where to open the link. Only used when `href` is present. |
 | `title`             |           | `string`                                         |                                                  |
-| `type`              |           | `"button" \| "submit" \| "reset"`                | The type of button. Note that the default value is `button` instead of `submit`, which is opposite of how native<br />`<button>` elements behave. When the type is `submit`, the button will submit the surrounding form. |
+| `type`              |           | `"reset" \| "submit" \| "button"`                | The type of button. Note that the default value is `button` instead of `submit`, which is opposite of how native<br />`<button>` elements behave. When the type is `submit`, the button will submit the surrounding form. |
 | `validationMessage` | readonly  | `string`                                         | Gets the validation message                      |
 | `validity`          | readonly  | `ValidityState`                                  | Gets the validity state object                   |
 | `value`             |           | `string`                                         | The value of the button, submitted as a pair with the button's name as part of the form data, but only when this<br />button is the submitter. This attribute is ignored when `href` is present. |
-| `variant`           |           | `"default" \| "primary" \| "success" \| "neutral" \| "warning" \| "danger" \| "text"` | The button's theme variant.                      |
+| `variant`           |           | `"primary" \| "success" \| "neutral" \| "warning" \| "danger" \| "default" \| "text"` | The button's theme variant.                      |
 
 ## Methods
 
@@ -58,7 +63,7 @@ TODO: Beskriv hvilke properties / attributter og varianter vi ikke skal bruke
 | `blur`                 | `(): void`                                       | Removes focus from the button.                   |
 | `checkValidity`        | `(): boolean`                                    | Checks for validity but does not show a validation message. Returns `true` when valid and `false` when invalid. |
 | `click`                | `(): void`                                       | Simulates a click on the button.                 |
-| `emit`                 | `{ <T extends "submit" \| "reset" \| "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| ... 112 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<...` | Emits a custom event with more convenient defaults. |
+| `emit`                 | `{ <T extends "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| "canplaythrough" \| ... 113 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<.....` | Emits a custom event with more convenient defaults. |
 | `focus`                | `(options?: FocusOptions \| undefined): void`    | Sets focus on the button.                        |
 | `getForm`              | `(): HTMLFormElement \| null`                    | Gets the associated form, if one exists.         |
 | `handleDisabledChange` | `(): void`                                       |                                                  |

--- a/doc/nve-checkbox-group.md
+++ b/doc/nve-checkbox-group.md
@@ -6,7 +6,7 @@
 |----------------|----------------|------------------------------|------------|--------------------------------------------------|
 | `disabled`     | `disabled`     | `boolean`                    | false      | Disable eller enable gruppa                      |
 | `errorMessage` | `errorMessage` | `string \| undefined`        |            | Viser feil melding under gruppen                 |
-| `isValid`      | `isValid`      | `boolean \| undefined`       |            | Bestemmer om sjekkboksgruppe er valid. Hvis ikke alle sjekkbokser i gruppe blir markert som feil |
+| `invalid`      | `invalid`      | `boolean`                    | false      | Bestemmer om sjekkboksgruppe er valid. Hvis ikke alle sjekkbokser i gruppe blir markert som feil |
 | `label`        | `label`        | `string \| undefined`        |            | Viser label til en gruppe                        |
 | `orientation`  | `orientation`  | `"horizontal" \| "vertical"` | "vertical" | Om gruppen skal rendres horisontalt eller vertikalt |
 | `slot`         |                |                              |            |                                                  |

--- a/doc/nve-checkbox.md
+++ b/doc/nve-checkbox.md
@@ -16,7 +16,7 @@ foreløpig finnes ikke noe hove
 | `getForm`           |           |           | `() => HTMLFormElement \| null`         |         |                                                  |
 | `indeterminate`     |           |           | `boolean`                               |         | Draws the checkbox in an indeterminate state. This is usually applied to checkboxes that represents a "select<br />all/none" behavior when associated checkboxes have a mix of checked and unchecked states. |
 | `input`             |           |           | `HTMLInputElement`                      |         |                                                  |
-| `isValid`           | `isValid` |           | `boolean`                               | true    | Checks if input is valid                         |
+| `invalid`           | `invalid` |           | `boolean`                               | false   | Checks if input is valid                         |
 | `lang`              |           |           | `string`                                |         |                                                  |
 | `max`               |           |           | `string \| number \| Date \| undefined` |         |                                                  |
 | `maxlength`         |           |           | `number \| undefined`                   |         |                                                  |
@@ -41,7 +41,7 @@ foreløpig finnes ikke noe hove
 | `blur`                 | `(): void`                                       | Removes focus from the checkbox.                 |
 | `checkValidity`        | `(): boolean`                                    | Checks for validity but does not show a validation message. Returns `true` when valid and `false` when invalid. |
 | `click`                | `(): void`                                       | Simulates a click on the checkbox.               |
-| `emit`                 | `{ <T extends "submit" \| "reset" \| "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| ... 112 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<...` | Emits a custom event with more convenient defaults. |
+| `emit`                 | `{ <T extends "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| "canplaythrough" \| ... 113 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<.....` | Emits a custom event with more convenient defaults. |
 | `focus`                | `(options?: FocusOptions \| undefined): void`    | Sets focus on the checkbox.                      |
 | `getForm`              | `(): HTMLFormElement \| null`                    | Gets the associated form, if one exists.         |
 | `handleDisabledChange` | `(): void`                                       |                                                  |

--- a/doc/nve-dialog.md
+++ b/doc/nve-dialog.md
@@ -26,12 +26,12 @@ Skal det ikke være mulig å trykke utenfor for å lukke dialogen, sett på disa
 
 | Method               | Type                                             | Description                                      |
 |----------------------|--------------------------------------------------|--------------------------------------------------|
-| `emit`               | `{ <T extends "submit" \| "reset" \| "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| ... 112 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<...` | Emits a custom event with more convenient defaults. |
+| `emit`               | `{ <T extends "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| "canplaythrough" \| ... 113 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<.....` | Emits a custom event with more convenient defaults. |
 | `handleOpenChange`   | `(): Promise<void>`                              |                                                  |
-| `handleRequestClose` | `(event: any): void`                             |                                                  |
+| `handleRequestClose` | `(event: any): void`                             | <br />Stjålet fra shoelace eksempel. Hindrer at man lukker dialogen ved å trykke utenfor |
 | `hide`               | `(): Promise<void>`                              | Hides the dialog                                 |
 | `show`               | `(): Promise<void>`                              | Shows the dialog.                                |
-| `updateIcon`         | `(): void`                                       |                                                  |
+| `updateIcon`         | `(): void`                                       | Oppdaterer ikonet som vises i dialogens tittel.<br />Metoden søker først etter tittel-elementet i komponentens skygge-DOM.<br />Hvis tittel-elementet finnes og `icon`-egenskapen er satt, oppdateres<br />tittel-elementets stil for å inkludere det angitte ikonet.<br />Hvis `icon`-egenskapen ikke er satt, settes ikoninnholdet til 'none'<br />for å unngå å skape unødvendig mellomrom i layouten. |
 
 ## Events
 

--- a/doc/nve-dropdown.md
+++ b/doc/nve-dropdown.md
@@ -26,9 +26,9 @@ Se https://shoelace.style/components/dropdown
 | Method                    | Type                                             | Description                                      |
 |---------------------------|--------------------------------------------------|--------------------------------------------------|
 | `addOpenListeners`        | `(): void`                                       |                                                  |
-| `emit`                    | `{ <T extends "submit" \| "reset" \| "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| ... 112 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<...` | Emits a custom event with more convenient defaults. |
+| `emit`                    | `{ <T extends "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| "canplaythrough" \| ... 113 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<.....` | Emits a custom event with more convenient defaults. |
 | `focusOnTrigger`          | `(): void`                                       |                                                  |
-| `getMenu`                 | `(): NveMenu \| undefined`                       |                                                  |
+| `getMenu`                 | `(): any`                                        |                                                  |
 | `handleOpenChange`        | `(): Promise<void>`                              |                                                  |
 | `handleTriggerClick`      | `(): void`                                       |                                                  |
 | `handleTriggerKeyDown`    | `(event: KeyboardEvent): Promise<void>`          |                                                  |

--- a/doc/nve-label.md
+++ b/doc/nve-label.md
@@ -1,6 +1,6 @@
 # nve-label
 
-Ledetekst med valgfritt info-ikon
+Ledetekst med valgfritt verktøy-hint (og tilhørende info-ikon)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Ledetekst med valgfritt info-ikon
 
 ## Slots
 
-| Name      | Description                                      |
-|-----------|--------------------------------------------------|
-| `label`   | teksten som skal vises. Eller du kan bruke label-attributtet |
-| `tooltip` | innhold i denne blir vist som en tooltip hvis man svever over info-ikonet<br /><br />TODO: Skal være litt mer plass mellom tekst og info-ikon |
+| Name        | Description                                      |
+|-------------|--------------------------------------------------|
+| `(default)` | teksten som skal vises. Eller du kan bruke value-attributtet |
+| `tooltip`   | innhold i denne blir vist som en tooltip hvis man svever over info-ikonet<br /><br />TODO: Skal være litt mer plass mellom tekst og info-ikon<br />TODO: Hvis du angir både value og innhold i slot, er det value som vises. Det bør være motsatt. |

--- a/doc/nve-menu.md
+++ b/doc/nve-menu.md
@@ -16,7 +16,7 @@ Mer info: https://shoelace.style/components/menu
 
 | Method           | Type                                             | Description                                      |
 |------------------|--------------------------------------------------|--------------------------------------------------|
-| `emit`           | `{ <T extends "submit" \| "reset" \| "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| ... 112 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<...` | Emits a custom event with more convenient defaults. |
+| `emit`           | `{ <T extends "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| "canplaythrough" \| ... 113 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<.....` | Emits a custom event with more convenient defaults. |
 | `getAllItems`    | `(): SlMenuItem[]`                               |                                                  |
 | `getCurrentItem` | `(): SlMenuItem \| undefined`                    |                                                  |
 | `setCurrentItem` | `(item: SlMenuItem): void`                       |                                                  |

--- a/doc/nve-tooltip.md
+++ b/doc/nve-tooltip.md
@@ -1,6 +1,9 @@
 # nve-tooltip
 
-En sl-tooltip i NVE-uniform. TODO: Denne har ingen NVE-styling ennå.
+En sl-tooltip i NVE-uniform.
+Mer info: https://shoelace.style/components/tooltip
+
+TODO: Denne har ingen NVE-styling ennå.
 
 ## Properties
 
@@ -24,7 +27,7 @@ En sl-tooltip i NVE-uniform. TODO: Denne har ingen NVE-styling ennå.
 
 | Method                 | Type                                             | Description                                      |
 |------------------------|--------------------------------------------------|--------------------------------------------------|
-| `emit`                 | `{ <T extends "submit" \| "reset" \| "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| ... 112 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<...` | Emits a custom event with more convenient defaults. |
+| `emit`                 | `{ <T extends "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| "canplaythrough" \| ... 113 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<.....` | Emits a custom event with more convenient defaults. |
 | `handleDisabledChange` | `(): void`                                       |                                                  |
 | `handleOpenChange`     | `(): Promise<void>`                              |                                                  |
 | `handleOptionsChange`  | `(): Promise<void>`                              |                                                  |

--- a/src/components/nve-tooltip/nve-tooltip.component.ts
+++ b/src/components/nve-tooltip/nve-tooltip.component.ts
@@ -3,7 +3,10 @@ import { customElement } from 'lit/decorators.js';
 import '../nve-icon/nve-icon.component';
 
 /**
- * En sl-tooltip i NVE-uniform. TODO: Denne har ingen NVE-styling ennå.
+ * En sl-tooltip i NVE-uniform.
+ * Mer info: https://shoelace.style/components/tooltip
+ * 
+ * TODO: Denne har ingen NVE-styling ennå.
  */
 @customElement('nve-tooltip')
 export default class NveTooltip extends SlTooltip {


### PR DESCRIPTION
- Har lagt inn linkene som manglet i "menyen" for API-dok. Det er lett å glemme å legge inn linker i fila components.md når vi lager API-dok. Burde nok ha en script som genererte denne fila.
- Har lagt inn link til Shoelace-dok for nve-tooltip
- Har generert API-dok på nytt. Var en del oppdateringer siden sist