### PR TITLE
PR: oppdatert nve-menu-label så at den kan brukes som kategori divideren i nve-menu

### DIFF
--- a/doc/nve-label.md
+++ b/doc/nve-label.md
@@ -2,14 +2,18 @@
 
 Ledetekst med valgfritt verktøy-hint (og tilhørende info-ikon)
 
+Kan brukes med inn i nve-menu (hvor den har en spesiell styling) som kategori skiller.
+
 ## Properties
 
-| Property  | Attribute | Type                                          | Default     | Description                                      |
-|-----------|-----------|-----------------------------------------------|-------------|--------------------------------------------------|
-| `light`   | `light`   | `boolean`                                     | false       | Sett denne hvis du vil ha litt lettere skriftvekt |
-| `size`    | `size`    | `"small" \| "medium" \| "large" \| "x-small"` | "small"     | Størrelse                                        |
-| `tooltip` | `tooltip` | `string \| undefined`                         | "undefined" | Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet |
-| `value`   | `value`   | `string`                                      | ""          | Teksten som skal vises                           |
+| Property    | Attribute   | Type                                          | Default     | Description                                      |
+|-------------|-------------|-----------------------------------------------|-------------|--------------------------------------------------|
+| `iconColor` | `iconColor` | `"default" \| "black"`                        | "default"   | Ikon farge                                       |
+| `iconLeft`  | `iconLeft`  | `boolean`                                     | false       | Om tooltip ikone skal vises på venstre siden     |
+| `light`     | `light`     | `boolean`                                     | false       | Sett denne hvis du vil ha litt lettere skriftvekt |
+| `size`      | `size`      | `"small" \| "medium" \| "large" \| "x-small"` | "small"     | Størrelse                                        |
+| `tooltip`   | `tooltip`   | `string \| undefined`                         | "undefined" | Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet |
+| `value`     | `value`     | `string`                                      | ""          | Teksten som skal vises                           |
 
 ## Slots
 

--- a/doc/nve-menu-item.md
+++ b/doc/nve-menu-item.md
@@ -7,7 +7,6 @@ Mer info: https://shoelace.style/components/menu-item
 
 | Property        | Attribute       | Type                     | Default | Description                                      |
 |-----------------|-----------------|--------------------------|---------|--------------------------------------------------|
-| `category`      | `category`      | `boolean`                | false   | Gjør at teksten vises som en unclickable kategori |
 | `checked`       |                 | `boolean`                |         | Draws the item in a checked state.               |
 | `defaultSlot`   |                 | `HTMLSlotElement`        |         |                                                  |
 | `dir`           |                 | `string`                 |         |                                                  |

--- a/doc/nve-menu.md
+++ b/doc/nve-menu.md
@@ -2,7 +2,8 @@
 
 En sl-menu i NVE-forkledning.
 Mer info: https://shoelace.style/components/menu
-Man kan bruke nve-label for å skille mellom kategorier. Nve-label inn i nve-menu har en spesiell styling.
+Man kan bruke nve-label inni sl-menu, f.eks. til å kategorisere menyvalg.
+Nve-label får en spesiell styling når den brukes inni nve-menu
 
 ## Properties
 

--- a/doc/nve-menu.md
+++ b/doc/nve-menu.md
@@ -2,7 +2,7 @@
 
 En sl-menu i NVE-forkledning.
 Mer info: https://shoelace.style/components/menu
-
+Man kan bruke nve-label for å skille mellom kategorier. Nve-label inn i nve-menu har en spesiell styling.
 
 ## Properties
 

