### PR TITLE
PR: lagde textarea komponent

### DIFF
--- a/doc/nve-stepper.md
+++ b/doc/nve-stepper.md
@@ -2,45 +2,61 @@
 
 ## Properties
 
-| Property            | Attribute           | Type                         | Default                  |
-|---------------------|---------------------|------------------------------|--------------------------|
-| `iconLibrary`       | `iconLibrary`       | `"Outlined" \| "Sharp"`      | "Outlined"               |
-| `orientation`       | `orientation`       | `"horizontal" \| "vertical"` | "horizontal"             |
-| `selectedStep`      | `selectedStep`      | `number`                     |                          |
-| `spaceBetweenSteps` | `spaceBetweenSteps` | `number`                     | 200                      |
-| `stepWidth`         |                     | `number`                     | 100                      |
-| `steps`             | `steps`             | `StepProps[]`                | "new Array<StepProps>()" |
+| Property            | Attribute           | Type                         | Default                  | Description                                      |
+|---------------------|---------------------|------------------------------|--------------------------|--------------------------------------------------|
+| `iconLibrary`       | `iconLibrary`       | `"Outlined" \| "Sharp"`      | "Outlined"               | Hvilken ikonbibliotek som skal brukes, Sharp eller Outlined. |
+| `optionalEndButton` | `optionalEndButton` | `string`                     | ""                       | Mulighet om å endre teksten på knapp ved siste steg,<br />default er disabled neste. |
+| `orientation`       | `orientation`       | `"horizontal" \| "vertical"` | "horizontal"             | Hvilken retning steppene skal gå. TODO: implementer vertical |
+| `selectedStepIndex` | `selectedStepIndex` | `{ value: number; }`         | {"value":0}              | Indeks for valgt steg, gir mulighet for å styre hvilket steg som er valgt. |
+| `spaceBetweenSteps` | `spaceBetweenSteps` | `number`                     | 200                      | Avstand mellom steppene                          |
+| `steps`             | `steps`             | `StepProps[]`                | "new Array<StepProps>()" | Steppene som skal vises, se StepProps interface for data som skal sendes inn. |
 
 ## Methods
 
-| Method        | Type                                |
-|---------------|-------------------------------------|
-| `getExtremes` | `(): "start" \| "end" \| undefined` |
-| `nextStep`    | `(): void`                          |
-| `prevStep`    | `(): void`                          |
-| `selectStep`  | `(event: any): void`                |
-| `setStep`     | `(index: number): void`             |
+| Method        | Type                                | Description                                      |
+|---------------|-------------------------------------|--------------------------------------------------|
+| `getExtremes` | `(): "start" \| "end" \| undefined` | Sjekker om vi er på start eller slutten av steppene |
+| `nextStep`    | `(): void`                          |                                                  |
+| `onComplete`  | `(): void`                          |                                                  |
+| `prevStep`    | `(): void`                          |                                                  |
+| `reRender`    | `(): void`                          | Ved endring av props, re-render komponenten eksternt med document.querySelector("nve-stepper")?.reRender();<br />Ellers vil man ikke se endringene før intern state endres. |
+| `selectStep`  | `(event: any): void`                |                                                  |
+| `setStep`     | `(index: number): void`             |                                                  |
+
+## Events
+
+| Event      |
+|------------|
+| `complete` |
 
 
 # my-nve
 
 ## Properties
 
-| Property            | Attribute           | Type                         | Default                  |
-|---------------------|---------------------|------------------------------|--------------------------|
-| `iconLibrary`       | `iconLibrary`       | `"Outlined" \| "Sharp"`      | "Outlined"               |
-| `orientation`       | `orientation`       | `"horizontal" \| "vertical"` | "horizontal"             |
-| `selectedStep`      | `selectedStep`      | `number`                     |                          |
-| `spaceBetweenSteps` | `spaceBetweenSteps` | `number`                     | 200                      |
-| `stepWidth`         |                     | `number`                     | 100                      |
-| `steps`             | `steps`             | `StepProps[]`                | "new Array<StepProps>()" |
+| Property            | Attribute           | Type                         | Default                  | Description                                      |
+|---------------------|---------------------|------------------------------|--------------------------|--------------------------------------------------|
+| `iconLibrary`       | `iconLibrary`       | `"Outlined" \| "Sharp"`      | "Outlined"               | Hvilken ikonbibliotek som skal brukes, Sharp eller Outlined. |
+| `optionalEndButton` | `optionalEndButton` | `string`                     | ""                       | Mulighet om å endre teksten på knapp ved siste steg,<br />default er disabled neste. |
+| `orientation`       | `orientation`       | `"horizontal" \| "vertical"` | "horizontal"             | Hvilken retning steppene skal gå. TODO: implementer vertical |
+| `selectedStepIndex` | `selectedStepIndex` | `{ value: number; }`         | {"value":0}              | Indeks for valgt steg, gir mulighet for å styre hvilket steg som er valgt. |
+| `spaceBetweenSteps` | `spaceBetweenSteps` | `number`                     | 200                      | Avstand mellom steppene                          |
+| `steps`             | `steps`             | `StepProps[]`                | "new Array<StepProps>()" | Steppene som skal vises, se StepProps interface for data som skal sendes inn. |
 
 ## Methods
 
