### PR TITLE
PR: lagt til validering i nve-select

### DIFF
--- a/doc/nve-select.md
+++ b/doc/nve-select.md
@@ -1,54 +1,58 @@
 # nve-select
 
 En Shoelace-select i NVE-forkledning.
-Se https://shoelace.style/components/select
+Se https://shoelace.style/components/select. Bruker constraint og custom validering. Klarte ikke å sette feil ikone når
+validering feiler. Eneste måte å gjøre det på kunne ha vært å bruke ::after pseudo-element på noen av sl-select partene, men
+funka ikke med ikonen.
 
 ## Properties
 
-| Property            | Modifiers | Type                                             | Description                                      |
-|---------------------|-----------|--------------------------------------------------|--------------------------------------------------|
-| `checkValidity`     |           | `() => boolean`                                  |                                                  |
-| `clearable`         |           | `boolean`                                        | Adds a clear button when the select is not empty. |
-| `combobox`          |           | `HTMLSlotElement`                                |                                                  |
-| `currentOption`     |           | `SlOption`                                       |                                                  |
-| `defaultChecked`    |           | `boolean \| undefined`                           |                                                  |
-| `defaultValue`      |           | `string \| string[]`                             | The default value of the form control. Primarily used for resetting the form control. |
-| `dir`               |           | `string`                                         |                                                  |
-| `disabled`          |           | `boolean`                                        | Disables the select control.                     |
-| `displayInput`      |           | `HTMLInputElement`                               |                                                  |
-| `displayLabel`      |           | `string`                                         |                                                  |
-| `filled`            |           | `boolean`                                        | Draws a filled select.                           |
-| `form`              |           | `string`                                         | By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you<br />to place the form control outside of a form and associate it with the form that has this `id`. The form must be in<br />the same document or shadow root for this to work. |
-| `getForm`           |           | `() => HTMLFormElement \| null`                  |                                                  |
-| `getTag`            |           | `(option: SlOption, index: number) => string \| HTMLElement \| TemplateResult` | A function that customizes the tags to be rendered when multiple=true. The first argument is the option, the second<br />is the current tag's index.  The function should return either a Lit TemplateResult or a string containing trusted HTML of the symbol to render at<br />the specified value. |
-| `helpText`          |           | `string`                                         | The select's help text. If you need to display HTML, use the `help-text` slot instead. |
-| `hoist`             |           | `boolean`                                        | Enable this option to prevent the listbox from being clipped when the component is placed inside a container with<br />`overflow: auto\|scroll`. Hoisting uses a fixed positioning strategy that works in many, but not all, scenarios. |
-| `label`             |           | `string`                                         | The select's label. If you need to display HTML, use the `label` slot instead. |
-| `lang`              |           | `string`                                         |                                                  |
-| `listbox`           |           | `HTMLSlotElement`                                |                                                  |
-| `max`               |           | `string \| number \| Date \| undefined`          |                                                  |
-| `maxOptionsVisible` |           | `number`                                         | The maximum number of selected options to show when `multiple` is true. After the maximum, "+n" will be shown to<br />indicate the number of additional items that are selected. Set to 0 to remove the limit. |
-| `maxlength`         |           | `number \| undefined`                            |                                                  |
-| `min`               |           | `string \| number \| Date \| undefined`          |                                                  |
-| `minlength`         |           | `number \| undefined`                            |                                                  |
-| `multiple`          |           | `boolean`                                        | Allows more than one option to be selected.      |
-| `name`              |           | `string`                                         | The name of the select, submitted as a name/value pair with form data. |
-| `open`              |           | `boolean`                                        | Indicates whether or not the select is open. You can toggle this attribute to show and hide the menu, or you can<br />use the `show()` and `hide()` methods and this attribute will reflect the select's open state. |
-| `pattern`           |           | `string \| undefined`                            |                                                  |
-| `pill`              |           | `boolean`                                        | Draws a pill-style select with rounded edges.    |
-| `placeholder`       |           | `string`                                         | Placeholder text to show as a hint when the select is empty. |
-| `placement`         |           | `"top" \| "bottom"`                              | The preferred placement of the select's menu. Note that the actual placement may vary as needed to keep the listbox<br />inside of the viewport. |
-| `popup`             |           | `SlPopup`                                        |                                                  |
-| `reportValidity`    |           | `() => boolean`                                  |                                                  |
-| `required`          |           | `boolean`                                        | The select's required attribute.                 |
-| `selectedOptions`   |           | `SlOption[]`                                     |                                                  |
-| `setCustomValidity` |           | `(message: string) => void`                      |                                                  |
-| `size`              |           | `"small" \| "medium" \| "large"`                 | The select's size.                               |
-| `step`              |           | `number \| "any" \| undefined`                   |                                                  |
-| `validationMessage` | readonly  | `string`                                         | Gets the validation message                      |
-| `validity`          | readonly  | `ValidityState`                                  | Gets the validity state object                   |
-| `value`             |           | `string \| string[]`                             | The current value of the select, submitted as a name/value pair with form data. When `multiple` is enabled, the<br />value attribute will be a space-delimited list of values based on the options selected, and the value property will<br />be an array. **For this reason, values must not contain spaces.** |
-| `valueInput`        |           | `HTMLInputElement`                               |                                                  |
+| Property            | Attribute       | Modifiers | Type                                             | Default         | Description                                      |
+|---------------------|-----------------|-----------|--------------------------------------------------|-----------------|--------------------------------------------------|
+| `checkValidity`     |                 |           | `() => boolean`                                  |                 |                                                  |
+| `clearable`         |                 |           | `boolean`                                        |                 | Adds a clear button when the select is not empty. |
+| `combobox`          |                 |           | `HTMLSlotElement`                                |                 |                                                  |
+| `currentOption`     |                 |           | `SlOption`                                       |                 |                                                  |
+| `defaultChecked`    |                 |           | `boolean \| undefined`                           |                 |                                                  |
+| `defaultValue`      |                 |           | `string \| string[]`                             |                 | The default value of the form control. Primarily used for resetting the form control. |
+| `dir`               |                 |           | `string`                                         |                 |                                                  |
+| `disabled`          |                 |           | `boolean`                                        |                 | Disables the select control.                     |
+| `displayInput`      |                 |           | `HTMLInputElement`                               |                 |                                                  |
+| `displayLabel`      |                 |           | `string`                                         |                 |                                                  |
+| `errorMessage`      | `errorMessage`  |           | `string \| undefined`                            |                 | Brukes til enkel constraint validation til å overskrive default nettleseren melding |
+| `filled`            |                 |           | `boolean`                                        |                 | Draws a filled select.                           |
+| `form`              |                 |           | `string`                                         |                 | By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you<br />to place the form control outside of a form and associate it with the form that has this `id`. The form must be in<br />the same document or shadow root for this to work. |
+| `getForm`           |                 |           | `() => HTMLFormElement \| null`                  |                 |                                                  |
+| `getTag`            |                 |           | `(option: SlOption, index: number) => string \| HTMLElement \| TemplateResult` |                 | A function that customizes the tags to be rendered when multiple=true. The first argument is the option, the second<br />is the current tag's index.  The function should return either a Lit TemplateResult or a string containing trusted HTML of the symbol to render at<br />the specified value. |
+| `helpText`          |                 |           | `string`                                         |                 | The select's help text. If you need to display HTML, use the `help-text` slot instead. |
+| `hoist`             |                 |           | `boolean`                                        |                 | Enable this option to prevent the listbox from being clipped when the component is placed inside a container with<br />`overflow: auto\|scroll`. Hoisting uses a fixed positioning strategy that works in many, but not all, scenarios. |
+| `label`             |                 |           | `string`                                         |                 | The select's label. If you need to display HTML, use the `label` slot instead. |
+| `lang`              |                 |           | `string`                                         |                 |                                                  |
+| `listbox`           |                 |           | `HTMLSlotElement`                                |                 |                                                  |
+| `max`               |                 |           | `string \| number \| Date \| undefined`          |                 |                                                  |
+| `maxOptionsVisible` |                 |           | `number`                                         |                 | The maximum number of selected options to show when `multiple` is true. After the maximum, "+n" will be shown to<br />indicate the number of additional items that are selected. Set to 0 to remove the limit. |
+| `maxlength`         |                 |           | `number \| undefined`                            |                 |                                                  |
+| `min`               |                 |           | `string \| number \| Date \| undefined`          |                 |                                                  |
+| `minlength`         |                 |           | `number \| undefined`                            |                 |                                                  |
+| `multiple`          |                 |           | `boolean`                                        |                 | Allows more than one option to be selected.      |
+| `name`              |                 |           | `string`                                         |                 | The name of the select, submitted as a name/value pair with form data. |
+| `open`              |                 |           | `boolean`                                        |                 | Indicates whether or not the select is open. You can toggle this attribute to show and hide the menu, or you can<br />use the `show()` and `hide()` methods and this attribute will reflect the select's open state. |
+| `pattern`           |                 |           | `string \| undefined`                            |                 |                                                  |
+| `pill`              |                 |           | `boolean`                                        |                 | Draws a pill-style select with rounded edges.    |
+| `placeholder`       |                 |           | `string`                                         |                 | Placeholder text to show as a hint when the select is empty. |
+| `placement`         |                 |           | `"top" \| "bottom"`                              |                 | The preferred placement of the select's menu. Note that the actual placement may vary as needed to keep the listbox<br />inside of the viewport. |
+| `popup`             |                 |           | `SlPopup`                                        |                 |                                                  |
+| `reportValidity`    |                 |           | `() => boolean`                                  |                 |                                                  |
+| `required`          |                 |           | `boolean`                                        |                 | The select's required attribute.                 |
+| `requiredLabel`     | `requiredLabel` |           | `string`                                         | "*Obligatorisk" | Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard. |
+| `selectedOptions`   |                 |           | `SlOption[]`                                     |                 |                                                  |
+| `setCustomValidity` |                 |           | `(message: string) => void`                      |                 |                                                  |
+| `size`              |                 |           | `"small" \| "medium" \| "large"`                 |                 | The select's size.                               |
+| `step`              |                 |           | `number \| "any" \| undefined`                   |                 |                                                  |
+| `validationMessage` |                 | readonly  | `string`                                         |                 | Gets the validation message                      |
+| `validity`          |                 | readonly  | `ValidityState`                                  |                 | Gets the validity state object                   |
+| `value`             |                 |           | `string \| string[]`                             |                 | The current value of the select, submitted as a name/value pair with form data. When `multiple` is enabled, the<br />value attribute will be a space-delimited list of values based on the options selected, and the value property will<br />be an array. **For this reason, values must not contain spaces.** |
+| `valueInput`        |                 |           | `HTMLInputElement`                               |                 |                                                  |
 
 ## Methods
 

