### PR TITLE
PR: bugfix vi må beholde fnytter i setProperty

### DIFF
--- a/src/components/nve-radio-group/nve-radio-group.component.ts
+++ b/src/components/nve-radio-group/nve-radio-group.component.ts
@@ -84,7 +84,8 @@ export default class NveRadioGroup extends SlRadioGroup {
   updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     if (changedProperties.has('requiredLabel')) {
-      this.style.setProperty('--sl-input-required-content', `${this.requiredLabel}`);
+      //`"${this.requiredLabel}"` er en rar syntaksen men hvis vi ikke bruker fnytter html skjønner ikke at requiredLabel er en verdi
+      this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
     }
     const hasDataUserInvalidAttr = this.hasAttribute('data-user-invalid');
     if (hasDataUserInvalidAttr && !this.alreadyInvalid) {
@@ -128,7 +129,7 @@ export default class NveRadioGroup extends SlRadioGroup {
       this.errorMessageCopy = this.validationMessage;
     }
     this.setCustomValidity(this.errorMessageCopy);
-    this.style.setProperty('--radio-group-error-message', `${this.errorMessageCopy}`);
+    this.style.setProperty('--radio-group-error-message', `"${this.errorMessageCopy}"`);
   }
 
   private resetValidation() {

--- a/src/components/nve-radio-group/nve-radio-group.styles.ts
+++ b/src/components/nve-radio-group/nve-radio-group.styles.ts
@@ -42,12 +42,17 @@ export default css`
     text-align: left;
   }
 
-  :host::part(form-control-label)::after {
+  :host([required]) .form-control--has-label .form-control__label::after,
+  :host([requiredLabel])::part(form-control-label)::after {
     align-self: flex-end;
+    font: var(--label-x-small-light);
+    color: var(--feedback-background-emphasized-error);
   }
 
   :host([orientation='vertical'])::part(form-control),
   :host([vertical])::part(form-control) {
+    font: var(--label-x-small-light);
+    color: var(--feedback-background-emphasized-error);
     align-items: flex-start;
   }
 

--- a/src/components/nve-radio/nve-radio.demo.ts
+++ b/src/components/nve-radio/nve-radio.demo.ts
@@ -126,10 +126,16 @@ const table = html`
   <hr />
   <h3>nve-radio-group constraint validering</h3>
   <form onsubmit="event.preventDefault();">
-    <nve-radio-group errorMessage="Kan ikke stå tom" required size="small" orientation="horizontal">
-      <label slot="label">
+    <nve-radio-group
+      style="width:fit-content"
+      errorMessage="Kan ikke stå tom"
+      required
+      size="small"
+      orientation="horizontal"
+    >
+      <nve-label slot="label">
         <span>Validering</span>
-      </label>
+      </nve-label>
       <nve-radio value="1">Value 1</nve-radio>
       <nve-radio value="2">Value 2</nve-radio>
       <nve-radio value="3">Value 3</nve-radio>
@@ -139,10 +145,10 @@ const table = html`
   </form>
   <h3>nve-radio-group custom validering</h3>
   <form @submit="${(e: any) => validateRadioGroupDemo(e)}">
-    <nve-radio-group required id="customValidation" size="small" orientation="horizontal">
-      <label slot="label">
+    <nve-radio-group style="width:fit-content" required id="customValidation" size="small" orientation="horizontal">
+      <nve-label slot="label">
         <span>Custom validering</span>
-      </label>
+      </nve-label>
       <nve-radio value="1">Value 1</nve-radio>
       <nve-radio value="2">Value 2</nve-radio>
       <nve-radio value="3">Value 3</nve-radio>


### PR DESCRIPTION
Ser ut at hvis vi fjerner fnytter  her  i `"${this.requiredLabel}"`
this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
html skjønner ikke at this.requiredLabel er en verdi fordi den må ha fnytter der