-| Method        | Type                                |
-|---------------|-------------------------------------|
-| `getExtremes` | `(): "start" \| "end" \| undefined` |
-| `nextStep`    | `(): void`                          |
-| `prevStep`    | `(): void`                          |
-| `selectStep`  | `(event: any): void`                |
-| `setStep`     | `(index: number): void`             |
+| Method        | Type                                | Description                                      |
+|---------------|-------------------------------------|--------------------------------------------------|
+| `getExtremes` | `(): "start" \| "end" \| undefined` | Sjekker om vi er på start eller slutten av steppene |
+| `nextStep`    | `(): void`                          |                                                  |
+| `onComplete`  | `(): void`                          |                                                  |
+| `prevStep`    | `(): void`                          |                                                  |
+| `reRender`    | `(): void`                          | Ved endring av props, re-render komponenten eksternt med document.querySelector("nve-stepper")?.reRender();<br />Ellers vil man ikke se endringene før intern state endres. |
+| `selectStep`  | `(event: any): void`                |                                                  |
+| `setStep`     | `(index: number): void`             |                                                  |
+
+## Events
+
+| Event      |
+|------------|
+| `complete` |

--- a/doc/nve-textarea.md
+++ b/doc/nve-textarea.md
@@ -1,0 +1,49 @@
+# nve-textarea
+
+## Properties
+
+| Property         | Attribute        | Type                                             | Default         | Description                                      |
+|------------------|------------------|--------------------------------------------------|-----------------|--------------------------------------------------|
+| `autocapitalize` | `autocapitalize` | `"off" \| "none" \| "on" \| "sentences" \| "words" \| "characters"` | "off"           | Kontrollerer om og hvordan tekstinnput automatisk blir gjort stor som det blir skrevet inn av brukeren. |
+| `autocorrect`    | `autocorrect`    | `string \| undefined`                            |                 | Indikerer om nettleserens autokorrekturfunksjon er på eller av. |
+| `disabled`       | `disabled`       | `boolean`                                        | false           | Om textarea er deaktivert                        |
+| `errorMessage`   | `errorMessage`   | `string \| undefined`                            |                 | Feil melding som vises under gruppe hvis validering feiler |
+| `filled`         | `filled`         | `boolean`                                        | false           | Viser filled variant                             |
+| `helpText`       | `helpText`       | `string`                                         | ""              | Hjelpetekst under textarea                       |
+| `input`          |                  | `HTMLTextAreaElement`                            |                 | Hoved input felt i nve-textarea komponentet. Brukes til constraint validering |
+| `inputmode`      | `inputmode`      | `"text" \| "none" \| "search" \| "decimal" \| "numeric" \| "tel" \| "email" \| "url" \| undefined` |                 | Forteller nettleseren hvilken type data som vil bli skrevet inn av brukeren, slik at den kan vise det passende virtuelle<br />tastaturet på støttede enheter. |
+| `label`          | `label`          | `string`                                         | ""              | Label tekst                                      |
+| `maxlength`      | `maxlength`      | `number \| undefined`                            |                 | Maksimal lengde på inndata som vil bli betraktet som gyldig. |
+| `minlength`      | `minlength`      | `number \| undefined`                            |                 | Den minste lengden på inndata som vil bli betraktet som gyldig. |
+| `name`           | `name`           | `string`                                         | ""              | Navnet på tekstområdet, sendt som et navn/verdi-par med skjemadata |
+| `placeholder`    | `placeholder`    | `string`                                         | ""              | Placeholder tekst                                |
+| `readonly`       | `readonly`       | `boolean`                                        | false           | Om textarea er skrivebeskyttet                   |
+| `required`       | `required`       | `boolean`                                        | false           | Om textarea er obligatorisk                      |
+| `requiredLabel`  | `requiredLabel`  | `string`                                         | "*Obligatorisk" | Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard. |
+| `title`          | `title`          | `string`                                         | ""              |                                                  |
+| `tooltip`        | `tooltip`        | `string \| undefined`                            |                 | Indikerer om nettleserens autokorrekturfunksjon er på eller av. |
+| `value`          | `value`          | `string`                                         | ""              | Textarea verdi, sendt som et navn/verdi-par med skjemadata |
+
+## Methods
+
+| Method              | Type                       |
+|---------------------|----------------------------|
+| `setCustomValidity` | `(message?: string): void` |
+
+## Events
+
+| Event        | Description                       |
+|--------------|-----------------------------------|
+| `sl-blur`    | trigges når textarea mister fokus |
+| `sl-change`  | trigges når textarea endrer verdi |
+| `sl-input`   | trigges når textarea endrer verdi |
+| `sl-invalid` | trigges når textarea er invalid   |
+
+## CSS Shadow Parts
+
+| Part                  | Description                                      |
+|-----------------------|--------------------------------------------------|
+| `base`                | textarea og ikone container                      |
+| `form-control`        | hoved komponent sitt container                   |
+| `help-text-container` | container for hjelpetekst<br /><br />Skal brukes til å lage lang tekstfelt. Min høyde er satt opp til --sizing-2x-small. De fleste attributer som brukes på vanlig textarea<br />burde bli støttet her. Hvis det er noe som mangler, bare å legge til.<br />Man kan bruke label og tooltip attributer for å vise label over textarea. Samt med helpText. Trenger ikke noe eksta slots per i dag. Trengs ikke å lage separate slots for det.<br />Siden vi skulle bruke ikoner inn i textarea var det enklere å lage vår egen komponent enn å leke med sl-textarea |
+| `textarea-label`      | label og requiredLabel container                 |