--- a/src/components/nve-select/nve-select.component.ts
+++ b/src/components/nve-select/nve-select.component.ts
@@ -1,15 +1,33 @@
 import SlSelect from '@shoelace-style/shoelace/dist/components/select/select.js';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import styles from './nve-select.styles';
 import NveOption from '../nve-option/nve-option.component';
 
 /**
  * En Shoelace-select i NVE-forkledning.
- * Se https://shoelace.style/components/select
+ * Se https://shoelace.style/components/select. Bruker constraint og custom validering. Klarte ikke å sette feil ikone når
+ * validering feiler. Eneste måte å gjøre det på kunne ha vært å bruke ::after pseudo-element på noen av sl-select partene, men
+ * funka ikke med ikonen.
  */
 @customElement('nve-select')
 // @ts-expect-error -next-line - overskriving av private metoder i sl-select
 export default class NveSelect extends SlSelect {
+  /**
+   * Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard.
+   */
+  @property() requiredLabel = '*Obligatorisk';
+  /**
+   * Brukes til enkel constraint validation til å overskrive default nettleseren melding
+   */
+  @property({ reflect: true }) errorMessage?: string;
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('sl-invalid', (e) => {
+      // vi vil ikke at nettleseren viser feil meldingen til oss
+      e.preventDefault();
+    });
+  }
+
   constructor() {
     super();
   }
