### PR TITLE
PR: avn-258 radio validation

### DIFF
--- a/src/components/nve-radio-group/nve-radio-group.component.ts
+++ b/src/components/nve-radio-group/nve-radio-group.component.ts
@@ -117,7 +117,7 @@ export default class NveRadioGroup extends SlRadioGroup {
     console.log(this.validationMessage);
     const nveRadios = this.getAllRadios();
     // toggler 'invalid' attribute på alle radio komponenter for å få riktig style
-    toggleBooleanAttrOnListOfNodes(nveRadios, true, 'invalid');
+    toggleBooleanAttrOnListOfNodes(nveRadios, true, 'data-invalid');
     if (!this.errorMessageCopy) {
       this.errorMessageCopy = this.validationMessage;
     }
@@ -128,7 +128,7 @@ export default class NveRadioGroup extends SlRadioGroup {
   private resetValidation() {
     const nveRadios = this.getAllRadios();
     // toggler 'invalid' attribute på alle radio komponenter for å få riktig style
-    toggleBooleanAttrOnListOfNodes(nveRadios, false, 'invalid');
+    toggleBooleanAttrOnListOfNodes(nveRadios, false, 'data-invalid');
     this.setCustomValidity('');
     this.style.removeProperty('--radio-group-error-message');
   }

--- a/src/components/nve-radio-group/nve-radio-group.component.ts
+++ b/src/components/nve-radio-group/nve-radio-group.component.ts
@@ -5,7 +5,7 @@ import NveRadio from '../nve-radio/nve-radio.component';
 import styles from './nve-radio-group.styles';
 import { watch } from '../../utils/watch';
 import toggleBooleanAttrOnListOfNodes from '../../utils/updateInvalidProperty';
-import { PropertyValueMap } from 'lit';
+import { PropertyValues } from 'lit';
 
 @customElement('nve-radio-group')
 /**
@@ -34,17 +34,21 @@ export default class NveRadioGroup extends SlRadioGroup {
     super();
   }
   /**
-   * Om radio knapper burde vises horisontalt eller vertikalt
+   * Om radio knapper skal vises horisontalt eller vertikalt
    */
   @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'vertical';
   /**
-   * Disable alle radio knapper i gruppen
+   * Deaktivere alle radio knapper i gruppen
    */
   @property({ type: Boolean, reflect: true }) disabled = false;
   /**
-   * Feil melding som vises under input feltet. Vi har ikke tilgang til SlRadioGroup errorMessage så må overskrive med vår egen
+   * Feil melding som vises under radiogruppe. Vi har ikke tilgang til SlRadioGroup errorMessage så må overskrive med vår egen
    */
   @property({ reflect: true }) errorMessage?: string;
+  /**
+   * Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard.
+   */
+  @property() requiredLabel = '*Obligatorisk';
   /**
    * Hjelpe variabel som sjekker om radio gruppe er allerede invalid
    */
@@ -77,8 +81,11 @@ export default class NveRadioGroup extends SlRadioGroup {
     this.removeEventListener('sl-change', this.resetValidation);
   }
 
-  updated(changedProperties: any): void {
+  updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
+    if (changedProperties.has('requiredLabel')) {
+      this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
+    }
     const hasDataUserInvalidAttr = this.hasAttribute('data-user-invalid');
     if (hasDataUserInvalidAttr && !this.alreadyInvalid) {
       this.makeInvalid();
@@ -114,14 +121,13 @@ export default class NveRadioGroup extends SlRadioGroup {
   }
 
   private makeInvalid() {
-    console.log(this.validationMessage);
     const nveRadios = this.getAllRadios();
     // toggler 'invalid' attribute på alle radio komponenter for å få riktig style
     toggleBooleanAttrOnListOfNodes(nveRadios, true, 'data-invalid');
     if (!this.errorMessageCopy) {
       this.errorMessageCopy = this.validationMessage;
     }
-    this.setCustomValidity(`${this.errorMessageCopy}`);
+    this.setCustomValidity(this.errorMessageCopy);
     this.style.setProperty('--radio-group-error-message', `"${this.errorMessageCopy}"`);
   }
 

--- a/src/components/nve-radio-group/nve-radio-group.component.ts
+++ b/src/components/nve-radio-group/nve-radio-group.component.ts
@@ -84,7 +84,7 @@ export default class NveRadioGroup extends SlRadioGroup {
   updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     if (changedProperties.has('requiredLabel')) {
-      this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
+      this.style.setProperty('--sl-input-required-content', `${this.requiredLabel}`);
     }
     const hasDataUserInvalidAttr = this.hasAttribute('data-user-invalid');
     if (hasDataUserInvalidAttr && !this.alreadyInvalid) {
@@ -122,13 +122,13 @@ export default class NveRadioGroup extends SlRadioGroup {
 
   private makeInvalid() {
     const nveRadios = this.getAllRadios();
-    // toggler 'invalid' attribute på alle radio komponenter for å få riktig style
+    // toggler 'data-invalid' attribute på alle radio komponenter for å få riktig style
     toggleBooleanAttrOnListOfNodes(nveRadios, true, 'data-invalid');
     if (!this.errorMessageCopy) {
       this.errorMessageCopy = this.validationMessage;
     }
     this.setCustomValidity(this.errorMessageCopy);
-    this.style.setProperty('--radio-group-error-message', `"${this.errorMessageCopy}"`);
+    this.style.setProperty('--radio-group-error-message', `${this.errorMessageCopy}`);
   }
 
   private resetValidation() {

--- a/src/components/nve-radio-group/nve-radio-group.component.ts
+++ b/src/components/nve-radio-group/nve-radio-group.component.ts
@@ -28,6 +28,8 @@ import { PropertyValueMap } from 'lit';
  */
 // @ts-expect-error -next-line - overskriving av private metoder i sl-radio-group
 export default class NveRadioGroup extends SlRadioGroup {
+  static styles = [SlRadioGroup.styles, styles];
+
   constructor() {
     super();
   }
@@ -44,13 +46,13 @@ export default class NveRadioGroup extends SlRadioGroup {
    */
   @property({ reflect: true }) errorMessage?: string;
   /**
-   * Hjelpe variabler som sjekker om radio gruppe er allerede invalid
+   * Hjelpe variabel som sjekker om radio gruppe er allerede invalid
    */
   @state() private alreadyInvalid = false;
   /**
-   * kan ikke få taket i errorMessage som er satt på SlRadioGroup her, og vi trenger den for å vise feilmelding under radio gruppe.
-   * samtidig errorMessage fra SlRadioGroup (som er tom, som deretter gir oss default nettleseren sin melding)
-   *  overskriver NveRadioGroup errorMessage prop når sl-input trigges, derfor må vi lagre den i staten når komponenten renderes første gang.
+   * Ikke mulig å få taket i errorMessage til superklassen (SlRadioGroup), og den trengs for å vise feilmelding under radio gruppe.
+   * Samtidig errorMessage fra SlRadioGroup (som er tom, som deretter gir oss default nettleseren sin melding)
+   * overskriver NveRadioGroup errorMessage prop når sl-input trigges, derfor må vi lagre den i staten når komponenten renderes første gang.
    */
   @state() private errorMessageCopy = '';
 
@@ -75,32 +77,15 @@ export default class NveRadioGroup extends SlRadioGroup {
     this.removeEventListener('sl-change', this.resetValidation);
   }
 
-  updated(): void {
-    if (this.hasAttribute('data-user-invalid') && !this.alreadyInvalid) {
+  updated(changedProperties: any): void {
+    super.updated(changedProperties);
+    const hasDataUserInvalidAttr = this.hasAttribute('data-user-invalid');
+    if (hasDataUserInvalidAttr && !this.alreadyInvalid) {
       this.makeInvalid();
     }
-    if (!this.hasAttribute('data-user-invalid')) {
+    if (!hasDataUserInvalidAttr) {
       this.resetValidation();
     }
-  }
-
-  private makeInvalid() {
-    const nveRadios = this.getAllRadios();
-    // bruker 'invalid' property her som er ikke en tilgjengelig property i nve-radio. Den skal settes automatisk, derfor man trenger ikke å få tilgang til det
-    toggleBooleanAttrOnListOfNodes(nveRadios, true, 'invalid');
-    if (!this.errorMessageCopy) {
-      this.errorMessageCopy = this.validationMessage;
-    }
-    this.setCustomValidity(`${this.errorMessageCopy}`);
-    this.style.setProperty('--radio-group-error-message', `"${this.errorMessageCopy}"`);
-  }
-
-  private resetValidation() {
-    const nveRadios = this.getAllRadios();
-    // bruker 'invalid' property her som er ikke en tilgjengelig property i nve-radio. Den skal settes automatisk, derfor man trenger ikke å få tilgang til det
-    toggleBooleanAttrOnListOfNodes(nveRadios, false, 'invalid');
-    this.setCustomValidity('');
-    this.style.removeProperty('--radio-group-error-message');
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -128,7 +113,25 @@ export default class NveRadioGroup extends SlRadioGroup {
     return true;
   }
 
-  static styles = [SlRadioGroup.styles, styles];
+  private makeInvalid() {
+    console.log(this.validationMessage);
+    const nveRadios = this.getAllRadios();
+    // toggler 'invalid' attribute på alle radio komponenter for å få riktig style
+    toggleBooleanAttrOnListOfNodes(nveRadios, true, 'invalid');
+    if (!this.errorMessageCopy) {
+      this.errorMessageCopy = this.validationMessage;
+    }
+    this.setCustomValidity(`${this.errorMessageCopy}`);
+    this.style.setProperty('--radio-group-error-message', `"${this.errorMessageCopy}"`);
+  }
+
+  private resetValidation() {
+    const nveRadios = this.getAllRadios();
+    // toggler 'invalid' attribute på alle radio komponenter for å få riktig style
+    toggleBooleanAttrOnListOfNodes(nveRadios, false, 'invalid');
+    this.setCustomValidity('');
+    this.style.removeProperty('--radio-group-error-message');
+  }
 
   /* Overskriver private metoder i sl-radio-group for å kunne bruke nve-radio og nve-radio-button elementer inne i <nve-radio-group></nve-radio-group>*/
   private getAllRadios = function () {

--- a/src/components/nve-radio-group/nve-radio-group.styles.ts
+++ b/src/components/nve-radio-group/nve-radio-group.styles.ts
@@ -11,7 +11,7 @@ export default css`
     --sl-input-spacing-medium: var(--spacing-x-small);
     --sl-input-spacing-large: var(--spacing-x-small);
 
-    --sl-input-required-content: '*obligatorisk';
+    --sl-input-required-content: '';
     --sl-input-required-content-offset: 0.25rem;
     --sl-input-required-content-color: var(--brand-deep);
 
@@ -40,6 +40,10 @@ export default css`
     font: var(--label-small-light);
     margin-bottom: unset;
     text-align: left;
+  }
+
+  :host::part(form-control-label)::after {
+    align-self: flex-end;
   }
 
   :host([orientation='vertical'])::part(form-control),

--- a/src/components/nve-radio-group/nve-radio-group.styles.ts
+++ b/src/components/nve-radio-group/nve-radio-group.styles.ts
@@ -24,6 +24,11 @@ export default css`
     flex-direction: column;
     gap: var(--spacing-x-small, 0.5rem);
   }
+  :host([data-user-invalid])::after {
+    content: var(--radio-group-error-message);
+    font: var(--detailtext-caption);
+    color: var(--feedback-background-emphasized-error);
+  }
 
   :host::part(form-control-input) {
     align-items: flex-start;

--- a/src/components/nve-radio/nve-radio.demo.ts
+++ b/src/components/nve-radio/nve-radio.demo.ts
@@ -1,4 +1,24 @@
 import { html } from 'lit';
+
+/**
+ * Metoden for å teste custom validering
+ * @param e event
+ * @returns
+ */
+const validateRGdDemo = (e: any) => {
+  e.preventDefault();
+  const rgElement = document.getElementById('customValidation') as HTMLInputElement;
+  const rgElementValue = rgElement.value;
+  if (!rgElement) return;
+  const valid = rgElementValue == '3';
+
+  if (!valid) {
+    rgElement.setCustomValidity('Feil svar. Må velge Value 3');
+  } else {
+    rgElement.setCustomValidity('');
+  }
+};
+
 const table = html`
   <hr />
   <h3>Radio</h3>
@@ -109,17 +129,30 @@ const table = html`
   </table>
   <hr />
   <h3>nve-radio-group validering</h3>
-  <form>
+  <form onsubmit="event.preventDefault();">
     <nve-radio-group errorMessage="Kan ikke stå tom" required size="small" orientation="horizontal">
       <label slot="label">
-        <span style="font-family:consolas;">Horizontal, required (small) with <b>slotted</b> label</span>
+        <span>Validering</span>
       </label>
-      <nve-radio value="1">Value</nve-radio>
-      <nve-radio value="2">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
-      <nve-radio value="3">Value</nve-radio>
-      <nve-radio value="4">Value</nve-radio>
+      <nve-radio value="1">Value 1</nve-radio>
+      <nve-radio value="2">Value 2</nve-radio>
+      <nve-radio value="3">Value 3</nve-radio>
+      <nve-radio value="4">Value 4</nve-radio>
     </nve-radio-group>
-    <nve-button style="margin-top: 10px" variant="primary" size="small" type="submit">submit</nve-button>
+    <nve-button style="margin-top: 10px" variant="primary" size="small" type="submit">Submit</nve-button>
+  </form>
+  <h3>nve-radio-group custom validering</h3>
+  <form @submit="${(e: any) => validateRGdDemo(e)}">
+    <nve-radio-group id="customValidation" size="small" orientation="horizontal">
+      <label slot="label">
+        <span>Custom validering</span>
+      </label>
+      <nve-radio value="1">Value 1</nve-radio>
+      <nve-radio value="2">Value 2</nve-radio>
+      <nve-radio value="3">Value 3</nve-radio>
+      <nve-radio value="4">Value 4</nve-radio>
+    </nve-radio-group>
+    <nve-button style="margin-top: 10px" variant="primary" size="small" type="submit">Submit</nve-button>
   </form>
 `;
 

--- a/src/components/nve-radio/nve-radio.demo.ts
+++ b/src/components/nve-radio/nve-radio.demo.ts
@@ -7,15 +7,15 @@ import { html } from 'lit';
  */
 const validateRGdDemo = (e: any) => {
   e.preventDefault();
-  const rgElement = document.getElementById('customValidation') as HTMLInputElement;
-  const rgElementValue = rgElement.value;
-  if (!rgElement) return;
-  const valid = rgElementValue == '3';
+  const radioGroupElement = document.getElementById('customValidation') as HTMLInputElement;
+  const radioGroupElementValue = radioGroupElement.value;
+  if (!radioGroupElement) return;
+  const valid = radioGroupElementValue == '3';
 
   if (!valid) {
-    rgElement.setCustomValidity('Feil svar. Må velge Value 3');
+    radioGroupElement.setCustomValidity('Feil svar. Må velge Value 3');
   } else {
-    rgElement.setCustomValidity('');
+    radioGroupElement.setCustomValidity('');
   }
 };
 
@@ -114,7 +114,7 @@ const table = html`
       <tr>
         <td></td>
         <td>
-          <nve-radio-group required size="small" orientation="horizontal">
+          <nve-radio-group required requiredLabel="*Required" size="small" orientation="horizontal">
             <label slot="label">
               <span style="font-family:consolas;">Horizontal, required (small) with <b>slotted</b> label</span>
             </label>
@@ -128,7 +128,7 @@ const table = html`
     </tbody>
   </table>
   <hr />
-  <h3>nve-radio-group validering</h3>
+  <h3>nve-radio-group constraint validering</h3>
   <form onsubmit="event.preventDefault();">
     <nve-radio-group errorMessage="Kan ikke stå tom" required size="small" orientation="horizontal">
       <label slot="label">

--- a/src/components/nve-radio/nve-radio.demo.ts
+++ b/src/components/nve-radio/nve-radio.demo.ts
@@ -5,7 +5,7 @@ import { html } from 'lit';
  * @param e event
  * @returns
  */
-const validateRGdDemo = (e: any) => {
+const validateRadioGroupDemo = (e: any) => {
   e.preventDefault();
   const radioGroupElement = document.getElementById('customValidation') as HTMLInputElement;
   const radioGroupElementValue = radioGroupElement.value;
@@ -142,8 +142,8 @@ const table = html`
     <nve-button style="margin-top: 10px" variant="primary" size="small" type="submit">Submit</nve-button>
   </form>
   <h3>nve-radio-group custom validering</h3>
-  <form @submit="${(e: any) => validateRGdDemo(e)}">
-    <nve-radio-group id="customValidation" size="small" orientation="horizontal">
+  <form @submit="${(e: any) => validateRadioGroupDemo(e)}">
+    <nve-radio-group required id="customValidation" size="small" orientation="horizontal">
       <label slot="label">
         <span>Custom validering</span>
       </label>

--- a/src/components/nve-radio/nve-radio.demo.ts
+++ b/src/components/nve-radio/nve-radio.demo.ts
@@ -4,109 +4,122 @@ const table = html`
   <h3>Radio</h3>
   <p>Radios should _not_ be used without label.</p>
   <p>Click here and press tab to see focus.</p>
-  <form>
-    <table class="demo">
-      <thead>
-        <tr>
-          <th></th>
-          <th>Unchecked</th>
-          <th>Checked</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Default</td>
-          <td>
-            <nve-radio-group value="0">
-              <nve-radio value="1">Unchecked</nve-radio>
-            </nve-radio-group>
-          </td>
-          <td>
-            <nve-radio-group value="1">
-              <nve-radio value="1">Checked The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
-            </nve-radio-group>
-          </td>
-        </tr>
-        <tr>
-          <td>Disabled</td>
-          <td>
-            <nve-radio-group value="0">
-              <nve-radio value="1" disabled>
-                Unchecked The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."
-              </nve-radio>
-            </nve-radio-group>
-          </td>
-          <td>
-            <nve-radio-group value="1">
-              <nve-radio value="1" disabled>Checked</nve-radio>
-            </nve-radio-group>
-          </td>
-        </tr>
-      </tbody>
-    </table>
 
-    <h3>Radio-group</h3>
-    <table class="demo">
-      <thead>
-        <tr>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td></td>
-          <td>
-            <nve-radio-group orientation="horizontal" value="1" label="Horizontal">
-              <nve-radio value="1">Value</nve-radio>
-              <nve-radio value="2">Value</nve-radio>
-              <nve-radio value="3">Value</nve-radio>
-              <nve-radio value="4">Value</nve-radio>
-            </nve-radio-group>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <td>
-            <nve-radio-group orientation="vertical" value="2" label="Vertical (small)">
-              <nve-radio value="1">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
-              <nve-radio value="2">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
-              <nve-radio value="3">Value</nve-radio>
-              <nve-radio value="4">Value</nve-radio>
-            </nve-radio-group>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <td>
-            <nve-radio-group required orientation="vertical" value="3">
-              <label slot="label">
-                <nve-label light size="x-small" required value="Slot med NVE-label">
-                  <div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>
-                </nve-label>
-              </label>
-              <nve-radio value="1">Value</nve-radio>
-              <nve-radio value="2">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
-              <nve-radio value="3">Value</nve-radio>
-              <nve-radio value="4">Value</nve-radio>
-            </nve-radio-group>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <td>
-            <nve-radio-group required size="small" orientation="horizontal">
-              <label slot="label">
-                <span style="font-family:consolas;">Horizontal, required (small) with <b>slotted</b> label</span>
-              </label>
-              <nve-radio value="1">Value</nve-radio>
-              <nve-radio value="2">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
-              <nve-radio value="3">Value</nve-radio>
-              <nve-radio value="4">Value</nve-radio>
-            </nve-radio-group>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <table class="demo">
+    <thead>
+      <tr>
+        <th></th>
+        <th>Unchecked</th>
+        <th>Checked</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Default</td>
+        <td>
+          <nve-radio-group value="0">
+            <nve-radio value="1">Unchecked</nve-radio>
+          </nve-radio-group>
+        </td>
+        <td>
+          <nve-radio-group value="1">
+            <nve-radio value="1">Checked The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
+          </nve-radio-group>
+        </td>
+      </tr>
+      <tr>
+        <td>Disabled</td>
+        <td>
+          <nve-radio-group value="0">
+            <nve-radio value="1" disabled>
+              Unchecked The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."
+            </nve-radio>
+          </nve-radio-group>
+        </td>
+        <td>
+          <nve-radio-group value="1">
+            <nve-radio value="1" disabled>Checked</nve-radio>
+          </nve-radio-group>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Radio-group</h3>
+  <table class="demo">
+    <thead>
+      <tr>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td></td>
+        <td>
+          <nve-radio-group orientation="horizontal" value="1" label="Horizontal">
+            <nve-radio value="1">Value</nve-radio>
+            <nve-radio value="2">Value</nve-radio>
+            <nve-radio value="3">Value</nve-radio>
+            <nve-radio value="4">Value</nve-radio>
+          </nve-radio-group>
+        </td>
+      </tr>
+      <tr>
+        <td></td>
+        <td>
+          <nve-radio-group orientation="vertical" value="2" label="Vertical (small)">
+            <nve-radio value="1">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
+            <nve-radio value="2">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
+            <nve-radio value="3">Value</nve-radio>
+            <nve-radio value="4">Value</nve-radio>
+          </nve-radio-group>
+        </td>
+      </tr>
+      <tr>
+        <td></td>
+        <td>
+          <nve-radio-group required orientation="vertical" value="3">
+            <label slot="label">
+              <nve-label light size="x-small" required value="Slot med NVE-label">
+                <div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>
+              </nve-label>
+            </label>
+            <nve-radio value="1">Value</nve-radio>
+            <nve-radio value="2">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
+            <nve-radio value="3">Value</nve-radio>
+            <nve-radio value="4">Value</nve-radio>
+          </nve-radio-group>
+        </td>
+      </tr>
+      <tr>
+        <td></td>
+        <td>
+          <nve-radio-group required size="small" orientation="horizontal">
+            <label slot="label">
+              <span style="font-family:consolas;">Horizontal, required (small) with <b>slotted</b> label</span>
+            </label>
+            <nve-radio value="1">Value</nve-radio>
+            <nve-radio value="2">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
+            <nve-radio value="3">Value</nve-radio>
+            <nve-radio value="4">Value</nve-radio>
+          </nve-radio-group>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <hr />
+  <h3>nve-radio-group validering</h3>
+  <form>
+    <nve-radio-group errorMessage="Kan ikke stå tom" required size="small" orientation="horizontal">
+      <label slot="label">
+        <span style="font-family:consolas;">Horizontal, required (small) with <b>slotted</b> label</span>
+      </label>
+      <nve-radio value="1">Value</nve-radio>
+      <nve-radio value="2">Value The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet.."</nve-radio>
+      <nve-radio value="3">Value</nve-radio>
+      <nve-radio value="4">Value</nve-radio>
+    </nve-radio-group>
+    <nve-button style="margin-top: 10px" variant="primary" size="small" type="submit">submit</nve-button>
   </form>
 `;
 

--- a/src/components/nve-radio/nve-radio.demo.ts
+++ b/src/components/nve-radio/nve-radio.demo.ts
@@ -1,12 +1,8 @@
 import { html } from 'lit';
 
-/**
- * Metoden for å teste custom validering
- * @param e event
- * @returns
- */
-const validateRadioGroupDemo = (e: any) => {
-  e.preventDefault();
+/**  Metoden for å teste custom validering */
+const validateRadioGroupDemo = (event: any) => {
+  event.preventDefault();
   const radioGroupElement = document.getElementById('customValidation') as HTMLInputElement;
   const radioGroupElementValue = radioGroupElement.value;
   if (!radioGroupElement) return;

--- a/src/components/nve-radio/nve-radio.styles.ts
+++ b/src/components/nve-radio/nve-radio.styles.ts
@@ -12,7 +12,7 @@ export default css`
     background-color: var(--neutrals-background-primary);
   }
 
-  :host([invalid])::part(control) {
+  :host([data-invalid])::part(control) {
     color: var(--feedback-background-emphasized-error);
     border-color: var(--feedback-background-emphasized-error);
   }

--- a/src/components/nve-radio/nve-radio.styles.ts
+++ b/src/components/nve-radio/nve-radio.styles.ts
@@ -12,6 +12,16 @@ export default css`
     background-color: var(--neutrals-background-primary);
   }
 
+  :host([invalid])::part(control) {
+    color: var(--feedback-background-emphasized-error);
+    border-color: var(--feedback-background-emphasized-error);
+  }
+
+  /* overstyr opacity på disabled */
+  .radio--disabled {
+    opacity: 0.38;
+  }
+
   /* overstyr opacity på disabled */
   .radio--disabled {
     opacity: 0.38;

--- a/src/utils/updateInvalidProperty.ts
+++ b/src/utils/updateInvalidProperty.ts
@@ -1,0 +1,16 @@
+// Oppdatere bolske properites på liste av nodes av samme type
+export default function toggleBooleanAttrOnListOfNodes<T extends Element>(
+  componentsToUpdate: Array<T>,
+  property: boolean,
+  propertyString: string
+) {
+  if (property) {
+    componentsToUpdate.forEach((ch) => {
+      ch.toggleAttribute(propertyString, true);
+    });
+  } else {
+    componentsToUpdate.forEach((ch) => {
+      ch.toggleAttribute(propertyString, false);
+    });
+  }
+}


### PR DESCRIPTION
La til kommentarer på properties i radio gruppe.
Tydeligvis har sl-radio-gruppe property som heter errorMessage som ikke er tilgjengelig via super. Hvis jeg sender vår egen errorMessage så overskrives det et sted i formcontroll klasse som gjør at vi får en default melding, ikke det som var ønsket via vår errorMessage. Derfor må jeg bruke state og lagre meldingen som skal brukes senere i setCustomValidity.

Det er kun required attribute som fungerer via constraint validation. Altså hvis man har required, burde man få en feilmelding (se demo).

For å gi alle radio knapper en style mens radiogruppe feiler, toggler jeg data-invalid attribute (ikke data-user-invalid). Både her i checkbox gruppe man trenger ikke å ha data-user-invalid på alle radioer fordi den feiler som helheten. Data user-invalid vises kun når man har tatt på en element så det gir ikke mening her, siden man må ikke ta på alle radioer for å vise feil. 

Man kan også bruke custom validering, men hvis man bruker både constraint og custom, vil constrain errorMessage ta over når den er satt via property, så jeg anbefaler ikke å blande de to. 

toggleBooleanAttrOnListOfNodes i utils skal også bruke i checkbox validering