--- a/public/css/global.css
+++ b/public/css/global.css
@@ -2,6 +2,8 @@
 @import url('https://fonts.cdnfonts.com/css/source-sans-pro');
 
 :root {
+  --transition-time: 0.3s;
+
   --sl-focus-ring-color: var(--interactive-links-focus);
   --sl-focus-ring-style: solid;
   --sl-focus-ring-width: 2px;

--- a/src/components/nve-alert/nve-alert.styles.ts
+++ b/src/components/nve-alert/nve-alert.styles.ts
@@ -43,7 +43,7 @@ export default css`
     padding: var(--spacing-xx-small);
     border-radius: 50%;
     stroke: var(--neutrals-foreground-primary);
-    transition: background-color 0.3s ease;
+    transition: background-color var(--transition-time) ease;
   }
 
   :host::part(message)::after {

--- a/src/components/nve-checkbox/nve-checkbox.styles.ts
+++ b/src/components/nve-checkbox/nve-checkbox.styles.ts
@@ -15,7 +15,7 @@ export default css`
     border-radius: var(--border-radius-small);
     width: 1.1rem;
     height: 1.1rem;
-    transition: all 0.3s ease-in;
+    transition: all var(--transition-time) ease-in;
   }
 
   :host::part(control control--checked),

--- a/src/components/nve-icon/nve-icon.styles.ts
+++ b/src/components/nve-icon/nve-icon.styles.ts
@@ -4,7 +4,7 @@ export default css`
   /* Brukes i dropdown. Eneste måten å override shadow dom for å rotere expand_more ikonet når menyen åpner */
   :host([name='expand_more']) {
     transform: var(--icon-rotation, none);
-    transition: transform 0.3s ease;
+    transition: transform var(--transition-time) ease;
   }
 
   /* prevent icon beeing highlighted */

--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -21,8 +21,16 @@ export default css`
     border-radius: var(--border-radius-small);
   }
 
