### PR TITLE
Riktig mellomrom mellom radioknapper som står under hverandre

### DIFF
--- a/src/components/nve-radio-group/nve-radio-group.styles.ts
+++ b/src/components/nve-radio-group/nve-radio-group.styles.ts
@@ -22,7 +22,7 @@ export default css`
   :host::part(form-control-input) {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-x-small, 0.5rem);
+    gap: var(--spacing-small);
   }
 
   :host::part(form-control-input) {


### PR DESCRIPTION
Det var for trangt mellom radioknapper som står under hverandre.
Slik så det ut:
![image](https://github.com/NVE/Designsystem/assets/71138449/fc3ab13e-b366-44df-8515-16b76af7d6d7)

Har oppdatert iht. Figma (og skisser i Abonner).

