### PR TITLE
Added props to be able to make custom CSS

### DIFF
--- a/src/components/nve-button/nve-button.component.ts
+++ b/src/components/nve-button/nve-button.component.ts
@@ -6,7 +6,15 @@ import { applyStyles } from '@utils/styles';
 import { applySlotStyle } from '@utils/slot';
 
 /**
- * En tilpasset knappkomponent som forlenger Shoelace button.
+ * En Shoelace-knapp i NVE-forkledning.
+ * Se https://shoelace.style/components/button
+ * 
+ * For å lage en lenke knapp legg til href på nve-button og den skal automatisk bli gjort om til <a>
+ * 
+ *  Vi skal ikke bruke properties:
+ * - circle
+ * - caret
+ * - pill
  * 
  * Denne komponenten lar tilpassede stiler brukes på knappen og dens slots.
  * Det inkluderer egenskaper for størrelse, testId, egendefinerte stiler og slot spesifikke stiler.

--- a/src/components/nve-button/nve-button.component.ts
+++ b/src/components/nve-button/nve-button.component.ts
@@ -2,26 +2,52 @@ import { customElement, property } from 'lit/decorators.js';
 import SlButton from '@shoelace-style/shoelace/dist/components/button/button.js';
 import styles from './nve-button.styles';
 import { INveComponent } from '@interfaces/NveComponent.interface';
+import { applyStyles } from '@utils/styles';
+import { applySlotStyle } from '@utils/slot';
 
 /**
- * En Shoelace-knapp i NVE-forkledning.
- * Se https://shoelace.style/components/button
- *
- * For å lage en lenke knapp legg til href på nve-button og den skal automatisk bli gjort om til <a>
- *
- * Vi skal ikke bruke properties:
- * - circle
- * - caret
- * - pill
+ * En tilpasset knappkomponent som forlenger Shoelace button.
+ * 
+ * Denne komponenten lar tilpassede stiler brukes på knappen og dens slots.
+ * Det inkluderer egenskaper for størrelse, testId, egendefinerte stiler og slot spesifikke stiler.
  */
 @customElement('nve-button')