--- a/doc/nve-popup.md
+++ b/doc/nve-popup.md
@@ -1,0 +1,69 @@
+# nve-popup
+
+En sl-popup med NVE design.
+Mer info: https://shoelace.style/components/popup
+
+## Properties
+
+| Property                 | Type                                             | Description                                      |
+|--------------------------|--------------------------------------------------|--------------------------------------------------|
+| `active`                 | `boolean`                                        | Activates the positioning logic and shows the popup. When this attribute is removed, the positioning logic is torn<br />down and the popup will be hidden. |
+| `anchor`                 | `string \| Element \| VirtualElement`            | The element the popup will be anchored to. If the anchor lives outside of the popup, you can provide the anchor<br />element `id`, a DOM element reference, or a `VirtualElement`. If the anchor lives inside the popup, use the<br />`anchor` slot instead. |
+| `arrow`                  | `boolean`                                        | Attaches an arrow to the popup. The arrow's size and color can be customized using the `--arrow-size` and<br />`--arrow-color` custom properties. For additional customizations, you can also target the arrow using<br />`::part(arrow)` in your stylesheet. |
+| `arrowPadding`           | `number`                                         | The amount of padding between the arrow and the edges of the popup. If the popup has a border-radius, for example,<br />this will prevent it from overflowing the corners. |
+| `arrowPlacement`         | `"start" \| "end" \| "center" \| "anchor"`       | The placement of the arrow. The default is `anchor`, which will align the arrow as close to the center of the<br />anchor as possible, considering available space and `arrow-padding`. A value of `start`, `end`, or `center` will<br />align the arrow to the start, end, or center of the popover instead. |
+| `autoSize`               | `"horizontal" \| "vertical" \| "both"`           | When set, this will cause the popup to automatically resize itself to prevent it from overflowing. |
+| `autoSizeBoundary`       | `Element \| Element[]`                           | The auto-size boundary describes clipping element(s) that overflow will be checked relative to when resizing. By<br />default, the boundary includes overflow ancestors that will cause the element to be clipped. If needed, you can<br />change the boundary by passing a reference to one or more elements to this property. |
+| `autoSizePadding`        | `number`                                         | The amount of padding, in pixels, to exceed before the auto-size behavior will occur. |
+| `dir`                    | `string`                                         |                                                  |
+| `distance`               | `number`                                         | The distance in pixels from which to offset the panel away from its anchor. |
+| `flip`                   | `boolean`                                        | When set, placement of the popup will flip to the opposite site to keep it in view. You can use<br />`flipFallbackPlacements` to further configure how the fallback placement is determined. |
+| `flipBoundary`           | `Element \| Element[]`                           | The flip boundary describes clipping element(s) that overflow will be checked relative to when flipping. By<br />default, the boundary includes overflow ancestors that will cause the element to be clipped. If needed, you can<br />change the boundary by passing a reference to one or more elements to this property. |
+| `flipFallbackPlacements` | `string`                                         | If the preferred placement doesn't fit, popup will be tested in these fallback placements until one fits. Must be a<br />string of any number of placements separated by a space, e.g. "top bottom left". If no placement fits, the flip<br />fallback strategy will be used instead. |
+| `flipFallbackStrategy`   | `"best-fit" \| "initial"`                        | When neither the preferred placement nor the fallback placements fit, this value will be used to determine whether<br />the popup should be positioned using the best available fit based on available space or as it was initially<br />preferred. |
+| `flipPadding`            | `number`                                         | The amount of padding, in pixels, to exceed before the flip behavior will occur. |
+| `lang`                   | `string`                                         |                                                  |
+| `placement`              | `"top" \| "top-start" \| "top-end" \| "bottom" \| "bottom-start" \| "bottom-end" \| "right" \| "right-start" \| "right-end" \| "left" \| "left-start" \| "left-end"` | The preferred placement of the popup. Note that the actual placement will vary as configured to keep the<br />panel inside of the viewport. |
+| `popup`                  | `HTMLElement`                                    | A reference to the internal popup container. Useful for animating and styling the popup with JavaScript. |
+| `shift`                  | `boolean`                                        | Moves the popup along the axis to keep it in view when clipped. |
+| `shiftBoundary`          | `Element \| Element[]`                           | The shift boundary describes clipping element(s) that overflow will be checked relative to when shifting. By<br />default, the boundary includes overflow ancestors that will cause the element to be clipped. If needed, you can<br />change the boundary by passing a reference to one or more elements to this property. |
+| `shiftPadding`           | `number`                                         | The amount of padding, in pixels, to exceed before the shift behavior will occur. |
+| `skidding`               | `number`                                         | The distance in pixels from which to offset the panel along its anchor. |
+| `strategy`               | `"absolute" \| "fixed"`                          | Determines how the popup is positioned. The `absolute` strategy works well in most cases, but if overflow is<br />clipped, using a `fixed` position strategy can often workaround it. |
+| `sync`                   | `"both" \| "width" \| "height"`                  | Syncs the popup's width or height to that of the anchor element. |
+
+## Methods
+
+| Method       | Type                                             | Description                                      |
+|--------------|--------------------------------------------------|--------------------------------------------------|
+| `emit`       | `{ <T extends "abort" \| "animationcancel" \| "animationend" \| "animationiteration" \| "animationstart" \| "auxclick" \| "beforeinput" \| "blur" \| "cancel" \| "canplay" \| "canplaythrough" \| ... 113 more ... \| "sl-start">(name: EventTypeDoesNotRequireDetail<...>, options?: SlEventInit<...> \| undefined): GetCustomEventType<.....` | Emits a custom event with more convenient defaults. |
+| `reposition` | `(): void`                                       | Forces the popup to recalculate and reposition itself. |
+
+## Events
+
+| Event           | Description                                      |
+|-----------------|--------------------------------------------------|
+| `sl-reposition` | Emitted when the popup is repositioned. This event can fire a lot, so avoid putting expensive<br />operations in your listener or consider debouncing it. |
+
+## Slots
+
+| Name     | Description                                      |
+|----------|--------------------------------------------------|
+|          | The popup's content.                             |
+| `anchor` | The element the popup will be anchored to. If the anchor lives outside of the popup, you can use the<br />`anchor` attribute or property instead. |
+
+## CSS Shadow Parts
+
+| Part    | Description                                      |
+|---------|--------------------------------------------------|
+| `arrow` | The arrow's container. Avoid setting `top\|bottom\|left\|right` properties, as these values are<br />assigned dynamically as the popup moves. This is most useful for applying a background color to match the popup, and<br />maybe a border or box shadow. |
+| `popup` | The popup's container. Useful for setting a background color, box shadow, etc. |
+
+## CSS Custom Properties
+
+| Property                       | Default                     | Description                                      |
+|--------------------------------|-----------------------------|--------------------------------------------------|
+| `--arrow-color`                | "var(--sl-color-neutral-0)" | The color of the arrow.                          |
+| `--arrow-size`                 | "6px"                       | The size of the arrow. Note that an arrow won't be shown unless the `arrow`<br />attribute is used. |
+| `--auto-size-available-height` |                             | A read-only custom property that determines the amount of height the<br />popup can be before overflowing. Useful for positioning child elements that need to overflow. This property is only<br />available when using `auto-size`. |
+| `--auto-size-available-width`  |                             | A read-only custom property that determines the amount of width the<br />popup can be before overflowing. Useful for positioning child elements that need to overflow. This property is only<br />available when using `auto-size`. |