+  :host::part(base) {
+    transition: border var(--transition-time) ease-in-out;
+  }
+
   .input--standard:hover:not(.input--disabled) {
-    border-color: var(--neutrals-border-subtle) !important;
+    border-color: var(--neutrals-foreground-primary) !important;
+  }
+
+  .input--filled:hover:not(.input--disabled) {
+    border-color: var(--neutrals-border-default) !important;
   }
 
   :host::after {
@@ -34,7 +42,6 @@ export default css`
   :host([required]) .form-control--has-label .form-control__label::after,
   :host([requiredLabel])::part(form-control-label)::after {
     content: var(--sl-input-required-content);
-    margin-top: var(--spacing-xx-small);
     font: var(--label-x-small-light);
     color: var(--feedback-background-emphasized-error);
   }

--- a/src/components/nve-textarea/nve-textarea.component.ts
+++ b/src/components/nve-textarea/nve-textarea.component.ts
@@ -1,0 +1,254 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import styles from './nve-textarea.styles';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { live } from 'lit/directives/live.js';
+import { classMap } from 'lit/directives/class-map.js';
+import '../nve-icon/nve-icon.component';
+import '../nve-label/nve-label.component';
+
+/**
+ * @dependency nve-icon
+ * @dependency nve-label
+ *
+ * Bruker sl-eventer for å være konsistent. Kan bruke våre egne eventer når vi droppper shoelace
+ * @event sl-blur - trigges når textarea mister fokus
+ * @event sl-change - trigges når textarea endrer verdi
+ * @event sl-input - trigges når textarea endrer verdi
+ * @event sl-invalid - trigges når textarea er invalid
+ *
+ * @csspart form-control - hoved komponent sitt container
+ * @csspart textarea-label - label og requiredLabel container
+ * @csspart base - textarea og ikone container
+ * @csspart help-text-container - container for hjelpetekst
+ *
+ * Skal brukes til å lage lang tekstfelt. Min høyde er satt opp til --sizing-2x-small. De fleste attributer som brukes på vanlig textarea
+ * burde bli støttet her. Hvis det er noe som mangler, bare å legge til.
+ * Man kan bruke label og tooltip attributer for å vise label over textarea. Samt med helpText. Trenger ikke noe eksta slots per i dag. Trengs ikke å lage separate slots for det.
+ * Siden vi skulle bruke ikoner inn i textarea var det enklere å lage vår egen komponent enn å leke med sl-textarea
+ */
+@customElement('nve-textarea')
+export default class NveTextarea extends LitElement {
+  static styles = [styles];
+
+  /** Navnet på tekstområdet, sendt som et navn/verdi-par med skjemadata */
+  @property() name = '';
+
+  /** Textarea verdi, sendt som et navn/verdi-par med skjemadata */
+  @property() value = '';
+
+  /** Feil melding som vises under gruppe hvis validering feiler */
+  @property() errorMessage?: string;
+
+  @property() title = '';
+
+  /** Viser filled variant */
+  @property({ type: Boolean, reflect: true }) filled = false;
+
+  /** Label tekst */
+  @property() label = '';
+
+  /** Hjelpetekst under textarea */
+  @property() helpText = '';
+
+  /** Om textarea er deaktivert */
+  @property({ type: Boolean, reflect: true }) disabled = false;
+
+  /** Om textarea er skrivebeskyttet */
+  @property({ type: Boolean, reflect: true }) readonly = false;
+
+  /** Placeholder tekst */
+  @property() placeholder = '';
+
+  /** Om textarea er obligatorisk */
+  @property({ type: Boolean, reflect: true }) required = false;
+
+  /** Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard.*/
+  @property() requiredLabel = '*Obligatorisk';
+
+  /** Den minste lengden på inndata som vil bli betraktet som gyldig. */
+  @property({ type: Number }) minlength?: number;
+
+  /** Maksimal lengde på inndata som vil bli betraktet som gyldig. */
+  @property({ type: Number }) maxlength?: number;
+
+  /** Kontrollerer om og hvordan tekstinnput automatisk blir gjort stor som det blir skrevet inn av brukeren. */
+  @property() autocapitalize: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters' = 'off';
+
+  /** Indikerer om nettleserens autokorrekturfunksjon er på eller av. */
+  @property() autocorrect?: string;
+
+  /** Indikerer om nettleserens autokorrekturfunksjon er på eller av. */
+  @property() tooltip?: string;
+
+  /**
+   * Forteller nettleseren hvilken type data som vil bli skrevet inn av brukeren, slik at den kan vise det passende virtuelle
+   * tastaturet på støttede enheter.
+   */
+  @property() inputmode?: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
+
+  /** Bestemmer om feilmelding skal vises når validering feiler  */
+  @state() private showErrorMessage = false;
+
+  /** Om bruker starter å skrive noe i textarea */
+  @state() private touched = false;
+
+  /** Hoved input felt i nve-textarea komponentet. Brukes til constraint validering */
+  @query('.textarea__control') input!: HTMLTextAreaElement;
+
+  constructor() {
+    super();
+  }
+
+  firstUpdated() {
+    // Sjekker om data-valid når komponenten først lastes
+    if (this.required) {
+      const isValid = this.input.checkValidity();
+      this.toggleAttribute('data-valid', isValid);
+      this.toggleAttribute('data-invalid', !isValid);
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    const formElement = this.closest('form');
+    // Kjører validering når den nærmeste formen trigger submit. Gjelder kun constraint validation.
+    formElement?.addEventListener('submit', this.handleSubmit.bind(this));
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    const formElement = this.closest('form');
+    formElement?.removeEventListener('submit', this.handleSubmit.bind(this));
+  }
+
+  // kan senere flyttes til utils hvis blir brukt flere steder
+  private emit(eventName: string) {
+    this.dispatchEvent(new CustomEvent(eventName));
+  }
+
+  private handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    this.checkValidity();
+  }
+
+  // validerer ikke hvis bruker ikke har tatt på input feltet
+  private handleBlur() {
+    if (this.touched) {
+      this.checkValidity();
+    }
+    this.emit('sl-blur');
+  }
+
+  private handleChange() {
+    this.value = this.input.value;
+    this.emit('sl-change');
+  }
+
+  private handleInput() {
+    this.touched = true;
+    this.value = this.input.value;
+    this.emit('sl-input');
+  }
+
+  /** Sjekker constraint validation og hvis man kjørte setCustomValidity med en melding, checkValidity blir falsk og. Hvis man ikke bruker errorMessage property vil den vise default engelsk tekst istedenfor */
+  private checkValidity() {
+    const isValid = this.input.checkValidity();
+    if (!isValid) {
+      this.makeInvalid();
+    } else {
+      this.resetValidation();
+    }
+  }
+
+  setCustomValidity(message = '') {
+    this.input.setCustomValidity(message);
+  }
+
+  private makeInvalid() {
+    this.errorMessage = this.errorMessage || this.input.validationMessage;
+    this.showErrorMessage = true;
+    this.emit('sl-invalid');
+    this.toggleValidationAttributes(false);
+  }
+
+  private resetValidation() {
+    this.showErrorMessage = false;
+    this.toggleValidationAttributes(true);
+  }
+
+  /** Toggler riktig validering attribute for å vise riktig style */
+  private toggleValidationAttributes(isValid: boolean) {
+    this.toggleAttribute('data-valid', isValid);
+    this.toggleAttribute('data-user-valid', isValid);
+    this.toggleAttribute('data-invalid', !isValid);
+    this.toggleAttribute('data-user-invalid', !isValid);
+  }
+
+  render() {
+    return html`
+      <div part="form-control" class=${classMap({ 'form-control': true, 'form-control--has-label': this.label })}>
+        <div part="textarea-label">
+          ${this.label
+            ? html`
+                <nve-label
+                  class=${classMap({ textarea__label: true })}
+                  for="input"
+                  aria-hidden=${this.label ? 'false' : 'true'}
+                  value=${this.label}
+                  tooltip=${ifDefined(this.tooltip)}
+                ></nve-label>
+              `
+            : null}
+          ${this.required ? html`<span class="textarea__required-label">${this.requiredLabel}</span>` : null}
+        </div>
+        <div part="base">
+          <textarea
+            class="textarea__control"
+            title=${this.title /** En tom tittel hindrer nettleserens valideringsverktøy i å vises ved overføring */}
+            name=${ifDefined(this.name)}
+            .value=${live(this.value)}
+            ?disabled=${this.disabled}
+            ?readonly=${this.readonly}
+            ?required=${this.required}
+            placeholder=${ifDefined(this.placeholder)}
+            minlength=${ifDefined(this.minlength)}
+            maxlength=${ifDefined(this.maxlength)}
+            autocapitalize=${ifDefined(this.autocapitalize)}
+            autocorrect=${ifDefined(this.autocorrect)}
+            ?autofocus=${this.autofocus}
+            inputmode=${ifDefined(this.inputmode)}
+            aria-describedby="help-text"
+            @change=${this.handleChange}
+            @input=${this.handleInput}
+            @blur=${this.handleBlur}
+          ></textarea>
+          <!-- Foreløpig kan man ha enten 'lock' eller 'error' ikone -->
+          ${this.disabled || this.showErrorMessage
+            ? html`<div class="textarea__icon__container">
+                ${this.disabled ? html`<nve-icon name="lock"></nve-icon>` : null}
+                ${this.showErrorMessage ? html`<nve-icon class="textarea__icon--error" name="error"></nve-icon>` : null}
+              </div>`
+            : null}
+        </div>
+        <div part="help-text-container" class="textarea__help-text__container">
+          <!-- Ikke vis hjelpe tekst mens feil -->
+          ${!this.showErrorMessage && this.helpText
+            ? html`<span class="textarea__help-text" id="help-text" aria-hidden=${this.helpText ? 'false' : 'true'}
+                >${this.helpText}</span
+              >`
+            : null}
+          ${this.showErrorMessage
+            ? html`<span class="textarea__help-text textarea__help-text--error">${this.errorMessage}</span>`
+            : null}
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-textarea': NveTextarea;
+  }
+}

