### PR TITLE
PR: AVN-291 added checkbox group validation

### DIFF
--- a/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
@@ -10,6 +10,7 @@ import toggleBooleanAttrOnListOfNodes from '../../utils/updateInvalidProperty';
  * Denne komponenten burde brukes kun med <nve-checkbox> komponent.
  * Man kan ta i bruk selectedValues som inneholder value-attributet fra alle aktive sjekkbokser inn i sjekkboksgruppen. Den
  * oppdaterer seg automatisk når mån klikker på sjekkbokser.
+ * Valideres både med constraint validation (kun required støttes per i dag), og custom validering. Custom validering prioriteres når man submitter formen.
  * <nve-checkbox> komponenter som er wrappet i <nve-checkbox-group>
  * @slot default - innholder alle nve-checkbox komponenter for global style styring og validering
  * */
@@ -37,6 +38,8 @@ export default class NveCheckboxGroup extends LitElement {
   @query('slot') slot: any;
   /** Bestemmer om feilmelding skal vises når validering feiler  */
   @state() protected showErrorMessage = false;
+  /** State på custom validering. Den trengs for å kunne kjøre både constaraint- og custom validering samtidig. */
+  @state() protected isCustomValidationError = false;
 
   static styles = [styles];
 
@@ -88,11 +91,14 @@ export default class NveCheckboxGroup extends LitElement {
     } else {
       this.resetValidation();
     }
+    this.isCustomValidationError = !isValid;
     this.toggleValidationAttributes(isValid);
   }
 
   private handleSubmit(e: SubmitEvent) {
     e.preventDefault();
+    // custom validering er prioritert. Hvis den feiler constraint validering via checkValidity kjører ikke.
+    if (this.isCustomValidationError) return;
     this.checkValidity();
   }
 

