### PR TITLE
PR: AVN-289 basic input validering

### DIFF
--- a/src/components/nve-dropdown/nve-dropdown.component.ts
+++ b/src/components/nve-dropdown/nve-dropdown.component.ts
@@ -2,7 +2,7 @@ import { SlDropdown, SlSelectEvent } from '@shoelace-style/shoelace';
 import { customElement } from 'lit/decorators.js';
 import { getTabbableBoundary } from '../../utils/tabbable';
 import NveButton from '../nve-button/nve-button.component';
-import { NveMenu } from '../nve-menu/nve-menu.component';
+import NveMenu from '../nve-menu/nve-menu.component';
 import styles from './nve-dropdown.styles';
 /**
  * En Shoelace-dropdown i NVE-forkledning.

--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -7,11 +7,16 @@ import styles from './nve-input.styles';
  * Mer info: https://shoelace.style/components/input
  *
  * Vil du ha info-ikon med hjelpetekst etter ledeteksten, putt en nve-label i label-slot.
- *
+ * Du trenger ikke å sette 'required' property for å vise requiredLabel hvis du velger å validere med invalid property
+ * Da må du sikre å ha med requiredLabel property, og at den har noe verdi
+ * Du trenger ikke å sette requiredLabel property hvis du velger constraint validering og bruker required property. Den
+ * vises *Obligatorisk som default og kan justeres med requiredLabel.
  * Disse attributtene skal ikke brukes:
  * - pill
  *
  * TODO: Vise valideringsfeil med rød tekst under tekstfeltet
+ * TODO: Felte blir breddere når feil ikone vises. Alt på grunn av at det dukker opp i en slot. Hvis Vi bestemmer oss
+ * å ha en fast verdi på sloten, kan det kanksje påvirke andre elementer som skal vises i sloten.
  */
 @customElement('nve-input')
 export default class NveInput extends SlInput {

--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -45,17 +45,23 @@ export default class NveInput extends SlInput {
     });
   }
 
-  firstUpdated(): void {
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('sl-invalid', this.makeInvalid);
+  }
+
+  firstUpdated() {
     if (this.requiredLabel) {
       this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
     }
   }
 