--- a/src/components/nve-textarea/nve-textarea.demo.ts
+++ b/src/components/nve-textarea/nve-textarea.demo.ts
@@ -1,0 +1,88 @@
+import { html } from 'lit';
+
+const validateInputFieldDemo = (e: any) => {
+  e.preventDefault();
+  const inputElement = document.getElementById('demoTextAreaVal') as HTMLInputElement;
+  const inputElementValue = inputElement.value;
+  if (!inputElement) return;
+  const valid = inputElementValue == '42';
+
+  if (!valid) {
+    inputElement.setCustomValidity('Feil svar');
+  } else {
+    inputElement.setCustomValidity('');
+  }
+};
+export default html`
+  <hr />
+  <h3 id="nve-textarea">nve-textarea</h3>
+  <table class="demo">
+    <thead>
+      <th></th>
+      <th>filled = false</th>
+      <th>filled = true</th>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Standard</td>
+        <td>
+          <nve-textarea placeholder="Placeholder" value=""></nve-textarea>
+        </td>
+        <td>
+          <nve-textarea placeholder="Placeholder" filled value=""></nve-textarea>
+        </td>
+      </tr>
+      <tr>
+        <td>Skrivebeskyttet</td>
+        <td>
+          <nve-textarea readonly label="Label" value="Tekst"></nve-textarea>
+        </td>
+        <td>
+          <nve-textarea readonly filled label="Label" value="Tekst"></nve-textarea>
+        </td>
+      </tr>
+      <tr>
+        <td>Deaktivert</td>
+        <td>
+          <nve-textarea disabled label="Label" tooltip="tooltip tekst" value="Tekst"></nve-textarea>
+        </td>
+        <td>
+          <nve-textarea disabled filled label="Label" tooltip="tooltip tekst" value="Tekst"></nve-textarea>
+        </td>
+      </tr>
+      <tr>
+        <td>Obligatorisk</td>
+        <td>
+          <nve-textarea required helpText="Må skrive noe" value="Tekst"></nve-textarea>
+        </td>
+        <td>
+          <nve-textarea required filled helpText="Må skrive noe" value="Tekst"></nve-textarea>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h3>nve-checkbox-group constraint validering</h3>
+  <form>
+    <nve-textarea
+      @sl-invalid="${() => console.log('invalid')}"
+      label="Validering"
+      errorMessage="Kan ikke stå tom"
+      helpText="Skriv noe tekst"
+      required
+    ></nve-textarea>
+    <nve-button style="margin-top:10px" type="submit" variant="primary" size="small">Submit</nve-button>
+  </form>
+  <h3>nve-checkbox-group custom validering</h3>
+  <form @submit="${(e: any) => validateInputFieldDemo(e)}" id="demoFormCustomVal">
+    <nve-textarea
+      label="Validering"
+      @sl-blur="${validateInputFieldDemo}"
+      @sl-invalid="${() => console.log('invalid')}"
+      errorMessage="Kan ikke stå tom"
+      helpText="Skriv noe tekst"
+      required
+      id="demoTextAreaVal"
+    ></nve-textarea>
+    <nve-button style="margin-top:10px" type="submit" variant="primary" size="small">Submit</nve-button>
+  </form>
+`;