--- a/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
@@ -97,8 +97,6 @@ export default class NveCheckboxGroup extends LitElement {
 
   private handleSubmit(e: SubmitEvent) {
     e.preventDefault();
-    // custom validering er prioritert. Hvis den feiler constraint validering via checkValidity kjører ikke.
-    if (this.isCustomValidationError) return;
     this.checkValidity();
   }
 
@@ -125,6 +123,8 @@ export default class NveCheckboxGroup extends LitElement {
   /** Sjekker validity basert på constraint validation. Man kan legge til flere properties. */
   private checkValidity() {
     if (!this.required) return;
+    // custom validering er prioritert. Hvis den feiler constraint validering via checkValidity kjører ikke.
+    if (this.isCustomValidationError) return;
     let isValid = true;
     if (this.required) {
       isValid = this.checkIfRequiredValid();

--- a/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
@@ -1,12 +1,15 @@
 import { html, LitElement } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import '../nve-label/nve-label.component';
 import styles from './nve-checkbox-group.styles';
+import toggleBooleanAttrOnListOfNodes from '../../utils/updateInvalidProperty';
 
 @customElement('nve-checkbox-group')
 /**
  * Representerer en tilpasset sjekboksgruppekomponent.
- * Denne komponenten burde brukes kun med <nve-checkbox> komponent. isValid property endrer fargene på alle
+ * Denne komponenten burde brukes kun med <nve-checkbox> komponent.
+ * Man kan ta i bruk selectedValues som inneholder value-attributet fra alle aktive sjekkbokser inn i sjekkboksgruppen. Den
+ * oppdaterer seg automatisk når mån klikker på sjekkbokser.
  * <nve-checkbox> komponenter som er wrappet i <nve-checkbox-group>
  * @slot default - innholder alle nve-checkbox komponenter for global style styring og validering
  * */
@@ -15,75 +18,180 @@ export default class NveCheckboxGroup extends LitElement {
     super();
   }
 
-  /**
-   * Bestemmer om sjekkboksgruppe er valid. Hvis ikke alle sjekkbokser i gruppe blir markert som feil
-   */
-  @property({ type: Boolean, reflect: true }) invalid = false;
-  /**
-   * Disable eller enable gruppa
-   */
+  /** Deaktiverer alle sjekkbokser hvis 'true' */
   @property({ type: Boolean, reflect: true }) disabled = false;
-  /**
-   * Viser label til en gruppe
-   */
+  /** Om minst en sjekkboks er sjekket på */
+  @property({ type: Boolean, reflect: true }) required = false;
+  /** Viser label til sjekboksgruppen */
   @property() label?: string;
-  /**
-   * Viser i ikone og tooltip tekst ved siden av label. Skal ikke fungere uten label
-   */
+  /** Viser i ikone og tooltip tekst ved siden av label. Skal ikke fungere uten label */
   @property() tooltip?: string;
-  /**
-   * Om gruppen skal rendres horisontalt eller vertikalt
-   */
+  /** Om gruppen skal rendres horisontalt eller vertikalt */
   @property() orientation: 'horizontal' | 'vertical' = 'vertical';
-  /**
-   * Viser feil melding under gruppen
-   */
+  /** Feil melding som vises under gruppe hvis validering feiler */
   @property() errorMessage?: string;
+  /** Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard */
+  @property() requiredLabel = '*Obligatorisk';
+  /** Returnerer et array av value-attributet til alle sjekkbokser som er valgt */
+  @property({ type: Array }) selectedValues?: string[];
   @query('slot') slot: any;
+  /** Bestemmer om feilmelding skal vises når validering feiler  */
+  @state() protected showErrorMessage = false;
 
   static styles = [styles];
 
+  connectedCallback() {
+    super.connectedCallback();
+    const formElement = this.closest('form');
+    // Kjører validering når den nærmeste formen trigger submit. Gjelder kun constraint validation.
+    formElement?.addEventListener('submit', this.handleSubmit.bind(this));
+    this.addEventListener('sl-change', this.handleChange.bind(this));
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('sl-change', this.handleChange);
+    this.removeEventListener('submit', this.handleSubmit);
+  }
+
+  protected firstUpdated() {
+    if (this.requiredLabel) {
+      this.style.setProperty('--sl-checkbox-required-content', `"${this.requiredLabel}"`);
+    }
+
+    // sjekker om selectedValues inneholder noe verdi fra starten
+    if (!this.selectedValues?.length) return;
+    const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
+    nveCheckboxes.forEach((ch) => {
+      if (this.selectedValues?.includes(ch.value)) {
+        ch.checked = true;
+      } else {
+        ch.checked = false;
+      }
+    });
+  }
+
   updated(changedProperties: any) {
-    const assignedElements: Element[] = this.slot.assignedElements({ flatten: true });
-    const nveCheckboxes: Element[] = assignedElements.filter((element) => element.localName === 'nve-checkbox');
-    if (changedProperties.has('invalid') && this.invalid !== undefined) {
-      // retrieves all elements assigned to the default slot
-
-      if (this.invalid) {
-        nveCheckboxes.forEach((ch) => {
-          ch.setAttribute('invalid', '');
-        });
-      } else {
-        nveCheckboxes.forEach((ch) => {
-          ch.removeAttribute('invalid');
-        });
-      }
-    }
-
+    super.updated(changedProperties);
     if (changedProperties.has('disabled')) {
-      if (this.disabled) {
-        nveCheckboxes.forEach((ch) => {
-          ch.setAttribute('disabled', '');
-        });
-      } else {
-        nveCheckboxes.forEach((ch) => {
-          ch.removeAttribute('disabled');
-        });
+      const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
+      toggleBooleanAttrOnListOfNodes(nveCheckboxes, this.disabled, 'disabled');
+    }
+  }
+
+  /** En 'fake' metode som gjør custom validering enklere på checkbox-group komponent */
+  setCustomValidity(message = '') {
+    const isValid = message.length ? false : true;
+    if (!isValid) {
+      this.errorMessage = message;
+      this.makeInvalid();
+    } else {
+      this.resetValidation();
+    }
+    this.toggleValidationAttributes(isValid);
+  }
+
+  private handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    this.checkValidity();
+  }
+
+  private handleChange(e: Event) {
+    this.updateSelectedValues(e);
+    this.checkValidity();
+  }
+
+  /** Oppdaterer selectedValues property hver gang man endrer noen av sjekkbokser i sjekkboksgruppen.  */
+  private updateSelectedValues = (e: Event) => {
+    if (!this.selectedValues) return;
+    const target = e.target as HTMLInputElement;
+    if (target.checked) {
+      this.selectedValues.push(target.value);
+    } else {
+      const indexToRemove = this.selectedValues.findIndex((element) => element === target.value);
+      if (indexToRemove !== -1) {
+        this.selectedValues.splice(indexToRemove, 1);
       }
     }
+    this.requestUpdate();
+  };
+
+  /** Sjekker validity basert på constraint validation. Man kan legge til flere properties. */
+  private checkValidity() {
+    if (!this.required) return;
+    let isValid = true;
+    if (this.required) {
+      isValid = this.checkIfRequiredValid();
+    }
+
+    if (isValid) {
+      this.resetValidation();
+    } else {
+      this.makeInvalid();
+    }
+    this.toggleValidationAttributes(isValid);
+  }
+
+  /** Toggler riktig validering attribute for å vise riktig style */
+  private toggleValidationAttributes(isValid: boolean) {
+    this.toggleAttribute('data-valid', isValid);
+    this.toggleAttribute('data-user-valid', isValid);
+    this.toggleAttribute('data-invalid', !isValid);
+    this.toggleAttribute('data-user-invalid', !isValid);
+  }
+
+  private resetValidation() {
+    const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
+    nveCheckboxes.forEach((c) => {
+      c.toggleAttribute('data-user-invalid', false);
+      c.setCustomValidity('');
+    });
+    this.showErrorMessage = false;
+  }
+
+  private makeInvalid() {
+    const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
+    // checkbox har data-valid prop derfor må vi endre den med å sette custom validity på alle barn. den gir også styling
+    nveCheckboxes.forEach((c) => {
+      c.toggleAttribute('data-user-invalid', true);
+      c.setCustomValidity(this.errorMessage || 'Error');
+    });
+    this.showErrorMessage = true;
+
+    const event = new Event('sl-invalid', {
+      bubbles: true,
+      cancelable: true,
+    });
+    this.dispatchEvent(event);
+  }
+
+  private checkIfRequiredValid(): boolean {
+    const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
+    const isValid = nveCheckboxes.some((checkbox) => checkbox.checked);
+    return isValid;
   }
 
   render() {
     return html`
-      <div class="checkbox-group">
+      <fieldset
+        class="checkbox-group"
+        aria-required=${this.required}
+        aria-labelledby="label"
+        aria-describedby="error-message"
+        aria-errormessage="error-message"
+      >
         ${this.label
           ? html`<div class="checkbox-group__label">
-              <nve-label value=${this.label} size="small" tooltip=${this.tooltip!}></nve-label>
+              <nve-label id="label" value=${this.label} size="small" tooltip=${this.tooltip!}></nve-label>
             </div>`
           : null}
         <slot class="checkbox-group__checkboxes"></slot>
-        ${this.invalid ? html`<span class="checkbox-group__error-message">${this.errorMessage || null}</span>` : null}
-      </div>
+        ${this.showErrorMessage
+          ? html`<span role="alert" id="error-message" class="checkbox-group__error-message"
+              >${this.errorMessage || null}</span
+            >`
+          : null}
+      </fieldset>
     `;
   }
 }

--- a/src/components/nve-checkbox-group/nve-checkbox-group.demo.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.demo.ts
@@ -1,5 +1,20 @@
 import { html } from 'lit';
 
+const checkedValues: string[] = [];
+
+/**  Metoden for å teste custom validering*/
+const validateCheckboxGroupDemo = (e: any) => {
+  e.preventDefault();
+
+  const chgrElement = document.getElementById('checkboxGroup') as HTMLInputElement;
+  if (!chgrElement) return;
+  if (!checkedValues.includes('3')) {
+    chgrElement.setCustomValidity('Feil svar, må inneholde 3');
+  } else {
+    chgrElement.setCustomValidity('');
+  }
+};
+
 export default html`
   <hr />
   <h3>nve-checkbox-group</h3>
@@ -16,7 +31,7 @@ export default html`
       <tr>
         <td>Horizontal</td>
         <td>
-          <nve-checkbox-group disabled orientation="horizontal">
+          <nve-checkbox-group orientation="horizontal">
             <nve-checkbox checked>Value</nve-checkbox>
             <nve-checkbox>Value</nve-checkbox>
             <nve-checkbox>Value</nve-checkbox>
@@ -62,59 +77,23 @@ export default html`
         </td>
       </tr>
       <tr>
-        <td>Horizontal error</td>
+        <td>Required</td>
         <td>
-          <nve-checkbox-group invalid orientation="horizontal" errorMessage="Error message">
+          <nve-checkbox-group required orientation="vertical">
             <nve-checkbox checked>Value</nve-checkbox>
             <nve-checkbox>Value</nve-checkbox>
             <nve-checkbox>Value</nve-checkbox>
           </nve-checkbox-group>
         </td>
         <td>
-          <nve-checkbox-group invalid label="Label" orientation="horizontal" errorMessage="Error message">
+          <nve-checkbox-group required label="Label" orientation="vertical">
             <nve-checkbox checked>Value</nve-checkbox>
             <nve-checkbox>Value</nve-checkbox>
             <nve-checkbox>Value</nve-checkbox>
           </nve-checkbox-group>
         </td>
         <td>
-          <nve-checkbox-group
-            invalid
-            label="Label"
-            tooltip="Help text"
-            orientation="horizontal"
-            errorMessage="Error message"
-          >
-            <nve-checkbox checked>Value</nve-checkbox>
-            <nve-checkbox>Value</nve-checkbox>
-            <nve-checkbox>Value</nve-checkbox>
-          </nve-checkbox-group>
-        </td>
-      </tr>
-      <tr>
-        <td>Vertical error</td>
-        <td>
-          <nve-checkbox-group invalid orientation="vertical" errorMessage="Error message">
-            <nve-checkbox checked>Value</nve-checkbox>
-            <nve-checkbox>Value</nve-checkbox>
-            <nve-checkbox>Value</nve-checkbox>
-          </nve-checkbox-group>
-        </td>
-        <td>
-          <nve-checkbox-group invalid label="Label" orientation="vertical" errorMessage="Error message">
-            <nve-checkbox checked>Value</nve-checkbox>
-            <nve-checkbox>Value</nve-checkbox>
-            <nve-checkbox>Value</nve-checkbox>
-          </nve-checkbox-group>
-        </td>
-        <td>
-          <nve-checkbox-group
-            invalid
-            label="Label"
-            tooltip="Help text"
-            orientation="vertical"
-            errorMessage="Error message"
-          >
+          <nve-checkbox-group required label="Label" tooltip="Help text" orientation="vertical">
             <nve-checkbox checked>Value</nve-checkbox>
             <nve-checkbox>Value</nve-checkbox>
             <nve-checkbox>Value</nve-checkbox>
@@ -123,4 +102,34 @@ export default html`
       </tr>
     </tbody>
   </table>
+  <h3>nve-checkbox-group constraint validering</h3>
+  <!-- preventdefault så at nettsider ikke lastes på nytt -->
+  <form onsubmit="event.preventDefault();">
+    <div style="width: fit-content">
+      <nve-checkbox-group required label="Label" orientation="horizontal" errorMessage="Velg minst en">
+        <nve-checkbox>1</nve-checkbox>
+        <nve-checkbox>2</nve-checkbox>
+        <nve-checkbox>3</nve-checkbox>
+      </nve-checkbox-group>
+    </div>
+    <nve-button style="margin-top:10px" type="submit" variant="primary" size="small">Submit</nve-button>
+  </form>
+  <h3>nve-checkbox-group custom validering</h3>
+  <form @submit="${(e: any) => validateCheckboxGroupDemo(e)}">
+    <div style="width: fit-content">
+      <nve-checkbox-group
+        required
+        requiredLabel="*Required"
+        .selectedValues=${checkedValues}
+        id="checkboxGroup"
+        label="Label"
+        orientation="horizontal"
+      >
+        <nve-checkbox value="1">1</nve-checkbox>
+        <nve-checkbox value="2">2</nve-checkbox>
+        <nve-checkbox value="3">3</nve-checkbox>
+      </nve-checkbox-group>
+    </div>
+    <nve-button style="margin-top:10px" type="submit" variant="primary" size="small">Submit</nve-button>
+  </form>
 `;

--- a/src/components/nve-checkbox-group/nve-checkbox-group.styles.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.styles.ts
@@ -1,16 +1,33 @@
 import { css } from 'lit';
 
 export default css`
+  :host {
+    --sl-checkbox-required-content: '*Obligatorisk';
+  }
+
+  fieldset {
+    border: none;
+    padding: unset;
+    margin: unset;
+    gap: var(--spacing-x-small);
+  }
+
   .checkbox-group {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-x-small);
   }
 
   .checkbox-group__label {
     font: var(--label-small);
     display: flex;
     gap: var(--spacing-x-small);
+  }
+
+  :host([required]) nve-label::after {
+    content: var(--sl-checkbox-required-content);
+    font: var(--label-x-small-light);
+    margin-left: auto;
+    color: var(--feedback-background-emphasized-error);
   }
 
   /* shoelace legger til styling når hele gruppa er disabled, så må overskrive den her */

--- a/src/components/nve-checkbox/nve-checkbox.component.ts
+++ b/src/components/nve-checkbox/nve-checkbox.component.ts
@@ -1,4 +1,4 @@
-import { customElement, property } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import { SlCheckbox } from '@shoelace-style/shoelace';
 import styles from './nve-checkbox.styles';
 
@@ -14,9 +14,19 @@ export default class NveCheckbox extends SlCheckbox {
     super();
   }
 
-  /** Checks if input is valid */
-  @property({ type: Boolean, reflect: true }) invalid = false;
   static styles = [SlCheckbox.styles, styles];
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('sl-invalid', (e) => {
+      // vi vil ikke at nettleseren viser feil meldingen til oss
+      e.preventDefault();
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('sl-invalid', () => {});
+  }
 }
 
 declare global {

--- a/src/components/nve-checkbox/nve-checkbox.demo.ts
+++ b/src/components/nve-checkbox/nve-checkbox.demo.ts
@@ -37,18 +37,6 @@ export default html`
           <nve-checkbox disabled indeterminate>Value</nve-checkbox>
         </td>
       </tr>
-      <tr>
-        <td>Error</td>
-        <td>
-          <nve-checkbox invalid>Value</nve-checkbox>
-        </td>
-        <td>
-          <nve-checkbox invalid checked>Value</nve-checkbox>
-        </td>
-        <td>
-          <nve-checkbox invalid indeterminate>Value</nve-checkbox>
-        </td>
-      </tr>
     </tbody>
   </table>
 `;

--- a/src/components/nve-checkbox/nve-checkbox.styles.ts
+++ b/src/components/nve-checkbox/nve-checkbox.styles.ts
@@ -26,14 +26,14 @@ export default css`
     border-color: var(--neutrals-foreground-primary);
   }
 
-  :host([invalid])::part(control),
-  :host([disabled][invalid]:hover)::part(control) {
+  :host([data-invalid])::part(control),
+  :host([disabled][data-user-invalid]:hover)::part(control) {
     border-color: var(--feedback-background-emphasized-error);
   }
-  :host([invalid])::part(control control--checked),
-  :host([invalid])::part(control control--indeterminate),
-  :host([disabled][invalid]:hover)::part(control control--checked),
-  :host([disabled][invalid]:hover)::part(control control--indeterminate) {
+  :host([data-invalid])::part(control control--checked),
+  :host([data-user-invalid])::part(control control--indeterminate),
+  :host([disabled][data-user-invalid]:hover)::part(control control--checked),
+  :host([disabled][data-user-invalid]:hover)::part(control control--indeterminate) {
     background: var(--feedback-background-emphasized-error);
   }
 

--- a/src/components/nve-label/nve-label.styles.ts
+++ b/src/components/nve-label/nve-label.styles.ts
@@ -7,20 +7,22 @@ export const styles = css`
   :host {
     color: var(--neutrals-foreground-primary);
     font: var(--label-small);
+    width: 100%;
+    display: flex;
+    align-items: center;
   }
 
-    /* skriftstørrelser */
-    :host([size='x-small']) {
-      font: var(--label-x-small);
-    }
-    :host([size='medium']) {
-      font: var(--label-medium);
-    }
-    :host([size='large']) {
-      font: var(--label-large);
-    }
-  
-  
+  /* skriftstørrelser */
+  :host([size='x-small']) {
+    font: var(--label-x-small);
+  }
+  :host([size='medium']) {
+    font: var(--label-medium);
+  }
+  :host([size='large']) {
+    font: var(--label-large);
+  }
+
   /* light-variant i standard størrelse */
   :host([light]) {
     font: var(--label-small-light);

--- a/src/stories/nve-checkbox-group/NveCheckboxGroup.stories.ts
+++ b/src/stories/nve-checkbox-group/NveCheckboxGroup.stories.ts
@@ -1,7 +1,8 @@
 import '../../components/nve-checkbox-group/nve-checkbox-group.component';
 import '../../components/nve-checkbox/nve-checkbox.component';
-import { StoryObj } from '@storybook/web-components';
+import { Meta, StoryObj } from '@storybook/web-components';
 import { NveCheckboxGroup, NveCheckboxGroupProps } from './NveCheckboxGroup';
+import NveCheckboxGroupDoc from './NveCheckboxGroupDoc.mdx';
 
 const meta = {
   title: 'Nve/NveCheckboxGroup',
@@ -15,13 +16,18 @@ const meta = {
   },
   parameters: {
     docs: {
+      page: NveCheckboxGroupDoc,
+
       description: {
-        component:
-          '<h2><nve-checkbox-group> | NveCheckboxGroup</h2><a href="https://github.com/NVE/Designsystem/tree/main/doc/nve-checkbox.md">API-dokumentasjon</a>',
+        component: `<div>
+          <a href="<a href="https://github.com/NVE/Designsystem/tree/main/doc/nve-checkbox-group.md">API-dokumentasjon</a>
+          <p>Sjekkboksgruppe lar brukere velge flere skjekkbokser fra en gruppe av alternativer. Den organiserer vanligvis relaterte sjekkbokser sammen og gir en praktisk måte for brukere å foreta flere valg innenfor en spesifikk kategori eller sett med alternativer.
+          De valgte skjekkbokser i gruppen representerer samlet sett brukerens valg blant de tilgjengelige alternativene.
+          </div>`,
       },
     },
   },
-};
+} satisfies Meta<NveCheckboxGroupProps>;
 
 export default meta;
 type Story = StoryObj<NveCheckboxGroupProps>;
@@ -29,10 +35,11 @@ type Story = StoryObj<NveCheckboxGroupProps>;
 export const standard: Story = {
   args: {
     disabled: false,
-    invalid: false,
     orientation: 'horizontal',
     label: 'Label',
     tooltip: 'Help text',
     errorMessage: 'Error message',
+    required: false,
+    requiredLabel: '',
   },
 };

--- a/src/stories/nve-checkbox-group/NveCheckboxGroup.ts
+++ b/src/stories/nve-checkbox-group/NveCheckboxGroup.ts
@@ -1,27 +1,33 @@
 import { html } from 'lit';
+import '../../components/nve-button/nve-button.component';
 
 export interface NveCheckboxGroupProps {
   disabled: boolean;
-  invalid: boolean;
   orientation: 'vertical' | 'horizontal';
   label: string;
   tooltip: string;
   errorMessage: string;
+  required: boolean;
+  requiredLabel: string;
 }
 
 export const NveCheckboxGroup = (props: NveCheckboxGroupProps) => {
   return html`
-    <nve-checkbox-group
-      ?disabled=${props.disabled}
-      ?invalid=${props.invalid}
-      orientation=${props.orientation}
-      label=${props.label}
-      tooltip=${props.tooltip}
-      errorMessage=${props.errorMessage}
-    >
-      <nve-checkbox>Value</nve-checkbox>
-      <nve-checkbox>Value</nve-checkbox>
-      <nve-checkbox>Value</nve-checkbox>
-    </nve-checkbox-group>
+    <form style="width: fit-content">
+      <nve-checkbox-group
+        ?disabled=${props.disabled}
+        orientation=${props.orientation}
+        label=${props.label}
+        tooltip=${props.tooltip}
+        errorMessage=${props.errorMessage}
+        ?required=${props.required}
+        requiredLabel=${props.requiredLabel}
+      >
+        <nve-checkbox>Value</nve-checkbox>
+        <nve-checkbox>Value</nve-checkbox>
+        <nve-checkbox>Value</nve-checkbox>
+      </nve-checkbox-group>
+      <nve-button style="margin-top: 10px" size="small" variant="primary" type="submit">Submit</nve-button>
+    </form>
   `;
 };

--- a/src/stories/nve-checkbox-group/NveCheckboxGroupDoc.mdx
+++ b/src/stories/nve-checkbox-group/NveCheckboxGroupDoc.mdx
@@ -1,0 +1,31 @@
+import './../css/stories.css';
+
+import {
+  Canvas,
+  Story,
+  Meta,
+  Title,
+  Subtitle,
+  Description,
+  Source,
+  Primary,
+  Controls,
+  Stories,
+} from '@storybook/blocks';
+
+import * as NveCheckboxGroup from './NveCheckboxGroup.stories';
+
+<Meta isTemplate />
+
+<Title />
+<Description />
+<br />
+<br />
+
+## Parametere/Props
+
+Her kan du se hvilke parametere (props) komponenten kan ta imot og se endringer i kode.
+Du kan se hvordan sjekkboksgruppe oppfører seg når du setter 'required' til 'true' og klikker på Submit knapp uten å velge noen av sjekkbokser.
+
+<Primary />
+<Controls />

--- a/src/stories/nve-checkbox/NveCheckbox.stories.ts
+++ b/src/stories/nve-checkbox/NveCheckbox.stories.ts
@@ -11,8 +11,13 @@ const meta = {
     docs: {
       page: NveCheckboxDoc,
       description: {
-        component:
-          '<h2><nve-checkbox> | NveCheckbox</h2><a href="https://github.com/NVE/Designsystem/tree/main/doc/nve-checkbox.md">API-dokumentasjon</a>',
+        component: `<div>
+        <a href="<a href="https://github.com/NVE/Designsystem/tree/main/doc/nve-checkbox.md">API-dokumentasjon</a>
+        <p>Brukeren kan klikke på en sjekkboks for å aktivere eller deaktivere en tilstand eller et alternativ. 
+        Når sjekkboksen er merket (hakket av), indikerer det at brukeren har valgt eller aktivert det tilhørende alternativet.
+        Når den ikke er merket, betyr det at alternativet ikke er valgt. Sjekkbokser brukes ofte i skjemaer, 
+        innstillinger og lignende situasjoner der brukeren skal gi spesifikke tillatelser, velge alternativer eller angi preferanser.
+        </div>`,
       },
     },
   },
@@ -26,8 +31,7 @@ export const Primary: Story = {
     disabled: false,
     checked: false,
     indeterminate: false,
-    invalid: false,
-    value: "value"
+    value: 'value',
   },
 };
 
@@ -36,8 +40,7 @@ export const Unchecked: Story = {
     disabled: false,
     checked: false,
     indeterminate: false,
-    invalid: false,
-    value: "unchecked"
+    value: 'unchecked',
   },
 };
 
@@ -46,8 +49,7 @@ export const Checked: Story = {
     disabled: false,
     checked: true,
     indeterminate: false,
-    invalid: false,
-    value: "checked"
+    value: 'checked',
   },
 };
 
