### PR TITLE
PR: added programmatic imports of material icons

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,16 +12,8 @@ const config: StorybookConfig = {
   ${head}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/themes/light.css" />
   <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/source-sans-pro" />
-  <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
-    />
   <link rel="stylesheet" href="/css/varsom.css" />
   <link rel="stylesheet"  href="/css/global.css"/>
-  <link
-  rel="stylesheet"
-  href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
-/>
 `,
   docs: {
     autodocs: 'tag',

--- a/doc/nve-icon.md
+++ b/doc/nve-icon.md
@@ -1,10 +1,11 @@
 # nve-icon
 
 Et ikon.
-Vi bruker ikoner fra Material Symbols.
+Vi bruker ikoner fra Material Symbols. Man kan bruke både 'Sharp' og 'Outlined' ikoner.
 
 ## Properties
 
-| Property | Attribute | Type     | Default | Description                                     |
-|----------|-----------|----------|---------|-------------------------------------------------|
-| `name`   | `name`    | `string` | ""      | Navnet på ikonet i Material Symbols-biblioteket |
+| Property  | Attribute | Type                    | Default    | Description                                      |
+|-----------|-----------|-------------------------|------------|--------------------------------------------------|
+| `library` | `library` | `"Outlined" \| "Sharp"` | "Outlined" | Bestemmer om man skal bruke 'sharp' eller 'outlined' ikoner |
+| `name`    | `name`    | `string`                | ""         | Navnet på ikonet i Material Symbols-biblioteket  |

--- a/doc/nve-stepper.md
+++ b/doc/nve-stepper.md
@@ -1,0 +1,46 @@
+# nve-stepper
+
+## Properties
+
+| Property            | Attribute           | Type                         | Default                  |
+|---------------------|---------------------|------------------------------|--------------------------|
+| `iconLibrary`       | `iconLibrary`       | `"Outlined" \| "Sharp"`      | "Outlined"               |
+| `orientation`       | `orientation`       | `"horizontal" \| "vertical"` | "horizontal"             |
+| `selectedStep`      | `selectedStep`      | `number`                     |                          |
+| `spaceBetweenSteps` | `spaceBetweenSteps` | `number`                     | 200                      |
+| `stepWidth`         |                     | `number`                     | 100                      |
+| `steps`             | `steps`             | `StepProps[]`                | "new Array<StepProps>()" |
+
+## Methods
+
+| Method        | Type                                |
+|---------------|-------------------------------------|
+| `getExtremes` | `(): "start" \| "end" \| undefined` |
+| `nextStep`    | `(): void`                          |
+| `prevStep`    | `(): void`                          |
+| `selectStep`  | `(event: any): void`                |
+| `setStep`     | `(index: number): void`             |
+
+
+# my-nve
+
+## Properties
+
+| Property            | Attribute           | Type                         | Default                  |
+|---------------------|---------------------|------------------------------|--------------------------|
+| `iconLibrary`       | `iconLibrary`       | `"Outlined" \| "Sharp"`      | "Outlined"               |
+| `orientation`       | `orientation`       | `"horizontal" \| "vertical"` | "horizontal"             |
+| `selectedStep`      | `selectedStep`      | `number`                     |                          |
+| `spaceBetweenSteps` | `spaceBetweenSteps` | `number`                     | 200                      |
+| `stepWidth`         |                     | `number`                     | 100                      |
+| `steps`             | `steps`             | `StepProps[]`                | "new Array<StepProps>()" |
+
+## Methods
+
+| Method        | Type                                |
+|---------------|-------------------------------------|
+| `getExtremes` | `(): "start" \| "end" \| undefined` |
+| `nextStep`    | `(): void`                          |
+| `prevStep`    | `(): void`                          |
+| `selectStep`  | `(event: any): void`                |
+| `setStep`     | `(index: number): void`             |

--- a/index.html
+++ b/index.html
@@ -5,10 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Lit + TS</title>
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
-    />
   </head>
   <body>
     <!-- This div serves as a container for your Lit app -->

--- a/src/components/nve-icon/nve-icon.component.ts
+++ b/src/components/nve-icon/nve-icon.component.ts
@@ -4,22 +4,33 @@ import styles from './nve-icon.styles';
 
 /**
  * Et ikon.
- * Vi bruker ikoner fra Material Symbols.
+ * Vi bruker ikoner fra Material Symbols. Man kan bruke både 'Sharp' og 'Outlined' ikoner.
  * @see https://fonts.google.com/icons
  */
 @customElement('nve-icon')
 export default class NveIcon extends LitElement {
   static styles = [styles];
 
+  /** Bestemmer om man skal bruke 'sharp' eller 'outlined' ikoner */
   @property({ type: String }) library: 'Outlined' | 'Sharp' = 'Outlined';
 
   /** Navnet på ikonet i Material Symbols-biblioteket */
   @property({ reflect: true }) name = '';
 
-  protected firstUpdated() {}
+  protected firstUpdated() {
+    // For å unngå å importere material ikoner i index.html, vi legger til ikoner programmatisk på den første oppdatering
+    // hvis material-icons lenke ikke eksisterer allerede
+    if (!document.getElementById(`material-icons-${this.library.toLowerCase()}`)) {
+      const link = document.createElement('link');
+      link.id = `material-icons-${this.library.toLowerCase()}`;
+      link.rel = 'stylesheet';
+      link.href = `https://fonts.googleapis.com/css2?family=Material+Symbols+${this.library}:opsz,wght,FILL,GRAD@24,400,0,0`;
+      document.head.appendChild(link);
+    }
+  }
 
   render() {
-    return html`<span style="font-family:Material Symbols ${this.library}">${this.name}</span>`;
+    return html`<span part="icon" style="font-family:Material Symbols ${this.library}">${this.name}</span>`;
   }
 }
 declare global {

--- a/src/components/nve-icon/nve-icon.styles.ts
+++ b/src/components/nve-icon/nve-icon.styles.ts
@@ -1,26 +1,25 @@
 import { css } from 'lit';
 
 export default css`
-
   /* Brukes i dropdown. Eneste måten å override shadow dom for å rotere expand_more ikonet når menyen åpner */
   :host([name='expand_more']) {
     transform: var(--icon-rotation, none);
     transition: transform 0.3s ease;
   }
 
-  /* prevent icon beeing highlighted */ 
+  /* prevent icon beeing highlighted */
   :host {
-  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
-     -khtml-user-select: none; /* Konqueror HTML */
-       -moz-user-select: none; /* Old versions of Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-            user-select: none; /* Non-prefixed version, currently
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Old versions of Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none; /* Non-prefixed version, currently
                                   supported by Chrome, Edge, Opera and Firefox */
-}
-:host {
+  }
+  :host {
     display: flex;
-}
+  }
 
   /* we need it to center the icon */
   :is(span) {

--- a/src/registerIcons/systemLibraryCustomization.ts
+++ b/src/registerIcons/systemLibraryCustomization.ts
@@ -102,10 +102,3 @@ const icons: Icons = {
 };
 
 export { icons, registerIconLibrary };
-
-// registerIconLibrary('system', {
-//   resolver: (name) => {
-//     console.log('icons injected');
-//     return `data:image/svg+xml,${encodeURIComponent(icons[name])}`;
-//   },
-// });


### PR DESCRIPTION
Per i dag man må importere material symboler i index.html for å få det til å fungere. Endringene i denne PRen gjør at man trenger ikke å tenke på det noe lenger. Den legger til import lenke til document header på den første bruk av nve-icon i DOMen. Den legger til header med riktig material bibliotekk basert på 'library' property (Outlined er default). Den legger til <link> i headeren kun en gang