### PR TITLE
PR: BUG - set proper import from shoelace in popup

### DIFF
--- a/src/components/nve-popup/nve-popup.component.ts
+++ b/src/components/nve-popup/nve-popup.component.ts
@@ -1,5 +1,5 @@
 import { customElement } from 'lit/decorators.js';
-import { SlPopup } from '@shoelace-style/shoelace';
+import SlPopup from '@shoelace-style/shoelace/dist/components/popup/popup.js';
 
 /**
  * En sl-popup med NVE design.

--- a/src/components/nve-select/nve-select.component.ts
+++ b/src/components/nve-select/nve-select.component.ts
@@ -41,8 +41,8 @@ export default class NveSelect extends SlSelect {
       if (this.value !== oldValue) {
         this.updateComplete.then(() => {
           console.log(this);
-          this.emit('sl-input');
-          this.emit('sl-change');
+          this.emit('sl-input' as any);
+          this.emit('sl-change' as any);
         });
       }
 


### PR DESCRIPTION
Den importerer fra shoelace på den gamle måten som gjør at hele shoelace pakka blir importert. Ikke bra. 
Jeg har også la til as any i sl- eventer fordi etter vi har endret måten vi importerer shoelace komponenter ts skjønte ikke at input kunne ta sl- eventer i metoden vi overksrev. 