@@ -56,8 +58,7 @@ export const Indeterminate: Story = {
     disabled: false,
     checked: false,
     indeterminate: true,
-    invalid: false,
-    value: "indeterminate"
+    value: 'indeterminate',
   },
 };
 
@@ -66,8 +67,7 @@ export const Disabledunchecked: Story = {
     disabled: true,
     checked: false,
     indeterminate: false,
-    invalid: false,
-    value: "unchecked",
+    value: 'unchecked',
   },
 };
 
@@ -76,8 +76,7 @@ export const Disabledchecked: Story = {
     disabled: true,
     checked: true,
     indeterminate: false,
-    invalid: false,
-    value: "checked"
+    value: 'checked',
   },
 };
 
@@ -86,37 +85,6 @@ export const Disabledindeterminate: Story = {
     disabled: true,
     checked: false,
     indeterminate: true,
-    invalid: false,
-    value: "indeterminate"
-  },
-};
-
-export const Errorunchecked: Story = {
-  args: {
-    disabled: false,
-    checked: false,
-    indeterminate: false,
-    invalid: true,
-    value: "unchecked"
-  },
-};
-
-export const Errorchecked: Story = {
-  args: {
-    disabled: false,
-    checked: true,
-    indeterminate: false,
-    invalid: true,
-    value: "checked"
-  },
-};
-
-export const Errorindeterminate: Story = {
-  args: {
-    disabled: false,
-    checked: false,
-    indeterminate: true,
-    invalid: true,
-    value: "indeterminate"
+    value: 'indeterminate',
   },
 };

