### PR TITLE
PR: avn-355 nve-input suffix slot fikset

### DIFF
--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -1,5 +1,5 @@
 import { customElement, property, state } from 'lit/decorators.js';
-import { SlInput } from '@shoelace-style/shoelace';
+import SlInput from '@shoelace-style/shoelace/dist/components/input/input.js';
 import styles from './nve-input.styles';
 
 /**
@@ -90,6 +90,7 @@ export default class NveInput extends SlInput {
   private showErrorIcon() {
     const nveInput = this;
     const nveIcon = document.createElement('nve-icon');
+    nveIcon.setAttribute('id', 'error-icon');
     nveIcon.setAttribute('name', 'error');
     nveIcon.setAttribute('slot', 'suffix');
     // ikone farge
@@ -101,9 +102,10 @@ export default class NveInput extends SlInput {
   }
   private hideErrorIcon() {
     const nveInput = this;
-    const nveIcon = nveInput.querySelector('[slot="suffix"]');
-    if (nveIcon) {
-      nveIcon.remove();
+    //make sure its an error icon!
+    const errorIcon = nveInput.querySelector('#error-icon');
+    if (errorIcon) {
+      errorIcon.remove();
     }
   }
 }

--- a/src/components/nve-input/nve-input.demo.ts
+++ b/src/components/nve-input/nve-input.demo.ts
@@ -165,11 +165,22 @@ const table = html`
           <nve-input filled size="large" label="large" value="large"></nve-input>
         </td>
       </tr>
+      <tr>
+        <td>Størrelse: Stor</td>
+        <td>
+          <nve-input size="large" label="large"> <nve-icon name="info" slot="suffix"></nve-icon></nve-input>
+        </td>
+        <td>
+          <nve-input filled size="large" label="large" value="large"></nve-input>
+        </td>
+      </tr>
     </tbody>
   </table>
   <h3 id="nve-inpu-validering">nve-input constraint validering</h3>
   <form style="max-width: 300px" onsubmit="event.preventDefault();">
-    <nve-input required errorMessage="Kan ikke være tom" label="Label" value=""></nve-input>
+    <nve-input required errorMessage="Kan ikke være tom" label="Label" value="">
+      <nve-icon slot="suffix" name="search"></nve-icon>
+    </nve-input>
     <nve-button style="margin-top: 10px" variant="primary" type="submit" size="small">Submit</nve-button>
   </form>
   <h3 id="nve-inpu-validering">nve-input custom validering (med blur)</h3>

--- a/src/components/nve-input/nve-input.demo.ts
+++ b/src/components/nve-input/nve-input.demo.ts
@@ -165,15 +165,6 @@ const table = html`
           <nve-input filled size="large" label="large" value="large"></nve-input>
         </td>
       </tr>
-      <tr>
-        <td>Størrelse: Stor</td>
-        <td>
-          <nve-input size="large" label="large"> <nve-icon name="info" slot="suffix"></nve-icon></nve-input>
-        </td>
-        <td>
-          <nve-input filled size="large" label="large" value="large"></nve-input>
-        </td>
-      </tr>
     </tbody>
   </table>
   <h3 id="nve-inpu-validering">nve-input constraint validering</h3>


### PR DESCRIPTION
Jeg fjerner alle suffix slots i nve-input hvis input ikke feiler. Det gjøt at vi kan ikke bruke suffix. Derfor endrer legger jeg til en id error-icon på 'feil' ikone og fjerner kun den når validering gikk greit. Du kan teste det i demo. Jeg la til en ekstra ikone i den første demo biten med validering. 