--- a/src/components/nve-textarea/nve-textarea.styles.ts
+++ b/src/components/nve-textarea/nve-textarea.styles.ts
@@ -1,0 +1,101 @@
+import { css } from 'lit';
+
+export default css`
+  :host {
+    width: fit-content;
+    display: flex;
+  }
+
+  :host::part(form-control) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-x-small);
+  }
+
+  :host::part(base) {
+    display: flex;
+    position: relative; /** trengs for å posisjonere ikonen */
+    width: fit-content;
+  }
+
+  .textarea__control {
+    font: var(--body-small);
+    padding: var(--sizing-4x-small);
+    padding-right: var(--sizing-2x-small); /** trenger padding for å vise ikone så at teksten ikke dekker den */
+    border-radius: var(--border-radius-small);
+    border: var(--border-width-default, 1px) solid var(--neutrals-border-default);
+    min-height: var(--sizing-2x-small);
+    min-width: 30px;
+    transition: border var(--transition-time) ease-in-out;
+
+    &:hover:not(:disabled) {
+      border-color: var(--neutrals-foreground-primary);
+    }
+
+    &:focus-visible {
+      outline: var(--sl-focus-ring);
+      outline-offset: var(--sl-focus-ring-offset);
+    }
+  }
+
+  :host([data-user-invalid]) .textarea__control {
+    border-color: var(--feedback-background-emphasized-error);
+  }
+
+  :host([disabled]) .textarea__control {
+    opacity: 0.38;
+    background: var(--neutrals-background-primary-contrast);
+  }
+
+  :host([filled]) .textarea__control {
+    background: var(--neutrals-background-primary-contrast);
+    border: var(--border-width-default, 1px) solid var(--neutrals-border-subtle);
+
+    &:hover:not(:disabled) {
+      border-color: var(--neutrals-border-default);
+    }
+  }
+
+  :host([readonly]) .textarea__control {
+    background: var(--neutrals-background-secondary);
+    color: var(--neutrals-foreground-subtle,);
+    border: none;
+  }
+
+  :host::part(textarea-label) {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .textarea__required-label {
+    font: var(--label-x-small-light);
+    color: var(--feedback-background-emphasized-error);
+  }
+
+  .textarea__help-text__container {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .textarea__help-text {
+    font: var(--label-x-small-light);
+    color: var(--sl-input-help-text-color);
+  }
+
+  .textarea__help-text--error {
+    color: var(--feedback-background-emphasized-error);
+  }
+
+  .textarea__icon__container {
+    position: absolute;
+    right: var(--sizing-4x-small);
+    top: var(--sizing-4x-small);
+  }
+
+  .textarea__icon--error {
+    color: var(--feedback-background-emphasized-error);
+  }
+`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import tooltipDemo from './components/nve-tooltip/nve-tooltip.demo';
 import radioGroupDemo from './components/nve-radio-group/nve-radio-group.demo';
 import selectDemo from './components/nve-select/nve-select.demo';
 import stepperDemo from './components/nve-stepper/nve-stepper.demo';