-  updated(): void {
-    if (this.hasAttribute('data-user-invalid') && !this.alreadyInvalid) {
+  updated() {
+    const hasDataUserInvalidAttr = this.hasAttribute('data-user-invalid');
+    if (hasDataUserInvalidAttr && !this.alreadyInvalid) {
       this.makeInvalid();
     }
-    if (!this.hasAttribute('data-user-invalid')) {
+    if (!hasDataUserInvalidAttr) {
       this.resetValidation();
     }
   }
@@ -68,7 +74,6 @@ export default class NveInput extends SlInput {
 
   private resetValidation() {
     this.hideErrorIcon();
-    //fjern den og bare vis meldingen når invalid er på plass
     this.style.setProperty('--nve-input-error-message', '');
     this.alreadyInvalid = false;
   }

--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -51,12 +51,14 @@ export default class NveInput extends SlInput {
   }
 
   firstUpdated() {
+    super.firstUpdated();
     if (this.requiredLabel) {
       this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
     }
   }
 
-  updated() {
+  updated(changedProperties: any) {
+    super.updated(changedProperties);
     const hasDataUserInvalidAttr = this.hasAttribute('data-user-invalid');
     if (hasDataUserInvalidAttr && !this.alreadyInvalid) {
       this.makeInvalid();

--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -29,9 +29,11 @@ export default class NveInput extends SlInput {
    */
   @property({ reflect: true }) errorMessage?: string;
   /**
-   * Reactive property som brukes for å signere at komponent ikke er valid. Brukes som alternativ til constraint validation
+   * Reactive property som brukes for å signere at komponent ikke er valid. Brukes som alternativ til constraint validation. Står som
+   * string her fordi DOM returnerer alltid properties som string. Vi vil at både isvalid=false og isvalid=true vises i DOMen
+   * når man bruker dette alternativet
    */
-  @property({ type: String, reflect: true }) isvalid?: string;
+  @property({ type: String, reflect: true }) isvalid?: 'true' | 'false';
   /**
    * Hjelpe variabler for å unngå å kjøre makeInvalid hver gang man klikker på submit knapp hvis felte er invalid allerede
    */

--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -11,7 +11,6 @@ import styles from './nve-input.styles';
  * Disse attributtene skal ikke brukes:
  * - pill
  *
- * TODO: Utropstegn-ikon ved valideringsfeil
  * TODO: Vise valideringsfeil med rød tekst under tekstfeltet
  */
 @customElement('nve-input')

--- a/src/components/nve-input/nve-input.demo.ts
+++ b/src/components/nve-input/nve-input.demo.ts
@@ -3,6 +3,25 @@ import { html } from 'lit';
 /**
  * Demonstrasjon av nve-input
  */
+
+/**
+ * Metoden for å teste custom validering
+ * @param e event
+ * @returns
+ */
+const validateInputFieldDemo = (e: any) => {
+  e.preventDefault();
+  const inputElement = document.getElementById('demoInputVal') as HTMLInputElement;
+  const inputElementValue = inputElement.value;
+  if (!inputElement) return;
+  const valid = inputElementValue == '42';
+
+  if (!valid) {
+    inputElement.setCustomValidity('Feil svar');
+  } else {
+    inputElement.setCustomValidity('');
+  }
+};
 const table = html`
   <hr />
   <h3 id="nve-input">nve-input</h3>
@@ -157,13 +176,17 @@ const table = html`
       </tr>
     </tbody>
   </table>
-  <h3 id="nve-inpu-validering">nve-input validering</h3>
-  <form>
+  <h3 id="nve-inpu-validering">nve-input constraint validering</h3>
+  <form style="max-width: 300px" onsubmit="event.preventDefault();">
+    <nve-input required errorMessage="Kan ikke være tom" label="Label" value=""></nve-input>
+    <nve-button style="margin-top: 10px" variant="primary" type="submit" size="small">Submit</nve-button>
+  </form>
+  <h3 id="nve-inpu-validering">nve-input custom validering (med blur)</h3>
+  <form @submit="${(e: any) => validateInputFieldDemo(e)}" id="demoFormCustomVal" style="max-width: 300px">
     <nve-input
-      errorMessage="Kan ikke være tom"
-      filled
-      required
-      requiredLabel="*Required"
+      @sl-blur="${validateInputFieldDemo}"
+      help-text="Må være 42"
+      id="demoInputVal"
       label="Label"
       value=""
     ></nve-input>

--- a/src/components/nve-input/nve-input.demo.ts
+++ b/src/components/nve-input/nve-input.demo.ts
@@ -97,15 +97,6 @@ const table = html`
         </td>
       </tr>
       <tr>
-        <td>Valideringsfeil</td>
-        <td>
-          <nve-input type="number" value="41" min="42" max="42"></nve-input>
-        </td>
-        <td>
-          <nve-input filled type="number" value="41" min="42" max="42"></nve-input>
-        </td>
-      </tr>
-      <tr>
         <td>Passord</td>
         <td><nve-input type="password" password-toggle="true" value="hemmelig"></nve-input></td>
         <td><nve-input filled type="password" password-toggle="true" value="hemmelig"></nve-input></td>

--- a/src/components/nve-input/nve-input.demo.ts
+++ b/src/components/nve-input/nve-input.demo.ts
@@ -157,6 +157,18 @@ const table = html`
       </tr>
     </tbody>
   </table>
+  <h3 id="nve-inpu-validering">nve-input validering</h3>
+  <form>
+    <nve-input
+      errorMessage="Kan ikke være tom"
+      filled
+      required
+      requiredLabel="*Required"
+      label="Label"
+      value=""
+    ></nve-input>
+    <nve-button style="margin-top: 10px" variant="primary" type="submit" size="small">Submit</nve-button>
+  </form>
 `;
 
 export default table;

--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -11,6 +11,7 @@ export default css`
     --sl-input-spacing-medium: var(--spacing-x-small);
     --sl-input-spacing-large: var(--spacing-x-small);
 
+    /** den burde vises alltid når requiredlabel er ikke tom. ikke kun når required prop er med  */
     --sl-input-required-content: '*Obligatorisk';
     --sl-input-required-content-offset: -2px;
     --sl-input-required-content-color: var(--brand-deep);
@@ -18,6 +19,20 @@ export default css`
   :host::part(input) {
     font: var(--body-small);
     border-radius: var(--border-radius-small);
+  }
+
+  :host::after {
+    content: var(--nve-input-error-message);
+    font: var(--detailtext-caption);
+    color: var(--feedback-background-emphasized-error);
+  }
+
+  :host([required]) .form-control--has-label .form-control__label::after,
+  :host([requiredLabel])::part(form-control-label)::after {
+    content: var(--sl-input-required-content);
+    margin-top: var(--spacing-xx-small);
+    font: var(--label-x-small-light);
+    color: var(--feedback-background-emphasized-error);
   }
 
   .input--filled {
@@ -35,13 +50,14 @@ export default css`
 
   .form-control label {
     font: var(--label-medium);
+    align-items: center;
   }
 
   /* Riktig fokus-markering også i filled-modus */
-  .input--standard.input--focused:not(.input--disabled) { 
-    outline: var(--sl-focus-ring); 
-    outline-offset: var(--sl-focus-ring-offset); 
-    box-shadow: unset; 
+  .input--standard.input--focused:not(.input--disabled) {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+    box-shadow: unset;
   }
 
   /* Annen bakgrunnsfarge og ingen ramme når skrivebeskyttet */
@@ -50,14 +66,10 @@ export default css`
     background: var(--neutrals-background-secondary);
   }
 
+  /**fikse til kun user-invalid */
   /* Gir rød ramme ved valideringsfeil  */
-  :host([data-invalid])::part(base),
   :host([data-user-invalid])::part(base) {
     border-color: var(--feedback-background-emphasized-error);
-  }
-  :host([data-invalid])::part(input),
-  :host([data-user-invalid])::part(input) {
-    color: var(--feedback-background-emphasized-error);
   }
 
   /* Formaterer "*Obligatorisk" over input-felt og til høyre riktig når required er satt */
@@ -65,10 +77,6 @@ export default css`
     display: flex;
     width: 100%;
     justify-content: space-between;
-    margin-inline-start: unset;
-  }
-  ::after {
-    font-weight: var(--font-weight-regular);
     margin-inline-start: unset;
   }
 `;

--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -66,7 +66,6 @@ export default css`
     background: var(--neutrals-background-secondary);
   }
 
-  /**fikse til kun user-invalid */
   /* Gir rød ramme ved valideringsfeil  */
   :host([data-user-invalid])::part(base) {
     border-color: var(--feedback-background-emphasized-error);


### PR DESCRIPTION
Man kan enten bruke constraint validering med attributer, eller bruke setCustomValidity for å validere input feltet.
Begge to eksemplarer vises i demo.
Input felt blir bredere når feil ikonen vises. Forklart i koden. Man burde kanskje sette noe bestemt bredde eller noe? 
Gjerne test i varsom appen