### PR TITLE
Funksjon for å generere Custom Elements Manifest

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -1,0 +1,238 @@
+import * as path from 'path';
+import { customElementJetBrainsPlugin } from 'custom-element-jet-brains-integration';
+import { customElementVsCodePlugin } from 'custom-element-vs-code-integration';
+import { customElementVuejsPlugin } from 'custom-element-vuejs-integration';
+import { parse } from 'comment-parser';
+import { pascalCase } from 'pascal-case';
+import commandLineArgs from 'command-line-args';
+import fs from 'fs';
+
+const packageData = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+const { name, description, version, author, homepage, license } = packageData;
+
+const { outdir } = commandLineArgs([
+  { name: 'litelement', type: String },
+  { name: 'analyze', defaultOption: true },
+  { name: 'outdir', type: String },
+]);
+
+function noDash(string) {
+  return string.replace(/^\s?-/, '').trim();
+}
+
+function replace(string, terms) {
+  terms.forEach(({ from, to }) => {
+    string = string?.replace(from, to);
+  });
+
+  return string;
+}
+
+export default {
+  globs: ['src/components/**/*.component.ts'],
+  exclude: ['**/*.styles.ts', '**/*.demo.ts'],
+  plugins: [
+    // Append package data
+    {
+      name: 'shoelace-package-data',
+      packageLinkPhase({ customElementsManifest }) {
+        customElementsManifest.package = { name, description, version, author, homepage, license };
+      },
+    },
+
+    // Infer tag names because we no longer use @customElement decorators.
+    {
+      name: 'shoelace-infer-tag-names',
+      analyzePhase({ ts, node, moduleDoc }) {
+        switch (node.kind) {
+          case ts.SyntaxKind.ClassDeclaration: {
+            const className = node.name.getText();
+            const classDoc = moduleDoc?.declarations?.find((declaration) => declaration.name === className);
+
+            const importPath = moduleDoc.path;
+
+            // This is kind of a best guess at components. "thing.component.ts"
+            if (!importPath.endsWith('.component.ts')) {
+              return;
+            }
+
+            const tagName = path.basename(importPath, '.component.ts');
+            const tagNameWithoutPrefix = tagName.replaceAll('nve-', '');
+
+            classDoc.tagNameWithoutPrefix = tagNameWithoutPrefix;
+            classDoc.tagName = tagName;
+
+            // This used to be set to true by @customElement
+            classDoc.customElement = true;
+          }
+        }
+      },
+    },
+
+    // Parse custom jsDoc tags
+    {
+      name: 'shoelace-custom-tags',
+      analyzePhase({ ts, node, moduleDoc }) {
+        switch (node.kind) {
+          case ts.SyntaxKind.ClassDeclaration: {
+            const className = node.name.getText();
+            const classDoc = moduleDoc?.declarations?.find((declaration) => declaration.name === className);
+            const customTags = ['animation', 'dependency', 'documentation', 'since', 'status', 'title'];
+            let customComments = '/**';
+
+            node.jsDoc?.forEach((jsDoc) => {
+              jsDoc?.tags?.forEach((tag) => {
+                const tagName = tag.tagName.getText();
+
+                if (customTags.includes(tagName)) {
+                  customComments += `\n * @${tagName} ${tag.comment}`;
+                }
+              });
+            });
+
+            // This is what allows us to map JSDOC comments to ReactWrappers.
+            classDoc['jsDoc'] = node.jsDoc?.map((jsDoc) => jsDoc.getFullText()).join('\n');
+
+            const parsed = parse(`${customComments}\n */`);
+            parsed[0].tags?.forEach((t) => {
+              switch (t.tag) {
+                // Animations
+                case 'animation':
+                  if (!Array.isArray(classDoc['animations'])) {
+                    classDoc['animations'] = [];
+                  }
+                  classDoc['animations'].push({
+                    name: t.name,
+                    description: noDash(t.description),
+                  });
+                  break;
+
+                // Dependencies
+                case 'dependency':
+                  if (!Array.isArray(classDoc['dependencies'])) {
+                    classDoc['dependencies'] = [];
+                  }
+                  classDoc['dependencies'].push(t.name);
+                  break;
+
+                // Value-only metadata tags
+                case 'documentation':
+                case 'since':
+                case 'status':
+                case 'title':
+                  classDoc[t.tag] = t.name;
+                  break;
+
+                // All other tags
+                default:
+                  if (!Array.isArray(classDoc[t.tag])) {
+                    classDoc[t.tag] = [];
+                  }
+
+                  classDoc[t.tag].push({
+                    name: t.name,
+                    description: t.description,
+                    type: t.type || undefined,
+                  });
+              }
+            });
+          }
+        }
+      },
+    },
+
+    {
+      name: 'shoelace-react-event-names',
+      analyzePhase({ ts, node, moduleDoc }) {
+        switch (node.kind) {
+          case ts.SyntaxKind.ClassDeclaration: {
+            const className = node.name.getText();
+            const classDoc = moduleDoc?.declarations?.find((declaration) => declaration.name === className);
+
+            if (classDoc?.events) {
+              classDoc.events.forEach((event) => {
+                event.reactName = `on${pascalCase(event.name)}`;
+                event.eventName = `${pascalCase(event.name)}Event`;
+              });
+            }
+          }
+        }
+      },
+    },
+
+    {
+      name: 'shoelace-translate-module-paths',
+      packageLinkPhase({ customElementsManifest }) {
+        customElementsManifest?.modules?.forEach((mod) => {
+          //
+          // CEM paths look like this:
+          //
+          //  src/components/button/button.ts
+          //
+          // But we want them to look like this:
+          //
+          //  components/button/button.js
+          //
+          const terms = [
+            { from: /^src\//, to: '' }, // Strip the src/ prefix
+            { from: /\.component.(t|j)sx?$/, to: '.js' }, // Convert .ts to .js
+          ];
+
+          mod.path = replace(mod.path, terms);
+
+          for (const ex of mod.exports ?? []) {
+            ex.declaration.module = replace(ex.declaration.module, terms);
+          }
+
+          for (const dec of mod.declarations ?? []) {
+            if (dec.kind === 'class') {
+              for (const member of dec.members ?? []) {
+                if (member.inheritedFrom) {
+                  member.inheritedFrom.module = replace(member.inheritedFrom.module, terms);
+                }
+              }
+            }
+          }
+        });
+      },
+    },
+
+    // Generate custom VS Code data
+    // TODO: Kommentert ut fordi jeg får denne feilen:
+    // [custom-element-vs-code-integration]: Looks like you've hit an error in third party plugin: custom-element-vs-code-integration. Please try to create a minimal reproduction and inform the author of the custom-element-vs-code-integration plugin.
+    // TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined
+    // customElementVsCodePlugin({
+    //   outdir,
+    //   cssFileName: null,
+    //   referencesTemplate: (_, tag) => [
+    //     {
+    //       name: 'Documentation',
+    //       url: `https://designsystem.nve.no/components/${tag}`,
+    //     },
+    //   ],
+    // }),
+
+    // TODO: Kommentert ut fordi vi får denne feilen:
+    // [custom-element-jet-brains-integration]: Looks like you've hit an error in third party plugin: custom-element-jet-brains-integration. Please try to create a minimal reproduction and inform the author of the custom-element-jet-brains-integration plugin.
+    // TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Promise
+    // customElementJetBrainsPlugin({
+    //   outdir: './dist',
+    //   excludeCss: true,
+    //   packageJson: false,
+    //   referencesTemplate: (_, tag) => {
+    //     return {
+    //       name: 'Documentation',
+    //       url: `https://designsystem.nve.no/components/${tag}`,
+    //     };
+    //   },
+    // }),
+
+    // TODO: Kommentert ut fordi vi får denne feilen:
+    // TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Promise
+    // customElementVuejsPlugin({
+    //   outdir: './dist/types/vue',
+    //   fileName: 'index.d.ts',
+    //   componentTypePath: (_, tag) => `../../components/${tag}/${tag}.component.js`,
+    // }),
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nve-designsystem",
       "version": "0.1.62",
+      "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.11.2",
         "chromatic": "^10.1.0",
@@ -30,6 +31,7 @@
         "custom-element-vs-code-integration": "^1.2.1",
         "custom-element-vuejs-integration": "^1.0.0",
         "custom-elements-manifest": "^2.1.0",
+        "custom-elements-manifest-inheritance": "^1.1.1",
         "eslint": "^8.54.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-lit": "^1.10.1",
@@ -8613,6 +8615,15 @@
       "resolved": "https://registry.npmjs.org/custom-elements-manifest/-/custom-elements-manifest-2.1.0.tgz",
       "integrity": "sha512-4TU+YhBQpCGYWonsZVTOPx6aYJXenOiSRT7TNGvDB7ipa4SZSJKed1DYXG77XKL9JFZ86sDSDVkwgv1mqw3V3A==",
       "dev": true
+    },
+    "node_modules/custom-elements-manifest-inheritance": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/custom-elements-manifest-inheritance/-/custom-elements-manifest-inheritance-1.1.1.tgz",
+      "integrity": "sha512-Z/eYNKLDB68axdUQllSrSZftAMaLQijJRCx9XRgR/2xQq+zeJgWM0orbbxJQrxFvlxtmKnFZJDr/HL4332Clkw==",
+      "dev": true,
+      "dependencies": {
+        "prettier": "^2.8.0"
+      }
     },
     "node_modules/de-indent": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,13 +22,20 @@
         "@storybook/web-components-vite": "^7.6.4",
         "@typescript-eslint/eslint-plugin": "^6.12.0",
         "@typescript-eslint/parser": "^6.12.0",
+        "command-line-args": "^5.2.1",
+        "comment-parser": "^1.4.0",
         "cpy": "^11.0.0",
         "cpy-cli": "^5.0.0",
+        "custom-element-jet-brains-integration": "^1.4.0",
+        "custom-element-vs-code-integration": "^1.2.1",
+        "custom-element-vuejs-integration": "^1.0.0",
+        "custom-elements-manifest": "^2.1.0",
         "eslint": "^8.54.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-lit": "^1.10.1",
         "eslint-plugin-storybook": "^0.6.15",
         "glob": "^10.3.10",
+        "pascal-case": "^3.1.2",
         "prettier": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -7237,6 +7244,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -8097,6 +8113,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -8104,6 +8135,15 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/commondir": {
@@ -8540,6 +8580,39 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "node_modules/custom-element-jet-brains-integration": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/custom-element-jet-brains-integration/-/custom-element-jet-brains-integration-1.5.0.tgz",
+      "integrity": "sha512-EsuOYM+BD/GhWJlfIaty51HWbPm40vdqhTk6yl46fcDMsCzPsiNX28HFk7YjwyccRYeef2yr6xQPgmilLcZ8bQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier": "^2.8.0"
+      }
+    },
+    "node_modules/custom-element-vs-code-integration": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/custom-element-vs-code-integration/-/custom-element-vs-code-integration-1.3.0.tgz",
+      "integrity": "sha512-828Y8cJFSsEaGD2HjS9jBlHY1tO2ycNKSer+sdyUCV8eqFOpIshlDlPsk8c+DAnHx47+WmnBhXAYHD/hMNgxuQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/custom-element-vuejs-integration": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/custom-element-vuejs-integration/-/custom-element-vuejs-integration-1.2.0.tgz",
+      "integrity": "sha512-yrrWF62V0zr91Just1skCoyiwY05DbE5CZx+QK2AD9G/TX0KKksxufNJ+nOFn6Y5UxNpMsA9RIhqDGooP09oJw==",
+      "dev": true,
+      "dependencies": {
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/custom-elements-manifest": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/custom-elements-manifest/-/custom-elements-manifest-2.1.0.tgz",
+      "integrity": "sha512-4TU+YhBQpCGYWonsZVTOPx6aYJXenOiSRT7TNGvDB7ipa4SZSJKed1DYXG77XKL9JFZ86sDSDVkwgv1mqw3V3A==",
+      "dev": true
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -10084,6 +10157,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/find-up": {
@@ -11754,6 +11839,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -11821,7 +11912,6 @@
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -13103,7 +13193,6 @@
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -13660,7 +13749,6 @@
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -15985,6 +16073,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "custom-element-vs-code-integration": "^1.2.1",
     "custom-element-vuejs-integration": "^1.0.0",
     "custom-elements-manifest": "^2.1.0",
+    "custom-elements-manifest-inheritance": "^1.1.1",
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-lit": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,12 @@
 {
   "name": "nve-designsystem",
+  "description": "Designsystem for NVE",
+  "author": {
+    "name": "NVE",
+    "email": "nve@nve.no"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/NVE/Designsystem/",
   "version": "0.1.62",
   "exports": {
     ".": {
@@ -46,13 +53,20 @@
     "@storybook/web-components-vite": "^7.6.4",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",
+    "command-line-args": "^5.2.1",
+    "comment-parser": "^1.4.0",
     "cpy": "^11.0.0",
     "cpy-cli": "^5.0.0",
+    "custom-element-jet-brains-integration": "^1.4.0",
+    "custom-element-vs-code-integration": "^1.2.1",
+    "custom-element-vuejs-integration": "^1.0.0",
+    "custom-elements-manifest": "^2.1.0",
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-lit": "^1.10.1",
     "eslint-plugin-storybook": "^0.6.15",
     "glob": "^10.3.10",
+    "pascal-case": "^3.1.2",
     "prettier": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Denne vil generere et Custom Elements Manifest (custom-elements.json) for komponentene våre.
For å teste det, bruk:
`npx @custom-elements-manifest/analyzer analyze --outdir dist`

Jeg har kopiert konfigurasjonen (custom-elements-manifest.config.js) fra Shoelace og tilpasset den litt.

Mer info:
- https://dev.to/open-wc/introducing-custom-elements-manifest-gkk
- https://github.com/webcomponents/custom-elements-manifest