+import textareaDemo from './components/nve-textarea/nve-textarea.demo';
 
 import { icons, registerIconLibrary } from './registerIcons/systemLibraryCustomization';
 
@@ -41,8 +42,9 @@ render(
     checkboxDemo,
     checkboxGroupDemo,
     dialogDemo,
+    textareaDemo,
     selectDemo,
-    stepperDemo
+    stepperDemo,
   ],
   document.getElementById('app')!
 ); // Render the Lit app in the specified container

--- a/src/nve-designsystem.ts
+++ b/src/nve-designsystem.ts
@@ -17,9 +17,9 @@ export { default as NveRadio } from './components/nve-radio/nve-radio.component'
 export { default as NveRadioButton } from './components/nve-radio-button/nve-radio-button.component';
 export { default as NveRadioGroup } from './components/nve-radio-group/nve-radio-group.component';
 export { default as NveSpinner } from './components/nve-spinner/nve-spinner.component';
+export { default as NveTextarea } from './components/nve-textarea/nve-textarea.component';
 export { default as NveTooltip } from './components/nve-tooltip/nve-tooltip.component';
 export { default as NveSelect } from './components/nve-select/nve-select.component';
 export { default as NveOption } from './components/nve-option/nve-option.component';
 export { default as NveStepper } from './components/nve-stepper/nve-stepper.component';
 export { default as NveStep } from './components/nve-stepper/nve-step/nve-step.component';
-

--- a/src/stories/nve-input/NveInput.stories.ts
+++ b/src/stories/nve-input/NveInput.stories.ts
@@ -31,7 +31,7 @@ export const Primary: Story = {
     required: false,
     type: 'text',
     tooltip: false,
-    icon: false
+    icon: false,
   },
 };
 
@@ -71,7 +71,6 @@ export const Filledone: Story = {
   },
 };
 
-
 export const Filledtwo: Story = {
   args: {
     filled: true,
@@ -103,10 +102,9 @@ export const Unlocked: Story = {
     label: 'Ledetekst',
     value: 'Skrivebeskyttet',
     size: 'large',
-    readonly: true
+    readonly: true,
   },
 };
-
 
 export const Enabled: Story = {
   args: {
@@ -114,7 +112,6 @@ export const Enabled: Story = {
     label: 'Ledetekst',
     value: 'Aktivert',
     size: 'medium',
-    
   },
 };
 
@@ -127,7 +124,6 @@ export const Disabled: Story = {
     disabled: true,
   },
 };
-
 
 export const Mandatory: Story = {
   args: {
@@ -148,7 +144,7 @@ export const Invalid: Story = {
     max: '10',
     required: true,
     requiredLabel: 'Mandatory field',
-    helpText: "Enter number between 1 and 10"
+    helpText: 'Enter number between 1 and 10',
   },
 };
 
@@ -157,7 +153,7 @@ export const Icon: Story = {
     label: 'Ledetekst',
     size: 'medium',
     value: 'Input med ikon',
-    icon: true    
+    icon: true,
   },
 };
 
@@ -166,19 +162,19 @@ export const Tooltip: Story = {
     label: 'Ledetekst',
     value: '41',
     size: 'medium',
-    tooltip: true
+    tooltip: true,
   },
 };
 
 export const Date: Story = {
   args: {
-    type: 'date'
+    type: 'date',
   },
 };
 
 export const Datetime: Story = {
   args: {
-    type: 'datetime-local'
+    type: 'datetime-local',
   },
 };
 
@@ -187,9 +183,6 @@ export const Password: Story = {
     label: 'Ledetekst',
     value: 'hemmelig',
     size: 'medium',
-    type: 'password'
+    type: 'password',
   },
 };
-
-
-