-export default class NveButton extends SlButton implements INveComponent{
+export default class NveButton extends SlButton implements INveComponent {
   constructor() {
     super();
   }
   static styles = [SlButton.styles, styles];
+
   @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'large';
-  @property({reflect: true, type: String}) testId: string = '';
+  @property({ reflect: true, type: String }) testId: string = '';
+
+  /** 
+  * Egendefinerte stiler som skal brukes på knappen. 
+  */
+  @property({ reflect: true, type: String }) customStyle?: string;
+
+  /**
+    * Egendefinerte stiler som skal brukes på sporene i knappen   
+   */
+  @property({ reflect: true, type: String }) slotStyle?: string;
+
+    /**
+   * Sørger for at customStyle og slotStyle blir satt på, hvis de er tilstede i properties
+   * 
+   */
+  updated(changedProperties: Map<string | number | symbol, unknown>) {
+    super.updated(changedProperties);
+    if (changedProperties.has('customStyle') && this.customStyle) {
+      const buttonElement = this.renderRoot.querySelector('.button') as HTMLElement;
+      if (buttonElement) {
+        applyStyles(buttonElement, this.customStyle);
+      }
+    }
+    if (changedProperties.has('slotStyle') && this.slotStyle) {
+      applySlotStyle(this.slotStyle, this);
+    }
+  }
+
 
 }
 

--- a/src/components/nve-dropdown/nve-dropdown.demo.ts
+++ b/src/components/nve-dropdown/nve-dropdown.demo.ts
@@ -21,7 +21,7 @@ const table = html`
     </nve-menu>
   </nve-dropdown>
       
-  <nve-dropdown  width="500px">
+  <nve-dropdown width="300px">
     <nve-button variant="primary" slot="trigger"  
       customStyle="width: 400px; display: flex; justify-content: space-between; "
       slotStyle="slot:prefix { display: none; }; slot:label { padding-left: 8px; };"

--- a/src/components/nve-dropdown/nve-dropdown.demo.ts
+++ b/src/components/nve-dropdown/nve-dropdown.demo.ts
@@ -21,7 +21,18 @@ const table = html`
     </nve-menu>
   </nve-dropdown>
       
-   
+  <nve-dropdown  width="500px">
+    <nve-button variant="primary" slot="trigger"  
+      customStyle="width: 400px; display: flex; justify-content: space-between; "
+      slotStyle="slot:prefix { display: none; }; slot:label { padding-left: 8px; };"
+    >
+
+    <nve-icon name="expand_more" slot="suffix" ></nve-icon>
+    Dropdown med custom css </nve-button>
+    <nve-menu>
+      <nve-menu-item  customStyle="width: 400px;">Tekst</nve-menu-item>
+    </nve-menu>
+  </nve-dropdown> 
 `;
 
 export default table;

--- a/src/components/nve-menu-item/nve-menu-item.component.ts
+++ b/src/components/nve-menu-item/nve-menu-item.component.ts
@@ -1,6 +1,7 @@
 import SlMenuItem from '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js';
 import { customElement, property } from 'lit/decorators.js';
 import styles from './nve-menu-item.styles';
+import { applyStyles } from '@utils/styles';
 /**
  * En sl-menu-item i NVE-forkledning.
  * Mer info: https://shoelace.style/components/menu-item
@@ -26,6 +27,11 @@ export default class NveMenuItem extends SlMenuItem {
    */
   @property({ type: Boolean, reflect: true }) indent: boolean = false;
 
+   /**
+  * Egendefinerte stiler som skal brukes på knappen. 
+   */
+   @property({ reflect: true, type: String }) customStyle?: string;
+
   constructor() {
     super();
   }
@@ -37,12 +43,20 @@ export default class NveMenuItem extends SlMenuItem {
   }
 
   /**
-   * Sørger for at subtext blir satt på, hvis den er tilstede i properties
+   * Sørger for at subtext og customStyle blir satt på, hvis de er tilstede i properties
+   * 
    */
   updated(changedProperties: any) {
     super.updated(changedProperties);
     if (changedProperties.has('subtext')) {
       this.style.setProperty('--nve-menu-item-subtext', `"${this.subtext}"`);
+    }
+    if (changedProperties.has('customStyle') && this.customStyle) {
+      const menuItemElement = this.renderRoot.querySelector('.menu-item') as HTMLElement;
+
+      if (menuItemElement) {
+        applyStyles(menuItemElement, this.customStyle);
+      }
     }
   }
 

--- a/src/utils/slot.ts
+++ b/src/utils/slot.ts
@@ -1,4 +1,5 @@
-import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import type { LitElement, ReactiveController, ReactiveControllerHost } from 'lit';
+import { applyStyles } from './styles';
 
 /** 
  * A reactive controller that determines when slots exist. 
@@ -110,4 +111,51 @@ export function getTextContent(slot: HTMLSlotElement | undefined | null): string
   });
 
   return text;
+}
+
+
+/**
+ * Bruker tilpassede stiler på spesifikke slots i en LitElement-komponent.
+ * 
+ * Denne funksjonen analyserer den angitte stilstrengen, trekker ut sporspesifikke stiler,
+ * og bruker disse stilene på de tilsvarende sporelementene i komponenten.
+ *
+ * @param-stiler – En streng som inneholder CSS-stiler med sporspesifikke velgere, f.eks. "slot:prefix { display: none; }; slot:label { padding-left: 8px; }".
+ * @param-komponent - LitElement-komponenten som stilene skal brukes på.
+ */
+export const applySlotStyle = (styles: string,component:LitElement) => {
+    const slotStyleRegex = /slot:([^{]+){([^}]+)}/g;
+    let match;
+    
+    while ((match = slotStyleRegex.exec(styles)) !== null) {
+      const slotName = match[1].trim();
+      const styles = match[2].split(';').filter(style => style.trim()).join(';');
+      const slotElement = getSlotElement(slotName, component);
+
+      if (slotElement) {
+        applyStyles(slotElement, styles);
+      }
+    }
+  
+}
+
+/**
+ * Henter HTMLElement knyttet til et spesifikt slot i en LitElement-komponent.
+ * 
+ * Denne funksjonen identifiserer og returnerer elementet som tilsvarer det gitte spornavnet.
+ *
+ * @param slotName - Navnet på slot som elementet skal hentes for. Akseptable verdier er prefix, suffix eller label.
+ * @param-komponent - LitElement-komponenten som inneholder slot.
+ * @returns HTMLElementet som er knyttet til det angitte slot, eller null hvis slot ikke eksisterer.
+ */
+ const getSlotElement = (slotName: string, component:LitElement): HTMLElement | null => {
+  switch (slotName) {
+    case 'prefix':
+    case 'suffix':
+      return component.renderRoot.querySelector(`slot[name="${slotName}"]`) as HTMLElement;
+    case 'label':
+      return component.renderRoot.querySelector(`slot[part="${slotName}"]`) as HTMLElement;
+    default:
+      return null;
+  }
 }

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -5,7 +5,7 @@
  * egenskaper og verdier, og bruker hver stil på det angitte HTMLElementet.
  *
  * @param element - HTML-elementet som stilene skal brukes på.
- * @param-stiler - En streng som inneholder CSS-stiler, f.eks. "bredde: 100px; høyde: 50px;".
+ * @param-stiler - En streng som inneholder CSS-stiler, f.eks. "width: 100px; height: 50px;".
  */
 export const applyStyles = (element: HTMLElement, styles: string)  => {
     styles.split(';').filter(style => style.trim()).forEach(style => {

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,0 +1,17 @@
+/**
+ * Bruker en streng med CSS-stiler på et gitt HTML-element.
+ * 
+ * Denne funksjonen analyserer en streng med CSS-stiler, deler dem opp i individuelle
+ * egenskaper og verdier, og bruker hver stil på det angitte HTMLElementet.
+ *
+ * @param element - HTML-elementet som stilene skal brukes på.
+ * @param-stiler - En streng som inneholder CSS-stiler, f.eks. "bredde: 100px; høyde: 50px;".
+ */
+export const applyStyles = (element: HTMLElement, styles: string)  => {
+    styles.split(';').filter(style => style.trim()).forEach(style => {
+      const [property, value] = style.split(':').map(part => part.trim());
+      if (property && value) {
+        element.style.setProperty(property, value);
+      }
+    });
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,9 @@
 
     "baseUrl": "./",
     "paths": {
-      "@interfaces/*": ["src/interfaces/*"]
+      "@interfaces/*": ["src/interfaces/*"],
+      "@utils/*": ["src/utils/*"]
+
     }
   },
   "include": ["src"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,8 @@ export default defineConfig(({ mode }) => {
       }),
       alias({
         entries: [
-          { find: '@interfaces', replacement: resolve(__dirname, 'src/interfaces') }
+          { find: '@interfaces', replacement: resolve(__dirname, 'src/interfaces') },
+          { find: '@utils', replacement: resolve(__dirname, 'src/utils') }
         ]
       }) as Plugin
     ],


### PR DESCRIPTION
**PR**: 

- Added props before being able to submit custom CSS before NVE-button and NVE-menu-item. This is needed so that you can give the flexibility of how you want the component to look. For example, if you want the Dropdown button to be of a fixed width and not responsive, you can now write: 
- `  <nve-dropdown >
    <nve-button variant="primary" slot="trigger"  
      customStyle="width: 400px; display: flex; justify-content: space-between; "
      slotStyle="slot:prefix { display: none; }; slot:label { padding-left: 8px; };"
    >

    <nve-icon name="expand_more" slot="suffix" ></nve-icon>
    Dropdown med custom css </nve-button>
    <nve-menu>
      <nve-menu-item  customStyle="width: 400px;">Tekst</nve-menu-item>
    </nve-menu>
  </nve-dropdown> `

- Added the new functions that are needed before implementing customCSS to components such as Utils functions so that the functions can be reused
- Added a new alias to Utils so it get cleaner imports. 