--- a/src/components/nve-label/nve-label.component.ts
+++ b/src/components/nve-label/nve-label.component.ts
@@ -8,6 +8,8 @@ import '../nve-tooltip/nve-tooltip.component';
 /**
  * Ledetekst med valgfritt verktøy-hint (og tilhørende info-ikon)
  *
+ * Kan brukes med inn i nve-menu (hvor den har en spesiell styling) som kategori skiller.
+ *
  * @slot (default) - teksten som skal vises. Eller du kan bruke value-attributtet
  * @slot tooltip - innhold i denne blir vist som en tooltip hvis man svever over info-ikonet
  *
@@ -37,6 +39,16 @@ export default class NveLabel extends LitElement {
    * Denne teksten blir vist som et verktøyhint hvis man svever over info-ikonet
    */
   @property({ reflect: true }) tooltip?: string = undefined;
+
+  /**
+   * Om tooltip ikone skal vises på venstre siden
+   */
+  @property({ type: Boolean, reflect: true }) iconLeft = false;
+
+  /**
+   * Ikon farge
+   */
+  @property({ reflect: true }) iconColor: 'default' | 'black' = 'default';
 
   static styles = [styles];
 
@@ -71,7 +83,10 @@ export default class NveLabel extends LitElement {
   }
 
   render() {
-    return html` ${this.renderValueProperty()} ${this.renderInfoIconWithTooltip()} `;
+    return html`
+      ${this.iconLeft ? this.renderInfoIconWithTooltip() : null} ${this.renderValueProperty()}
+      ${!this.iconLeft ? this.renderInfoIconWithTooltip() : null}
+    `;
   }
 }
 