@@ -17,8 +35,25 @@ export default class NveSelect extends SlSelect {
 
   protected firstUpdated(changedProperties: any) {
     super.firstUpdated(changedProperties);
+    if (this.requiredLabel) {
+      this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
+    }
     const popup = this.shadowRoot?.querySelector('sl-popup');
     popup?.setAttribute('distance', '3');
+  }
+
+  updated(changedProperties: any) {
+    super.updated(changedProperties);
+    const hasDataUserInvalidAttr = this.hasAttribute('data-user-invalid');
+    if (hasDataUserInvalidAttr) {
+      if (!this.errorMessage) {
+        this.errorMessage = this.validationMessage;
+      }
+      this.style.setProperty('--nve-input-error-message', `"${this.validationMessage}"`);
+    }
+    if (!hasDataUserInvalidAttr) {
+      this.style.setProperty('--nve-input-error-message', '');
+    }
   }
 
   // @ts-ignore

--- a/src/components/nve-select/nve-select.component.ts
+++ b/src/components/nve-select/nve-select.component.ts
@@ -75,7 +75,6 @@ export default class NveSelect extends SlSelect {
 
       if (this.value !== oldValue) {
         this.updateComplete.then(() => {
-          console.log(this);
           // @ts-expect-error - this is shadowed by outer container
           this.emit('sl-input');
           // @ts-expect-error - this is shadowed by outer container

--- a/src/components/nve-select/nve-select.demo.ts
+++ b/src/components/nve-select/nve-select.demo.ts
@@ -3,44 +3,80 @@ import { html } from 'lit';
 /**
  * Demonstrasjon av nve-select
  */
+
+/** Lurt å nullstille validering på sl-change når man velger et alternativ */
+const resetValidation = () => {
+  const selectElement = document.getElementById('demoSelect') as HTMLSelectElement;
+  if (!selectElement) return;
+  selectElement.setCustomValidity('');
+};
+
+const validateSelectDemo = (e: any) => {
+  e.preventDefault();
+  const selectElement = document.getElementById('demoSelect') as HTMLSelectElement;
+  if (!selectElement.value) {
+    selectElement.setCustomValidity('Du må velge et alternativ');
+  } else {
+    resetValidation();
+  }
+};
 const table = html`
   <hr />
   <h3 id="nve-select">nve-select</h3>
   <table class="demo">
-      <thead>
-        <tr>
-          <th></th>
-          <th>Default</th>
-          <th>Filled</th>
-
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Standard</td>
-          <td>
-          <nve-select  clear-icon>
-          <nve-label value="Hjelpetekst" slot="label" tooltip="Hjelpetekst"></nve-label>
-          <nve-option value="option-1">Option 1</nve-option>
-          <nve-option value="option-2">Option 2</nve-option>
-          <nve-option value="option-3">Option 3</nve-option>
-          <nve-option disabled value="option-4">Option 4 <nve-icon slot="suffix" name="lock"></nve-icon></nve-option>
+    <thead>
+      <tr>
+        <th></th>
+        <th>Default</th>
+        <th>Filled</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Standard</td>
+        <td>
+          <nve-select clear-icon>
+            <nve-label value="Hjelpetekst" slot="label" tooltip="Hjelpetekst"></nve-label>
+            <nve-option value="option-1">Option 1</nve-option>
+            <nve-option value="option-2">Option 2</nve-option>
+            <nve-option value="option-3">Option 3</nve-option>
+            <nve-option disabled value="option-4">Option 4 <nve-icon slot="suffix" name="lock"></nve-icon></nve-option>
           </nve-select>
-          </td>
-          <td>
-          <nve-select  filled clear-icon>
-          <nve-label value="Hjelpetekst" slot="label" tooltip="Hjelpetekst"></nve-label>
-          <nve-option value="option-1">Option 1</nve-option>
-          <nve-option value="option-2">Option 2</nve-option>
-          <nve-option value="option-3">Option 3</nve-option>
-          <nve-option disabled value="option-4">Option 4 <nve-icon slot="suffix" name="lock"></nve-icon></nve-option>
+        </td>
+        <td>
+          <nve-select filled clear-icon>
+            <nve-label value="Hjelpetekst" slot="label" tooltip="Hjelpetekst"></nve-label>
+            <nve-option value="option-1">Option 1</nve-option>
+            <nve-option value="option-2">Option 2</nve-option>
+            <nve-option value="option-3">Option 3</nve-option>
+            <nve-option disabled value="option-4">Option 4 <nve-icon slot="suffix" name="lock"></nve-icon></nve-option>
           </nve-select>
-          </td>
-        </tr>
-       
-       
-      </tbody>
-    </table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="nve-select-validering">nve-select constraint validering</h3>
+  <form @submit="${(e: any) => validateSelectDemo(e)}" id="demoFormCustomVal" style="max-width: 300px">
+    <nve-select required errorMessage="Må velge et alternativ" id="demo" clear-icon @sl-change="${resetValidation}">
+      <nve-label value="Hjelpetekst" slot="label" tooltip="Hjelpetekst"></nve-label>
+      <nve-option value="option-1">Option 1</nve-option>
+      <nve-option value="option-2">Option 2</nve-option>
+      <nve-option value="option-3">Option 3</nve-option>
+      <nve-option disabled value="option-4">Option 4 <nve-icon slot="suffix" name="lock"></nve-icon></nve-option>
+    </nve-select>
+    <nve-button style="margin-top: 10px" variant="primary" type="submit" size="small">Submit</nve-button>
+  </form>
+  <h3 id="nve-select-validering">nve-select custom validering (med blur)</h3>
+  <form @submit="${(e: any) => validateSelectDemo(e)}" id="demoFormCustomVal" style="max-width: 300px">
+    <nve-select required id="demoSelect" clear-icon @sl-change="${resetValidation}">
+      <nve-label value="Hjelpetekst" slot="label" tooltip="Hjelpetekst"></nve-label>
+      <nve-option value="option-1">Option 1</nve-option>
+      <nve-option value="option-2">Option 2</nve-option>
+      <nve-option value="option-3">Option 3</nve-option>
+      <nve-option disabled value="option-4">Option 4 <nve-icon slot="suffix" name="lock"></nve-icon></nve-option>
+    </nve-select>
+    <nve-button style="margin-top: 10px" variant="primary" type="submit" size="small">Submit</nve-button>
+  </form>
 `;
 
 export default table;

--- a/src/components/nve-select/nve-select.styles.ts
+++ b/src/components/nve-select/nve-select.styles.ts
@@ -1,6 +1,15 @@
 import { css } from 'lit';
 
+/** Det er en del repetisjoner med nve-input.styles.ts, men jeg har ikke tid til å rette det nå. Kan også være at vi
+ * må lage vår egen nve-select komponent pga feil ikone derfor vil jeg ikke bruke mer tid på komponenten.
+ */
 export default css`
+  :host {
+    --sl-input-required-content: '*Obligatorisk';
+    --sl-input-required-content-offset: -2px;
+    --sl-input-required-content-color: var(--brand-deep);
+  }
+
   :host::part(combobox) {
     font: var(--body-small);
     color: var(--neutrals-foreground-primary, #0d0d0e);
@@ -12,6 +21,13 @@ export default css`
 
   :host(:hover)::part(combobox) {
     border-color: var(--neutrals-foreground-primary, #00131c);
+  }
+
+  :host([required]) .form-control--has-label .form-control__label::after,
+  :host([requiredLabel])::part(form-control-label)::after {
+    content: var(--sl-input-required-content);
+    font: var(--label-x-small-light);
+    color: var(--feedback-background-emphasized-error);
   }
 
   :host(:focus-visible)::part(form-control-input) {
@@ -33,5 +49,47 @@ export default css`
   /* filled*/
   :host([filled])::part(listbox) {
     background-color: var(--neutrals-background-primary-contrast, #eff8fc);
+  }
+
+  /* Gir rød ramme ved valideringsfeil  */
+  :host([data-user-invalid])::part(combobox) {
+    border-color: var(--feedback-background-emphasized-error);
+    color: var(--feedback-background-emphasized-error);
+  }
+
+  :host::part(form-control-help-text) {
+    font: var(--detailtext-caption);
+  }
+
+  :host::after {
+    content: var(--nve-input-error-message);
+    font: var(--detailtext-caption);
+    color: var(--feedback-background-emphasized-error);
+  }
+
+  /** gjemmer hjelpe tekst om det finnes et feil og feilmelding skal vises */
+  :host([data-user-invalid])::part(form-control-help-text) {
+    display: none;
+  }
+
+  :host([data-user-invalid])::part(form-control) {
+    margin-bottom: var(--spacing-x-small);
+  }
+
+  :host::part(form-control-label) {
+    align-items: center;
+  }
+
+  /** hvis hjelpe tekst vises skal den */
+  .form-control--has-help-text .form-control__help-text {
+    margin-top: var(--spacing-x-small);
+  }
+  /* Formaterer "*Obligatorisk" over input-felt og til høyre riktig når required er satt */
+  .form-control--has-label .form-control__label {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    margin-inline-start: unset;
+    margin-bottom: var(--spacing-x-small);
   }
 `;

--- a/src/components/nve-textarea/nve-textarea.demo.ts
+++ b/src/components/nve-textarea/nve-textarea.demo.ts
@@ -3,11 +3,8 @@ import { html } from 'lit';
 const validateInputFieldDemo = (e: any) => {
   e.preventDefault();
   const inputElement = document.getElementById('demoTextAreaVal') as HTMLInputElement;
-  const inputElementValue = inputElement.value;
   if (!inputElement) return;
-  const valid = inputElementValue == '42';
-
-  if (!valid) {
+  if (!inputElement.value) {
     inputElement.setCustomValidity('Feil svar');
   } else {
     inputElement.setCustomValidity('');
@@ -61,7 +58,7 @@ export default html`
       </tr>
     </tbody>
   </table>
-  <h3>nve-checkbox-group constraint validering</h3>
+  <h3>nve-textarea constraint validering</h3>
   <form>
     <nve-textarea
       @sl-invalid="${() => console.log('invalid')}"
@@ -72,17 +69,9 @@ export default html`
     ></nve-textarea>
     <nve-button style="margin-top:10px" type="submit" variant="primary" size="small">Submit</nve-button>
   </form>
-  <h3>nve-checkbox-group custom validering</h3>
+  <h3>nve-textarea custom validering</h3>
   <form @submit="${(e: any) => validateInputFieldDemo(e)}" id="demoFormCustomVal">
-    <nve-textarea
-      label="Validering"
-      @sl-blur="${validateInputFieldDemo}"
-      @sl-invalid="${() => console.log('invalid')}"
-      errorMessage="Kan ikke stå tom"
-      helpText="Skriv noe tekst"
-      required
-      id="demoTextAreaVal"
-    ></nve-textarea>
+    <nve-textarea required label="Validering" @sl-blur="${validateInputFieldDemo}" id="demoTextAreaVal"></nve-textarea>
     <nve-button style="margin-top:10px" type="submit" variant="primary" size="small">Submit</nve-button>
   </form>
 `;


### PR DESCRIPTION
Nå får vi riktig styling i nve-select hvis det oppstår et feil. 
Klarte ikke å legge til feil ikone dessverre. Eneste måte å kunne gjøre det på er å bruke ::after pseudo-element på noen av partene fordi både clear-button og expand-icon partene kan ikke utvides, og det finnes ikke noe annet slot jeg kunne bruke. Prøvde å sette en ikone inn i ::after men det funka ikke. Vil si at vi kanskje må ha egen komponent hvis vi mener at ikonen er veldig viktig.