### PR TITLE
PR: oppdatere textarea label og visning av ikone

### DIFF
--- a/src/components/nve-textarea/nve-textarea.component.ts
+++ b/src/components/nve-textarea/nve-textarea.component.ts
@@ -220,7 +220,9 @@ export default class NveTextarea extends LitElement {
                 ></nve-label>
               `
             : null}
-          ${this.required ? html`<span class="textarea__required-label">${this.requiredLabel}</span>` : null}
+          ${this.required && this.label
+            ? html`<span class="textarea__required-label">${this.requiredLabel}</span>`
+            : null}
         </div>
         <div part="base" class="textarea__base">
           <textarea
@@ -244,6 +246,10 @@ export default class NveTextarea extends LitElement {
             @input=${this.handleInput}
             @blur=${this.handleBlur}
           ></textarea>
+          <!-- Her kommer litt hokus pokus med å poisjonere ikonen. Det er en ekstra div med posisjon relativt 
+          som skal vises rett etter textarea, og den skal inneholde ikone med position absolute som skal deretter vises inn i textarea.
+          Må gjøres sånn fordi vi vil ikke begrense textarea__base brede til fit-content (da textarea kan aldri ta så mye plass som er 
+          tilgjengelig i nettleseren og man må alltid sette brede på den manuelt. Nei takk.) -->
           <!-- Foreløpig kan man ha enten 'lock' eller 'error' ikone -->
           ${this.disabled || this.showErrorMessage
             ? html`<div class="textarea__icon__container">

--- a/src/components/nve-textarea/nve-textarea.styles.ts
+++ b/src/components/nve-textarea/nve-textarea.styles.ts
@@ -14,7 +14,6 @@ export default css`
 
   .textarea__base {
     display: flex;
-    position: relative; /** trengs for å posisjonere ikonen */
   }
 
   .textarea__control {
@@ -89,12 +88,13 @@ export default css`
   }
 
   .textarea__icon__container {
-    position: absolute;
-    right: var(--sizing-4x-small);
-    top: var(--sizing-4x-small);
+    position: relative; /** trengs for å posisjonere ikonen */
   }
 
   .textarea__icon--error {
+    position: absolute;
+    left: -24px;
+    top: 10px;
     color: var(--feedback-background-emphasized-error);
   }
 `;


### PR DESCRIPTION
I første omgang så trodde jeg at det er smart å vise *obligatorisk (eller annen type requiredLabel) selv om man ikke skulle vise vanlig label. Problemet med dette er at hvis i et annet prosjekt jeg hadde lyst til å vise nve-label separat (prosjekts spesifikk oppsette) men fortsatt bruke constraint-validering på textarea, jeg hadde både min separat nve-label og *Obligatorisk label under den (sjekk vedlegg). Det finnes ikke i nve-input for eksempel, så jeg burde faktisk følge samme mønster.

Forresten var det en del problemet med posisjonering av ikone når textarea feiler. Hvis jeg ville ha en bredde på textarea så fulgte ikonen ikke med når man endret størrelsen på textarea. Den ble løst med en ekstra kontainer som vises retter textarea og som inneholder ikone med absolute posisjonering. Både top og left er 'hardkodet' så at de passer til posisjonering av teksten i textarea. 
![image](https://github.com/NVE/Designsystem/assets/42612597/3b8ab7cf-d8c7-4199-a5e8-c007de0243c8)