--- a/src/components/nve-label/nve-label.demo.ts
+++ b/src/components/nve-label/nve-label.demo.ts
@@ -74,16 +74,38 @@ const table = html`
         </td>
       </tr>
       <tr>
-        <td>Innhold i slot</td>
+        <td>Med info-ikon på venstre siden</td>
         <td>
-          <nve-label>
-            Ledetekst i <i>HTML</i>
+          <nve-label value="Svev over ikonet" iconLeft>
+            <div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>
           </nve-label>
         </td>
         <td>
-          <nve-label light>
-            Ledetekst i <i>HTML</i>
+          <nve-label light value="Svev over ikonet" iconLeft>
+            <div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>
           </nve-label>
+        </td>
+      </tr>
+      <tr>
+        <td>Med svart info-ikon</td>
+        <td>
+          <nve-label value="Svev over ikonet" iconColor="black">
+            <div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>
+          </nve-label>
+        </td>
+        <td>
+          <nve-label light value="Svev over ikonet" iconColor="black">
+            <div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>
+          </nve-label>
+        </td>
+      </tr>
+      <tr>
+        <td>Innhold i slot</td>
+        <td>
+          <nve-label> Ledetekst i <i>HTML</i> </nve-label>
+        </td>
+        <td>
+          <nve-label light> Ledetekst i <i>HTML</i> </nve-label>
         </td>
       </tr>
     </tbody>

--- a/src/components/nve-label/nve-label.styles.ts
+++ b/src/components/nve-label/nve-label.styles.ts
@@ -10,6 +10,7 @@ export const styles = css`
     width: 100%;
     display: flex;
     align-items: center;
+    gap: var(--spacing-xx-small);
   }
 
   /* skriftstørrelser */
@@ -44,6 +45,9 @@ export const styles = css`
     align-items: center;
     vertical-align: bottom;
     cursor: pointer;
-    margin-left: var(--spacing-xx-small);
+  }
+
+  :host([iconColor='black']) .nve-info-icon {
+    color: var(--grey-999, #000000);
   }
 `;

