### PR TITLE
Vue-eksempel for å vise bruk av selectedValues i nve-checkbox-group

### DIFF
--- a/doc-site/.vitepress/theme/components/SandboxPreview.vue
+++ b/doc-site/.vitepress/theme/components/SandboxPreview.vue
@@ -36,10 +36,11 @@ watch(
 
 const sandboxUrl = computed(() => {
   if (!sandboxId.value) return '';
-  return `https://codesandbox.io/embed/${sandboxId.value}?module=${encodeURIComponent(filePath)}`;
+  return `https://codesandbox.io/embed/${sandboxId.value}?module=${encodeURIComponent(filePath)}&view=split`;
 });
 
 // Codesandbox vue prosjekt oppsette. Kjøres via vue cli. Klarte ikke å kjøre vite script setup malen i codesandbox.
+// TODO: Ikke hardkode versjonsnummer til nve-designsystem
 const sandboxDefinition = (content: string) => ({
   files: {
     'package.json': {

--- a/doc-site/components/nve-checkbox-group.md
+++ b/doc-site/components/nve-checkbox-group.md
@@ -38,22 +38,6 @@ Bruk `orientation` for å velge retning. `vertical` er standard.
 
 `selectedValues` gir deg en liste av valgte avkrysningsbokser sin `value`
 
-```vue
-<template>
-  <nve-checkbox-group label="Vennligst velg 1 eller 2" :selectedValues="result">
-    <nve-checkbox value="value1">1</nve-checkbox>
-    <nve-checkbox value="value2">2</nve-checkbox>
-  </nve-checkbox-group>
-  Du har valgt: {{ result }}
-</template>
-<script setup lang="ts">
-import 'nve-designsystem/components/nve-checkbox-group/nve-checkbox-group.component.js';
-import 'nve-designsystem/components/nve-checkbox/nve-checkbox.component.js';
-import { ref } from 'vue';
-const result = ref<string[]>([]);
-</script>
-```
-
 <SandboxPreview>
 
 ```
@@ -64,10 +48,12 @@ const result = ref<string[]>([]);
   </nve-checkbox-group>
   Du har valgt: {{ result }}
 </template>
+
 <script setup lang="ts">
 import 'nve-designsystem/components/nve-checkbox-group/nve-checkbox-group.component.js';
 import 'nve-designsystem/components/nve-checkbox/nve-checkbox.component.js';
 import { ref } from 'vue';
+
 const result = ref<string[]>([]);
 </script>
 ```

--- a/doc-site/components/nve-checkbox-group.md
+++ b/doc-site/components/nve-checkbox-group.md
@@ -36,20 +36,43 @@ Bruk `orientation` for å velge retning. `vertical` er standard.
 
 ### Valgte verdier
 
-TODO: Dette funker ikke. Lage et Vue-eksempel i stedet?
+`selectedValues` gir deg en liste av valgte avkrysningsbokser sin `value`
 
-`selectedValues` gir deg en liste av valgte avkrysningsbokser sin `value`. Klikk på elementet og sjekk konsollet for å se `selectedValues`.
-
-<CodeExamplePreview>
-
-```html
-<nve-checkbox-group label="Vennligst velg 1 eller 2" onclick="console.log('selectedValues er ' + selectedValues)">
-  <nve-checkbox value="value1">1</nve-checkbox>
-  <nve-checkbox value="value2">2</nve-checkbox>
-</nve-checkbox-group>
+```vue
+<template>
+  <nve-checkbox-group label="Vennligst velg 1 eller 2" :selectedValues="result">
+    <nve-checkbox value="value1">1</nve-checkbox>
+    <nve-checkbox value="value2">2</nve-checkbox>
+  </nve-checkbox-group>
+  Du har valgt: {{ result }}
+</template>
+<script setup lang="ts">
+import 'nve-designsystem/components/nve-checkbox-group/nve-checkbox-group.component.js';
+import 'nve-designsystem/components/nve-checkbox/nve-checkbox.component.js';
+import { ref } from 'vue';
+const result = ref<string[]>([]);
+</script>
 ```
 
-</CodeExamplePreview>
+<SandboxPreview>
+
+```
+<template>
+  <nve-checkbox-group label="Vennligst velg 1 eller 2" :selectedValues="result">
+    <nve-checkbox value="value1">1</nve-checkbox>
+    <nve-checkbox value="value2">2</nve-checkbox>
+  </nve-checkbox-group>
+  Du har valgt: {{ result }}
+</template>
+<script setup lang="ts">
+import 'nve-designsystem/components/nve-checkbox-group/nve-checkbox-group.component.js';
+import 'nve-designsystem/components/nve-checkbox/nve-checkbox.component.js';
+import { ref } from 'vue';
+const result = ref<string[]>([]);
+</script>
+```
+
+</SandboxPreview>
 
 ### Hjelpetekst
 


### PR DESCRIPTION
Å vise bruk av `nve-checkbox-group` sin `selectedValues` vha html var ikke så lett. 
Nå har jeg skrevet om kodeeksemplet til Vue, og da virker det fint.