### PR TITLE
PR: får script delen i kodeeksempel kjøre

### DIFF
--- a/doc-site/.vitepress/theme/components/CodeExamplePreview.vue
+++ b/doc-site/.vitepress/theme/components/CodeExamplePreview.vue
@@ -1,6 +1,6 @@
 <!-- Viser både kodeblokk og kjører en eksempel av gitt kode.   -->
 <template>
-  <div class="code-example-box">
+  <div class="code-example-box" ref="codeExampleBox">
     <!-- Fjerner html fra ```html, hvis du vil fjerne andre sprøkene gjerne legg til replace, eller lag en utils metode -->
     <div class="slot-container" v-html="slot?.textContent?.replace('html', '')" />
     <div ref="slot">
@@ -9,8 +9,31 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted, nextTick } from 'vue';
 const slot = ref<HTMLElement | null>(null);
+const codeExampleBox = ref<HTMLElement | null>(null);
+
+/** Henter script delen fra kodeeksempel og legger den ved i code-example-box så at den kan kjøres */
+const processAndExecuteScripts = () => {
+  if (slot.value) {
+    const content = slot.value.textContent;
+
+    // Ta ut og kjør script tagger
+    const scriptMatches = content?.match(/<script.*>([\s\S]*?)<\/script>/g);
+    if (scriptMatches) {
+      scriptMatches.forEach((scriptTag: string) => {
+        const scriptContent = scriptTag.match(/<script.*>([\s\S]*?)<\/script>/);
+        const scriptElement = document.createElement('script');
+        scriptElement.textContent = scriptContent ? scriptContent[1] : '';
+        nextTick(() => codeExampleBox.value?.appendChild(scriptElement));
+      });
+    }
+  }
+};
+
+onMounted(() => {
+  processAndExecuteScripts();
+});
 </script>
 
 <style scoped>

--- a/doc-site/components/nve-alert.md
+++ b/doc-site/components/nve-alert.md
@@ -104,8 +104,6 @@ Bruk `closable` for å vise en lukke-knapp på høyre side, som skjuler komponen
 
 <CodeExamplePreview arrangeComponentsVertically>
 
-TODO: Fikse lukke-scriptet
-
 ```html
 <nve-alert open closable class="alert-closeable"> Trykk på krysset for å lukke denne </nve-alert>
 


### PR DESCRIPTION
Denne PR løser manglende funksjonalitet på script-tagenes inni kodeeksemplarer. Når man legger til script-tag i CodeExamplePreview ```html kodeblokken, skal scriptet fungere