### PR TITLE
PR: bug noen komponenter fungerer ikke som de burde i safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ ser bedre ut enn dette:
 ```
 
 Hvis det ikke er mulig å style med ::part, bruk css-klasser.
+Tydeligvis safari (liten forbokstav med vilje) sliter med å ta presedens i :host(:hover)::part(control) syntaksen over klasser derfor noen ganger blir shoelace sin styling ikke overskrevet riktig. Derfor må vi huske å teste web komponenter i safari og. Problemet blir løst med '!important' keyword som f.eks.
+
+```css
+:host([disabled]:hover)::part(control control--indeterminate) {
+  background: var(--neutrals-foreground-primary) !important;
+  border-color: var(--neutrals-foreground-primary) !important;
+}
+```
 
 ### Typografi
 

--- a/src/components/nve-checkbox/nve-checkbox.styles.ts
+++ b/src/components/nve-checkbox/nve-checkbox.styles.ts
@@ -22,8 +22,8 @@ export default css`
   :host::part(control control--indeterminate),
   :host([disabled]:hover)::part(control control--checked),
   :host([disabled]:hover)::part(control control--indeterminate) {
-    background: var(--neutrals-foreground-primary);
-    border-color: var(--neutrals-foreground-primary);
+    background: var(--neutrals-foreground-primary) !important;
+    border-color: var(--neutrals-foreground-primary) !important;
   }
 
   :host([data-invalid])::part(control),
@@ -38,7 +38,7 @@ export default css`
   }
 
   :host(:hover)::part(control) {
-    border-color: var(--neutrals-foreground-subtle, #006b99);
+    border-color: var(--neutrals-foreground-subtle, #006b99) !important;
   }
 
   sl-icon::part(checked-icon svg) {

--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -21,6 +21,10 @@ export default css`
     border-radius: var(--border-radius-small);
   }
 
+  .input--standard:hover:not(.input--disabled) {
+    border-color: var(--neutrals-border-subtle) !important;
+  }
+
   :host::after {
     content: var(--nve-input-error-message);
     font: var(--detailtext-caption);

--- a/src/components/nve-option/nve-option.styles.ts
+++ b/src/components/nve-option/nve-option.styles.ts
@@ -15,7 +15,7 @@ export default css`
 
   /* fjerner checkmark siden den er hvit */
   :host::part(checked-icon) {
-    display: none;
+    display: none !important;
   }
 
   .option--current,

--- a/src/components/nve-radio/nve-radio.styles.ts
+++ b/src/components/nve-radio/nve-radio.styles.ts
@@ -8,8 +8,8 @@ export default css`
 
   /* Sett "ring" og fjern default blå bakgrunn fra shoelace */
   :host(:hover)::part(control) {
-    border: solid var(--border-width-strong) var(--neutrals-foreground-subtle);
-    background-color: var(--neutrals-background-primary);
+    border: solid var(--border-width-strong) var(--neutrals-foreground-subtle) !important;
+    background-color: var(--neutrals-background-primary) !important;
   }
 
   :host([data-invalid])::part(control) {

--- a/src/components/nve-select/nve-select.styles.ts
+++ b/src/components/nve-select/nve-select.styles.ts
@@ -26,8 +26,8 @@ export default css`
   }
 
   :host::part(popup) {
-    border-radius: var(--border-radius-small, 0.25rem);
-    border: 1px solid var(--neutrals-foreground-subtle, #006b99);
+    border-radius: var(--border-radius-small, 0.25rem) !important;
+    border: 1px solid var(--neutrals-foreground-subtle, #006b99) !important;
   }
 
   /* filled*/


### PR DESCRIPTION
Tydeligvis safari har problemer med å prioritere ```:host(:hover)::part(control)```over klassenavn derfor shoelace sin styling blir overskrevet (som i checkbox, radio, input, select). Kan være at det er flere komponenter som feiler men jeg testet kun de som vi brukte i Abonner appen