### PR TITLE
Removed min and max width to support more flexible select component

### DIFF
--- a/src/components/nve-select/nve-select.styles.ts
+++ b/src/components/nve-select/nve-select.styles.ts
@@ -13,8 +13,7 @@ export default css`
   :host::part(combobox) {
     font: var(--body-small);
     color: var(--neutrals-foreground-primary, #0d0d0e);
-    max-width: 300px;
-    min-width: 200px;
+
     border-radius: 0.25rem;
     border: var(--border-width-default, 1px) solid var(--neutrals-border-default, #878c94);
   }


### PR DESCRIPTION
**PR**

- Removed min and max width to support more flexible select component. When having a long Option name the name did not fit inside the select. 