--- a/src/stories/nve-textarea/NveTextarea.stories.ts
+++ b/src/stories/nve-textarea/NveTextarea.stories.ts
@@ -1,0 +1,72 @@
+import '../../components/nve-textarea/nve-textarea.component';
+import { StoryObj } from '@storybook/web-components';
+import { NveTextarea } from './NveTextarea';
+import type { NveTextareaProps } from './NveTextarea';
+import NveTextareaDoc from './NveTextareaDoc.mdx';
+
+const meta = {
+  title: 'Nve/NveTextarea',
+  tags: ['autodocs'],
+  render: (args: NveTextareaProps) => NveTextarea(args),
+  parameters: {
+    docs: {
+      page: NveTextareaDoc,
+      description: {
+        component:
+          '<h2><nve-textarea> | NveTextarea</h2><a href="https://github.com/NVE/Designsystem/tree/main/doc/nve-textarea.md">API-dokumentasjon</a>',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<NveTextareaProps>;
+
+export const Primary: Story = {
+  args: {
+    filled: false,
+    label: 'Ledetekst',
+    value: 'Tekst',
+    required: false,
+    requiredLabel: '',
+    tooltip: 'Tooltip tekst',
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    filled: true,
+    label: 'Ledetekst',
+    value: 'Filled input text',
+    required: false,
+    tooltip: 'Tooltip tekst',
+  },
+};
+
+export const Readonly: Story = {
+  args: {
+    label: 'Ledetekst',
+    tooltip: 'Tooltip tekst',
+    value: 'Standard',
+    readonly: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    filled: true,
+    label: 'Ledetekst',
+    tooltip: 'Tooltip tekst',
+    value: 'Deaktivert',
+    disabled: true,
+  },
+};
+
+export const Mandatory: Story = {
+  args: {
+    label: 'Ledetekst',
+    value: 'Obligatorisk',
+    required: true,
+    requiredLabel: '',
+  },
+};

--- a/src/stories/nve-textarea/NveTextarea.ts
+++ b/src/stories/nve-textarea/NveTextarea.ts
@@ -1,0 +1,30 @@
+import { html } from 'lit';
+
+export interface NveTextareaProps {
+  value: string;
+  filled: boolean;
+  label: string;
+  helpText: string;
+  tooltip: string;
+  disabled: boolean;
+  readonly: boolean;
+  required: boolean;
+  requiredLabel: string;
+}
+
+export const NveTextarea = (props: NveTextareaProps) => {
+  return html`
+    <nve-textarea
+      ?filled=${props.filled}
+      label=${props.label}
+      value=${props.value}
+      ?required=${props.required}
+      requiredLabel=${props.required ? (props.requiredLabel ? props.requiredLabel : '*Obligatorisk') : ' '}
+      tooltip=${props.tooltip}
+      ?disabled=${props.disabled}
+      helpText=${props.helpText}
+      ?readonly=${props.readonly}
+    >
+    </nve-textarea>
+  `;
+};

--- a/src/stories/nve-textarea/NveTextareaDoc.mdx
+++ b/src/stories/nve-textarea/NveTextareaDoc.mdx
@@ -1,0 +1,53 @@
+import './../css/stories.css';
+
+import { Canvas, Story, Meta, Title, Subtitle, Description, Source, Primary, Controls } from '@storybook/blocks';
+
+import * as NveTextareaStories from './NveTextarea.stories';
+
+<Meta isTemplate />
+
+<Title />
+<Description />
+<br />
+<br />
+
+## Filled
+
+Bruk property "filled" for å fylle textarea-felt med farge
+
+<div class="container">
+  <span class="elem">
+    <Canvas of={NveTextareaStories.Filled} />
+  </span>
+</div>
+
+## Skrivebeskyttet
+
+Bruk property "readonly" for å gjøre feltet Skrivebeskyttet
+
+<div class="container">
+  <span class="elem">
+    <Canvas of={NveTextareaStories.Readonly} />
+  </span>
+</div>
+
+## Deaktivert
+
+Bruk property "disabled" for å disable textarea
+
+<div class="container">
+  <span class="elem">
+    <Canvas of={NveTextareaStories.Disabled} />
+  </span>
+</div>
+
+## Obligatorisk
+
+Bruk properties "required" og "requiredLabel" for å vise obligatorisk label.
+Se flere eksempler <a href='https://shoelace.style/getting-started/form-controls#constraint-validation'>her</a>. Legg inn hjelpetekst med property "helpText"
+
+<div class="container">
+  <span class="elem">
+    <Canvas of={NveTextareaStories.Mandatory} />
+  </span>
+</div>


### PR DESCRIPTION
Tenkte først å arve fra nve-input men, den krevde ekstra unødvendig arbeid med å sette ikone på et riktig sted. Derfor har jeg bestemt å lage en separat komponent. Som result ble det en enkel komponent som kan brukes enda enklere enn vanlig nve-input felt. Jeg tror vi kan gjerne gjøre om nve-input på samme måte i fremtiden. 

Komponent støttes både custom og constratint validering akkurat som vanlig input. 

Hadde noen små problemer med å vise default requiredLabel i storybook. Vet ikke hvorfor det funka ikke fra starten. Jeg satt opp *Obligatorisk i render metode. Jeg testet pakken med en eksternt prosjekt og alt virka som det burde. 