--- a/src/components/nve-menu-item/nve-menu-item.component.ts
+++ b/src/components/nve-menu-item/nve-menu-item.component.ts
@@ -24,10 +24,6 @@ export default class NveMenuItem extends SlMenuItem {
    * Gjør at teksten blir indent og mindre dominant farge
    */
   @property({ type: Boolean, reflect: true }) indent: boolean = false;
-  /**
-   * Gjør at teksten vises som en unclickable kategori
-   */
-  @property({ type: Boolean, reflect: true }) category: boolean = false;
 
   constructor() {
     super();

--- a/src/components/nve-menu-item/nve-menu-item.demo.ts
+++ b/src/components/nve-menu-item/nve-menu-item.demo.ts
@@ -16,96 +16,127 @@ const table = html`
         <th>Divider button</th>
         <th>Subtext</th>
         <th>Checkbox</th>
-        <th>Category</th>
         <th>Submenu</th>
         <th>Disabled</th>
         <th>Divider</th>
-        
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>Default</td>
         <td>
-            <nve-menu-item >Tekst</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item indent>Undertittel</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item dividerTop>Tekst</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item dividerBottom>Tekst</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item subtext="Ekstratekst">Tekst</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item type="checkbox" checked>Checkbox</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item category>Category</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item ->Submenu  
-          <nve-menu slot="submenu">
-            <nve-menu-item >Tekst 2</nve-menu-item>
-            <nve-menu-item >Tekst 3</nve-menu-item>
-            <nve-menu-item >Tekst 4</nve-menu-item>
+          <nve-menu>
+            <nve-menu-item>Tekst</nve-menu-item>
           </nve-menu>
-        </nve-menu-item>
         </td>
         <td>
-        <nve-menu-item disabled>disabled</nve-menu-item>
+          <nve-menu>
+            <nve-menu-item indent>Undertittel</nve-menu-item>
+          </nve-menu>
         </td>
         <td>
-        <nve-divider></nve-divider>
+          <nve-menu>
+            <nve-menu-item dividerTop>Tekst</nve-menu-item>
+          </nve-menu>
         </td>
-      </tr>   
+        <td>
+          <nve-menu>
+            <nve-menu-item dividerBottom>Tekst</nve-menu-item>
+          </nve-menu>
+        </td>
+        <td>
+          <nve-menu>
+            <nve-menu-item subtext="Ekstratekst">Tekst</nve-menu-item>
+          </nve-menu>
+        </td>
+        <td>
+          <nve-menu>
+            <nve-menu-item type="checkbox" checked>Checkbox</nve-menu-item>
+          </nve-menu>
+        </td>
+        <td>
+          <nve-menu>
+            <nve-menu-item -
+              >Submenu
+              <nve-menu slot="submenu">
+                <nve-menu-item>Tekst 2</nve-menu-item>
+                <nve-menu-item>Tekst 3</nve-menu-item>
+                <nve-menu-item>Tekst 4</nve-menu-item>
+              </nve-menu>
+            </nve-menu-item>
+          </nve-menu>
+        </td>
+        <td>
+          <nve-menu>
+            <nve-menu-item disabled>disabled</nve-menu-item>
+          </nve-menu>
+        </td>
+        <td>
+          <nve-menu>
+            <nve-divider></nve-divider>
+          </nve-menu>
+        </td>
+      </tr>
 
       <tr>
         <td>Icon</td>
         <td>
-            <nve-menu-item >    <nve-icon slot="prefix" name="info"></nve-icon> Tekst</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item indent><nve-icon slot="prefix" name="info"></nve-icon> Undertittel</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item dividerTop><nve-icon slot="prefix" name="info"></nve-icon> Tekst</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item dividerBottom><nve-icon slot="prefix" name="info"></nve-icon> Tekst</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item subtext="Ekstratekst"><nve-icon slot="prefix" name="info"></nve-icon> Tekst</nve-menu-item>
-        </td>
-        <td>
-        
-        </td>
-        <td>
-        <nve-menu-item category><nve-icon slot="prefix" name="info"></nve-icon> Category</nve-menu-item>
-        </td>
-        <td>
-        <nve-menu-item> <nve-icon slot="prefix" name="info"></nve-icon> Submenu
-          <nve-menu slot="submenu">
-            <nve-menu-item >Tekst 2</nve-menu-item>
-            <nve-menu-item >Tekst 3</nve-menu-item>
-            <nve-menu-item >Tekst 4</nve-menu-item>
+          <nve-menu>
+            <nve-menu-item> <nve-icon slot="prefix" name="info"></nve-icon> Tekst</nve-menu-item>
           </nve-menu>
-        </nve-menu-item>
         </td>
         <td>
-        <nve-menu-item disabled><nve-icon slot="prefix" name="info"></nve-icon> disabled</nve-menu-item>
+          <nve-menu>
+            <nve-menu-item indent><nve-icon slot="prefix" name="info"></nve-icon> Undertittel</nve-menu-item>
+          </nve-menu>
         </td>
         <td>
-       
+          <nve-menu>
+            <nve-menu-item dividerTop><nve-icon slot="prefix" name="info"></nve-icon> Tekst</nve-menu-item>
+          </nve-menu>
         </td>
-      </tr>   
-     
+        <td>
+          <nve-menu>
+            <nve-menu-item dividerBottom><nve-icon slot="prefix" name="info"></nve-icon> Tekst</nve-menu-item>
+          </nve-menu>
+        </td>
+        <td>
+          <nve-menu>
+            <nve-menu-item subtext="Ekstratekst"><nve-icon slot="prefix" name="info"></nve-icon> Tekst</nve-menu-item>
+          </nve-menu>
+        </td>
+        <td>
+          <nve-menu>
+            <nve-menu-item>
+              <nve-icon slot="prefix" name="info"></nve-icon> Submenu
+              <nve-menu slot="submenu">
+                <nve-menu-item>Tekst 2</nve-menu-item>
+                <nve-menu-item>Tekst 3</nve-menu-item>
+                <nve-menu-item>Tekst 4</nve-menu-item>
+              </nve-menu>
+            </nve-menu-item>
+          </nve-menu>
+        </td>
+        <td>
+          <nve-menu>
+            <nve-menu-item disabled><nve-icon slot="prefix" name="info"></nve-icon> disabled</nve-menu-item>
+          </nve-menu>
+        </td>
+        <td></td>
+      </tr>
     </tbody>
   </table>
+  <h4>Eksempel på menu visning med (ikke tabbable) kategorier og hvordan det ser ut med ikone</h4>
+  <nve-menu>
+    <nve-label value="Svev over ikonet" iconLeft iconColor="black">
+      <div slot="tooltip">Hjelpetekst kan være veldig lang <strong>HTML</strong></div>
+    </nve-label>
+    <nve-menu-item>Tekst 1</nve-menu-item>
+    <nve-menu-item>Tekst 2</nve-menu-item>
+    <nve-label>Kategori 2</nve-label>
+    <nve-menu-item>Tekst 1</nve-menu-item>
+    <nve-menu-item>Tekst 2</nve-menu-item>
+  </nve-menu>
 `;
 
 export default table;

--- a/src/components/nve-menu/nve-menu.component.ts
+++ b/src/components/nve-menu/nve-menu.component.ts
@@ -4,7 +4,7 @@ import styles from '../nve-menu/nve-menu.styles';
 /*
  * En sl-menu i NVE-forkledning.
  * Mer info: https://shoelace.style/components/menu
- *
+ * Man kan bruke nve-label for å skille mellom kategorier. Nve-label inn i nve-menu har en spesiell styling.
  */
 @customElement('nve-menu')
 export default class NveMenu extends SlMenu {

--- a/src/components/nve-menu/nve-menu.component.ts
+++ b/src/components/nve-menu/nve-menu.component.ts
@@ -4,7 +4,8 @@ import styles from '../nve-menu/nve-menu.styles';
 /*
  * En sl-menu i NVE-forkledning.
  * Mer info: https://shoelace.style/components/menu
- * Man kan bruke nve-label for å skille mellom kategorier. Nve-label inn i nve-menu har en spesiell styling.
+ * Man kan bruke nve-label inni sl-menu, f.eks. til å kategorisere menyvalg.
+ * Nve-label får en spesiell styling når den brukes inni nve-menu
  */
 @customElement('nve-menu')
 export default class NveMenu extends SlMenu {

--- a/src/components/nve-menu/nve-menu.styles.ts
+++ b/src/components/nve-menu/nve-menu.styles.ts
@@ -1,10 +1,14 @@
 import { css } from 'lit';
 export default css`
-
-:host{
+  :host {
     padding: 0px;
     margin-top: var(--spacing-xx-small);
     border: none;
     box-shadow: var(--soft);
+  }
+  ::slotted(nve-label) {
+    padding: var(--spacing-small, 0.75rem);
+    color: var(--neutrals-foreground-subtle, #006b99);
+    font: var(--label-x-small);
   }
 `;

--- a/src/stories/nve-dropdown/NveDropdown.stories.ts
+++ b/src/stories/nve-dropdown/NveDropdown.stories.ts
@@ -5,6 +5,7 @@ import '../../components/nve-divider/nve-divider.component';
 import '../../components/nve-dropdown/nve-dropdown.component';
 import '../../components/nve-icon/nve-icon.component';
 import '../../components/nve-menu-item/nve-menu-item.component';
+import '../../components/nve-label/nve-label.component';
 import '../../components/nve-menu/nve-menu.component';
 import { NveDropdown } from './NveDropdown';
 
@@ -15,8 +16,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component:
-          `<h2><nve-dropdown> | NveDropdown</h2><a href="https://github.com/NVE/Designsystem/tree/main/doc/nve-dropdown.md">API-dokumentasjon</a> 
+        component: `<h2><nve-dropdown> | NveDropdown</h2><a href="https://github.com/NVE/Designsystem/tree/main/doc/nve-dropdown.md">API-dokumentasjon</a> 
           Denne komponenten bygges opp av andre komponenter og deres properties. Trykk på "show code" for å se hvordan komponenten kan bygges opp. 
           Dropdown inneholder en nve-menu-komponent og hvert element er en nve-menu-item-komponent. Innenfor nve-menu-item kan man bruke flere komponenter, 
           f.eks. nve-checkbox`,

--- a/src/stories/nve-dropdown/NveDropdown.ts
+++ b/src/stories/nve-dropdown/NveDropdown.ts
@@ -2,32 +2,37 @@ import { html } from 'lit';
 
 export const NveDropdown = () => {
   return html`
-  <nve-dropdown>
-    <nve-button variant="primary" slot="trigger">
-    <nve-icon name="expand_more" slot="suffix"></nve-icon>
-    Dropdown</nve-button>
-    <nve-menu>
-      <nve-menu-item >Normal tekst</nve-menu-item>
-      <nve-menu-item subtext='Dette er en undertekst'>Tekst</nve-menu-item>
-      <nve-menu-item> 
-            <nve-checkbox>Checkbox</nve-checkbox>
-      </nve-menu-item>
-      <nve-divider></nve-divider>
-      <nve-menu-item>Normal tekst</nve-menu-item>
-      <nve-menu-item indent>Undertittel</nve-menu-item>
-      <nve-menu-item category>Kategori</nve-menu-item>
-      <nve-menu-item ->Submenu  
+    <nve-dropdown>
+      <nve-button variant="primary" slot="trigger">
+        <nve-icon name="expand_more" slot="suffix"></nve-icon>
+        Dropdown</nve-button
+      >
+      <nve-menu>
+        <nve-menu-item>Normal tekst</nve-menu-item>
+        <nve-menu-item subtext="Dette er en undertekst">Tekst</nve-menu-item>
+        <nve-menu-item>
+          <nve-checkbox>Checkbox</nve-checkbox>
+        </nve-menu-item>
+        <nve-divider></nve-divider>
+        <nve-menu-item>Normal tekst</nve-menu-item>
+        <nve-menu-item indent>Undertittel</nve-menu-item>
+        <nve-label value="Kategori 1"> </nve-label>
+        <nve-menu-item -
+          >Submenu
           <nve-menu slot="submenu">
-            <nve-menu-item >Tekst 2</nve-menu-item>
-            <nve-menu-item >Tekst 3</nve-menu-item>
-            <nve-menu-item >Tekst 4</nve-menu-item>
+            <nve-menu-item>Tekst 2</nve-menu-item>
+            <nve-menu-item>Tekst 3</nve-menu-item>
+            <nve-menu-item>Tekst 4</nve-menu-item>
           </nve-menu>
-      </nve-menu-item>
-      <nve-menu-item dividerTop>Divider top</nve-menu-item>
-      <nve-menu-item disabled>Disabled</nve-menu-item>
-      <nve-menu-item dividerBottom>Divider bottom</nve-menu-item>
-      <nve-menu-item ><nve-icon slot="prefix" name="info"></nve-icon>Ikon</nve-menu-item>
-    </nve-menu>
-  </nve-dropdown>
-    `;
+        </nve-menu-item>
+        <nve-menu-item dividerTop>Divider top</nve-menu-item>
+        <nve-menu-item disabled>Disabled</nve-menu-item>
+        <nve-label value="Kategori 2" iconLeft iconColor="black">
+          <div slot="tooltip">Hjelpetekst kan være veldig lang <strong>HTML</strong></div>
+        </nve-label>
+        <nve-menu-item dividerBottom>Divider bottom</nve-menu-item>
+        <nve-menu-item><nve-icon slot="prefix" name="info"></nve-icon>Ikon</nve-menu-item>
+      </nve-menu>
+    </nve-dropdown>
+  `;
 };

--- a/src/stories/nve-label/NveLabel.stories.ts
+++ b/src/stories/nve-label/NveLabel.stories.ts
@@ -15,6 +15,10 @@ const meta = {
       control: { type: 'select' },
       options: ['x-small', 'small', 'medium', 'large'],
     },
+    iconColor: {
+      control: { type: 'select' },
+      options: ['black', 'default'],
+    },
   },
   parameters: {
     docs: {
@@ -36,11 +40,12 @@ export const Primary: Story = {
     size: 'medium',
     light: false,
     tooltip: '',
+    iconLeft: false,
+    iconColor: 'default',
   },
 };
 
 export const Xsmall: Story = {
-  
   args: {
     value: 'XS',
     size: 'small',
@@ -48,7 +53,6 @@ export const Xsmall: Story = {
 };
 
 export const Small: Story = {
-  
   args: {
     value: 'Small',
     size: 'small',
@@ -56,7 +60,6 @@ export const Small: Story = {
 };
 
 export const Medium: Story = {
-  
   args: {
     value: 'Medium',
     size: 'medium',
@@ -64,7 +67,6 @@ export const Medium: Story = {
 };
 
 export const Large: Story = {
-  
   args: {
     value: 'Large',
     size: 'large',
@@ -72,28 +74,41 @@ export const Large: Story = {
 };
 
 export const Light: Story = {
-  
   args: {
     value: 'Light',
     size: 'large',
-    light: true
+    light: true,
   },
 };
 export const Tooltip: Story = {
-  
   args: {
     value: 'Svev over meg',
     size: 'medium',
-    tooltip: 'Tooltip text'
+    tooltip: 'Tooltip text',
   },
 };
 
 export const Standard: Story = {
-  
   args: {
     value: 'Standard',
     size: 'large',
   },
 };
 
+export const IconPositionLeft: Story = {
+  args: {
+    value: 'Svev over meg',
+    size: 'large',
+    tooltip: 'Tooltip text',
+    iconLeft: true,
+  },
+};
 
+export const IconColorBlack: Story = {
+  args: {
+    value: 'Svev over meg',
+    size: 'large',
+    tooltip: 'Tooltip text',
+    iconColor: 'black',
+  },
+};

--- a/src/stories/nve-label/NveLabel.ts
+++ b/src/stories/nve-label/NveLabel.ts
@@ -1,22 +1,26 @@
 import { html } from 'lit';
 
 export interface NveLabelProps {
-  value: string,
+  value: string;
   size: 'x-small' | 'small' | 'medium' | 'large';
-  light: boolean,
-  tooltip: string
+  light: boolean;
+  tooltip: string;
+  iconLeft: boolean;
+  iconColor: 'default' | 'black';
 }
 
 export const NveLabel = (props: NveLabelProps) => {
   let size = props.size ?? 'small';
   return html`
-      <nve-label
-        value=${props.value}
-        size=${size}
-        ?light=${props.light}
-        tooltip=${props.tooltip}
-      >
+    <nve-label
+      value=${props.value}
+      size=${size}
+      ?light=${props.light}
+      tooltip=${props.tooltip}
+      ?iconLeft=${props.iconLeft}
+      iconColor=${props.iconColor}
+    >
       ${props.tooltip ? html`<div slot="tooltip">Hjelpetekst i <strong>HTML</strong></div>` : ''}
-      </nve-label>
-    `;
+    </nve-label>
+  `;
 };

--- a/src/stories/nve-label/NveLabelDoc.mdx
+++ b/src/stories/nve-label/NveLabelDoc.mdx
@@ -51,6 +51,32 @@ Bruk property "tooltip" for å legge til tooltip
   <Canvas of={NveLabelStories.Tooltip} />
 </div>
 
+## Tooltip posisjon
+
+Bruk property "iconLeft" for å endre info ikon posisjon til venstre. Hvis iconLeft ikke er brukt, skal ikonen vises til høyre som default.
+
+<div style={{ width: '20rem' }}>
+  <span class="elem">
+    <Canvas of={NveLabelStories.IconPositionLeft} />
+  </span>
+  <span class="elem">
+    <Canvas of={NveLabelStories.Tooltip} />
+  </span>
+</div>
+
+## Tooltip ikon farge
+
+I noen tilfeller trenger man å ha svart farge på ikonen. Bruk "iconColor" property til å endre den. Tilgjengelige verdier er "black" og "default"
+
+<div style={{ width: '20rem' }}>
+  <span class="elem">
+    <Canvas of={NveLabelStories.IconColorBlack} />
+  </span>
+  <span class="elem">
+    <Canvas of={NveLabelStories.Tooltip} />
+  </span>
+</div>
+
 ## Parametere/Props
 
 Her kan du se hvilke parametere (props) komponenten kan ta imot og se endringer i kode


### PR DESCRIPTION
Per i dag category property på nve-menu-item fungerer ikke som tenkt. Det er menu-item som gjør at kategori er tabbable. Den burde ikke det. Derfor bruker vi nve-label istedenfor. Tooltipen fungerer også på den, fordi det var ikke mulig å legge til tooltipen hvis man brukte nve-menu-item med property category