--- a/src/stories/nve-checkbox/NveCheckbox.ts
+++ b/src/stories/nve-checkbox/NveCheckbox.ts
@@ -4,8 +4,7 @@ export interface NveCheckboxProps {
   disabled: boolean;
   checked: boolean;
   indeterminate: boolean;
-  invalid: boolean;
-  value: string;
+  dataUserInvalid: boolean;
 }
 
 export const NveCheckbox = (props: NveCheckboxProps) => {
@@ -14,8 +13,9 @@ export const NveCheckbox = (props: NveCheckboxProps) => {
       ?disabled=${props.disabled}
       ?checked=${props.checked}
       ?indeterminate=${props.indeterminate}
-      ?invalid=${props.invalid}
-      >${props.value}</nve-checkbox
+      ?data-user-invalid=${props.dataUserInvalid}
+      ?data-valid=${!props.dataUserInvalid}
+      >Value</nve-checkbox
     >
   `;
 };

--- a/src/stories/nve-checkbox/NveCheckboxDoc.mdx
+++ b/src/stories/nve-checkbox/NveCheckboxDoc.mdx
@@ -43,22 +43,6 @@ Bruk property "disabled" for å disable bokser
   </span>
 </div>
 
-## Error
-
-Bruk property "invalid" for å markere bokser med rød farge
-
-<div class="container">
-  <span class="elem">
-    <Canvas of={NveCheckboxStories.Errorunchecked} />
-  </span>
-  <span class="elem">
-    <Canvas of={NveCheckboxStories.Errorchecked} />
-  </span>
-  <span class="elem">
-    <Canvas of={NveCheckboxStories.Errorindeterminate} />
-  </span>
-</div>
-
 ## Parametere/Props
 
 Her kan du se hvilke parametere (props) komponenten kan ta imot og se endringer i kode

--- a/src/utils/updateInvalidProperty.ts
+++ b/src/utils/updateInvalidProperty.ts
@@ -1,16 +1,11 @@
-// Oppdatere bolske properites på liste av nodes av samme type
+/** Oppdatere bolske properites på en list av samme type nodes f.eks i sjekkboksen setter man disabled i sjekkboksgruppen
+ * denne funksjonen toggler disabled på alle sjekkbokser som er barn til sjekkboksgruppen */
 export default function toggleBooleanAttrOnListOfNodes<T extends Element>(
-  componentsToUpdate: Array<T>,
-  property: boolean,
-  propertyString: string
+  componentsToUpdate: T[],
+  isProperty: boolean,
+  propertyName: string
 ) {
-  if (property) {
-    componentsToUpdate.forEach((ch) => {
-      ch.toggleAttribute(propertyString, true);
-    });
-  } else {
-    componentsToUpdate.forEach((ch) => {
-      ch.toggleAttribute(propertyString, false);
-    });
-  }
+  componentsToUpdate.forEach((ch) => {
+    ch.toggleAttribute(propertyName, isProperty);
+  });
 }


### PR DESCRIPTION
Selv om sjekkboksgruppe er vår egen komponent jeg prøvde å 'etterligne' shoelace validering så at bruker ikke blir forvirret når de ser på komponentene i DOMen. Altså jeg la til samme attributer som shoelace bruker: data-valid, data-invalid, data-user-valid, data-user-invalid. Sjekkobksgruppe kaster også sl-invalid hvis valideringen feiler. 

Både her i checkbox gruppe man trenger ikke å ha data-user-invalid på alle sjekkbokser/radioer fordi den feiler som helheten (gruppe). Data user-invalid vises kun når man har tatt på en element så det gir ikke å toggle den, siden man må ikke ta på alle sjekkbokser for å vise feil. Derfor styles den på data-invalid.

Jeg la til alle UU viktige attributer

Testing akkurat på samme måte som input og radio sjekkboks. Man kan teste required (eneaste constraint validering proparty som valideres, akkurat som i radio gruppe). 

Det blir selectedValues arrat på checkbox-group som inneholder 'values' på sjekket sjekkbokser. Den er nyttig for å vise sjekkboksene som skal vær sjekket (eller ikke) når siden åpnes, men også til validering. Man kan f.eks. se hvilke verdier er i selectedValues og lage en validering basert på det (la oss si at de må finne en value="3")