### PR TITLE
PR: lagde message--card komponent

### DIFF
--- a/doc-site/.vitepress/theme/components/Card.vue
+++ b/doc-site/.vitepress/theme/components/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="variant === 'nve-card'">
+  <div>
     <div class="card nve-card">
       <div class="card-title-container">
         <p class="card-title">{{ title }}</p>
@@ -7,26 +7,12 @@
       <p class="text"><slot></slot></p>
     </div>
   </div>
-  <div v-if="variant === 'info'">
-    <div class="card info-card">
-      <div class="card-title-container">
-        <nve-icon name="info" slot="prefix" style="font-size: 26px; padding-right: 8px"></nve-icon>
-        <p class="card-title">{{ title }}</p>
-      </div>
-      <slot></slot>
-    </div>
-  </div>
 </template>
 
 <script setup lang="ts">
-type Props = {
+defineProps<{
   title: string;
-  variant: string;
-};
-
-const { title } = withDefaults(defineProps<Props>(), {
-  variant: 'info',
-});
+}>();
 </script>
 
 <style scoped>

--- a/doc-site/.vitepress/theme/components/SandboxPreview.vue
+++ b/doc-site/.vitepress/theme/components/SandboxPreview.vue
@@ -49,7 +49,7 @@ const sandboxDefinition = (content: string, theme: Theme) => ({
       content: {
         dependencies: {
           vue: '^3.2.0',
-          'nve-designsystem': '^0.1.71',
+          'nve-designsystem': '^0.1.76',
           '@vue/cli-plugin-babel': '~4.5.0',
           '@vue/cli-service': '~4.5.0',
           '@vue/compiler-sfc': '^3.0.0-0',

--- a/doc-site/.vitepress/theme/components/apidoc/ComponentMethods.vue
+++ b/doc-site/.vitepress/theme/components/apidoc/ComponentMethods.vue
@@ -1,32 +1,35 @@
 <!-- 
  Viser API-dokumentasjon for alle metoder til en komponent
  Henter opplysningene fra custom-elements.json.
- -->
+ Vi trenger ikke å vise private metoder, men også lit lifecycle methods, derfor blir de filtrert bort.
+-->
 <template>
-  <h2 id="metoder">
-    Metoder
-    <a class="header-anchor" href="#metoder" aria-label='Permalink to "Metoder"'>&ZeroWidthSpace;</a>
-  </h2>
-  <table>
-    <tr>
-      <td>Navn</td>
-      <td>Parametre</td>
-      <td>Returtype</td>
-      <td>Arvet fra</td>
-      <td>Beskrivelse</td>
-    </tr>
-    <tr v-for="method in methods" :key="method.name">
-      <td>{{ method.name }}</td>
-      <td>
-        <div v-for="parameter in method.parameters" :key="parameter.name">
-          {{ parameter.name }}: {{ parameter.type?.text }}
-        </div>
-      </td>
-      <td>{{ method.return?.type?.text }}</td>
-      <td>{{ method.inheritedFrom?.name }}</td>
-      <td>{{ method.description }}</td>
-    </tr>
-  </table>
+  <template v-if="methods.length">
+    <h2 id="metoder">
+      Metoder
+      <a class="header-anchor" href="#metoder" aria-label='Permalink to "Metoder"'>&ZeroWidthSpace;</a>
+    </h2>
+    <table>
+      <tr>
+        <td>Navn</td>
+        <td>Parametre</td>
+        <td>Returtype</td>
+        <td>Arvet fra</td>
+        <td>Beskrivelse</td>
+      </tr>
+      <tr v-for="method in methods" :key="method.name">
+        <td>{{ method.name }}</td>
+        <td>
+          <div v-for="parameter in method.parameters" :key="parameter.name">
+            {{ parameter.name }}: {{ parameter.type?.text }}
+          </div>
+        </td>
+        <td>{{ method.return?.type?.text }}</td>
+        <td>{{ method.inheritedFrom?.name }}</td>
+        <td>{{ method.description }}</td>
+      </tr>
+    </table>
+  </template>
 </template>
 
 <script setup lang="ts">
@@ -37,5 +40,24 @@ const props = defineProps<{
   componentName: string;
 }>();
 
-const methods = computed(() => getComponentMethods(props.componentName));
+/** Lifecycle metoder fra lit, eller alt annet som vi ikke skal vise i doc sida. */
+const methodsToExclude = [
+  'render',
+  'connectedCallback',
+  'disconnectedCallback',
+  'attributeChangedCallback',
+  'adoptedCallback',
+  'requestUpdate',
+  'hasChanged',
+  'shouldUpdate',
+  'willUpdate',
+  'update',
+  'firstUpdated',
+  'updated',
+  'updateComplete',
+];
+
+const methods = computed(() =>
+  getComponentMethods(props.componentName).filter((m) => m.privacy !== 'private' && !methodsToExclude.includes(m.name))
+);
 </script>

--- a/doc-site/components/nve-alert.md
+++ b/doc-site/components/nve-alert.md
@@ -10,10 +10,9 @@ layout: component
 
 </CodeExamplePreview>
 
-<Card title="Tips" variant="info">
+<nve-message-card title="Tips">
 Bruk `open` for å vise en alert. Hvis ikke `open` er satt, vises den ikke.
-
-</Card>
+</nve-message-card>
 
 ## Eksempler
 

--- a/doc-site/components/nve-dropdown.md
+++ b/doc-site/components/nve-dropdown.md
@@ -2,10 +2,9 @@
 layout: component
 ---
 
-<Card title="Tips" variant="info">
+<nve-message-card title="Tips">
 <span>For nedtrekksliste/"rullgardin"/dropdown-list, bruk <a href="/components/nve-select.html">nve-select</a></span>
-
-</Card>
+</nve-message-card>
 
 <CodeExamplePreview>
 

--- a/doc-site/components/nve-message-card.md
+++ b/doc-site/components/nve-message-card.md
@@ -1,0 +1,178 @@
+---
+layout: component
+---
+
+<CodeExamplePreview>
+
+```html
+<nve-message-card title="Dette er et kort">Bruk meg med glede</nve-message-card>
+<nve-message-card title="NVE avdelinger">
+  <ul>
+    <li>RME</li>
+    <li>EK</li>
+    <li>TB</li>
+    <li>H</li>
+    <li>IKT</li>
+    <li>V</li>
+    <li>SV</li>
+  </ul>
+</nve-message-card>
+```
+
+</CodeExamplePreview>
+
+## Eksempler
+
+### Varianter
+
+Bruk `variant` for å velge farge. `primary` er standard.
+
+<CodeExamplePreview>
+
+```html
+<nve-message-card title="Tittel">Primary</nve-message-card>
+<!-- Box-shadow stil på den nøytrale varianten på grunn av lik farger med bakgrunnen i kodeforhåndsvisningen -->
+<nve-message-card style="box-shadow:var(--dropdown)" variant="neutral" title="Tittel">Neutral</nve-message-card>
+<nve-message-card variant="warning" title="Tittel">Warning</nve-message-card>
+<nve-message-card variant="danger" title="Tittel">Danger</nve-message-card>
+<nve-message-card variant="success" title="Tittel">Success</nve-message-card>
+```
+
+</CodeExamplePreview>
+
+### Størrelse
+
+Man kan velge mellom `default` (som er standard og ikke trenger å skrives), `compact` og `simple`.
+Forskjellen mellom `compact` og `simple` er at `simple` viser kun tittel og ikon. Tittelen blir også tynnere.
+
+<CodeExamplePreview>
+
+```html
+<nve-message-card title="Default">Størrelsen på kortet</nve-message-card>
+<nve-message-card size="compact" title="Compact">Størrelsen på kortet</nve-message-card>
+<nve-message-card size="simple" title="Simple">Størrelsen på kortet</nve-message-card>
+```
+
+</CodeExamplePreview>
+
+### Emphasized
+
+Bruk `emphasized` for å vise sterkere bakgrunnsfarge.
+
+<CodeExamplePreview>
+
+```html
+<nve-message-card emphasized title="Tittel">Primary</nve-message-card>
+<nve-message-card emphasized variant="neutral" title="Tittel">Neutral</nve-message-card>
+<nve-message-card emphasized variant="warning" title="Tittel">Warning</nve-message-card>
+<nve-message-card emphasized variant="danger" title="Tittel">Danger</nve-message-card>
+<nve-message-card emphasized variant="success" title="Tittel">Success</nve-message-card>
+```
+
+</CodeExamplePreview>
+
+### Closable
+
+Bruk `closable` for å vise lukk-knappen i tittel.
+
+<CodeExamplePreview>
+
+```html
+<div class="closable-example-container">
+  <nve-message-card closable class="message-card-closable" title="Tittel "> </nve-message-card>
+</div>
+
+<script>
+  // Denne snutten skal vise message-card igjen etter 2 sek, og legge til an event igjen på det ny lagde message-card.
+  // Grunnen vi må legge til event-listener igjen er at når man lukker message-card den forsvinner fra DOMen.
+  let initialMessageCard;
+  if (!initialMessageCard) {
+    initialMessageCard = document.querySelector('.message-card-closable');
+    initialMessageCard.addEventListener('nve-hide', () => {
+      handleHideEvent();
+    });
+  }
+
+  function addMessageCard() {
+    const container = document.querySelector('.closable-example-container');
+    const newMessageCard = document.createElement('nve-message-card');
+    newMessageCard.setAttribute('closable', '');
+    newMessageCard.classList.add('message-card-closable');
+    newMessageCard.setAttribute('variant', 'primary');
+    newMessageCard.setAttribute('title', 'Tittel');
+
+    newMessageCard.addEventListener('nve-hide', () => {
+      handleHideEvent();
+    });
+
+    container.appendChild(newMessageCard);
+  }
+
+  function handleHideEvent() {
+    setTimeout(() => {
+      addMessageCard();
+    }, 2000);
+  }
+</script>
+```
+
+</CodeExamplePreview>
+
+### Footer
+
+Du kan bruke `footer`spor til å vise f.eks. en knapp.
+
+<CodeExamplePreview>
+
+```html
+<nve-message-card variant="warning" title="Ingen støtte">
+  Vi støtter ikke denne funksjonen.
+  <slot name="footer">
+    <nve-button variant="neutral">Les mer</nve-button>
+  </slot>
+</nve-message-card>
+```
+
+</CodeExamplePreview>
+
+### Subheader
+
+Slot `subheader` brukes til å vise en ekstra tekst over tittelen.
+
+<CodeExamplePreview>
+
+```html
+<nve-message-card title="Tittel">
+  <div slot="subheader">Varsel | 21.08.2024</slot>
+</nve-message-card
+>
+```
+
+</CodeExamplePreview>
+
+### Vise eller gjemme ikon
+
+Som default ikon vises ved tittelen. Ikon kan slås av ved ønske.
+
+<CodeExamplePreview>
+
+```html
+<nve-message-card showIcon="false" title="Ingen ikon"> Ikon skal ikke vises </nve-message-card>
+```
+
+</CodeExamplePreview>
+
+### Ikon
+
+Ikon er tilpasset varianten i utgangspunktet, men du kan velge ditt eget ikon ved bruk av `iconTitle`-attributen.
+
+<CodeExamplePreview>
+
+```html
+<nve-message-card iconTitle="pets" title="Hunden sier voff voff">
+  Du kan velge et ikon i headeren selv
+</nve-message-card>
+<nve-message-card variant="warning" title="Katten liker ikke voff voff"> Vær forsiktig </nve-message-card>
+```
+
+</CodeExamplePreview>

--- a/doc-site/introduction/forDesigner/contribution.md
+++ b/doc-site/introduction/forDesigner/contribution.md
@@ -66,15 +66,14 @@ Designsystemet er en felles dugnad fra og for alle prosjekter i NVE og Varsom. D
 4. **Løs oppgaven i Figma eller i kode**  
    Løs oppgaven du har fått tildelt i Figma eller i kode avhengig av oppgave. Sørg for at du forholder deg til retningslinjene satt i profilmanualen og i designsystemet, og sørg for at løsningen din oppfyller kravene til universell utforming.
 
-<Card title="Krav" variant="info">
-<ul>
-<li class="list-item">Gi komponenten et navn som er fornuftig. Det skal være lett å finne for folk som ikke vet om det. Navnet skal være beskrivende for hva det er eller hva det gjør.
-</li>
-        <li class="list-item">Gjør komponenten enkel å bruke for andre ved å sørge for at den fungerer bra i andre sammenhenger enn den du designet den for: Ulike størrelser, med ulik mengde innhold osv.</li>
-        <li class="list-item"> Legg til alle varianter/rekvisitter, og navngi dem fornuftig.</li>
-        <li class="list-item">Dokumenter arbeidet ditt.</li>
-    </ul>
-    </Card>
+<nve-message-card title="Krav">
+  <ul>
+    <li class="list-item">Gi komponenten et navn som er fornuftig. Det skal være lett å finne for folk som ikke vet om det. Navnet skal være beskrivende for hva det er eller hva det gjør.</li>
+    <li class="list-item">Gjør komponenten enkel å bruke for andre ved å sørge for at den fungerer bra i andre sammenhenger enn den du designet den for: Ulike størrelser, med ulik mengde innhold osv.</li>
+    <li class="list-item"> Legg til alle varianter/rekvisitter, og navngi dem fornuftig.</li>
+    <li class="list-item">Dokumenter arbeidet ditt.</li>
+  </ul>
+</nve-message-card>
 
 ## Bruk Branching
 

--- a/doc-site/introduction/forDesigner/getStarted.md
+++ b/doc-site/introduction/forDesigner/getStarted.md
@@ -36,4 +36,4 @@ Device - Kan du bytte mellom forskjellige skjermstørrelser. Da vil innholdet ju
 
 <img src="../../assets/images/get-started-2.png" width="auto">
 
-<Card title="Tips" variant="info">For at dette skal funke utmerket må du huske å bruke variablene som er fastsatt og ikke løse designverdier. Da vil ikke alt av innholdet endres i forhold til hva slags variabler/tokens du bruker.</Card>
+<nve-message-card title="Tips">For at dette skal funke utmerket må du huske å bruke variablene som er fastsatt og ikke løse designverdier. Da vil ikke alt av innholdet endres i forhold til hva slags variabler/tokens du bruker.</nve-message-card>

--- a/doc-site/introduction/forDevelopers/codeExamples/stepper.md
+++ b/doc-site/introduction/forDevelopers/codeExamples/stepper.md
@@ -33,7 +33,7 @@ Eksemplet viser hvordan du bruker nve-stepper med standardinnstillinger. Som sta
 
 For å legge til valideringslogikk før du går til neste trinn, kan du skrive over komponentens nextStep-funksjon. Dette gjør det mulig å kontrollere om gjeldende trinn er gyldig før du går videre. Nedenfor finner du et eksempel på hvordan du kan skrive over nextStep-funksjonen og inkludere egen valideringslogikk.
 
-<Card title="Tips" variant="info">Merk at du bør lage en kopi av den originale funksjonen slik at du kan bruke den dersom valideringen lykkes.</Card>
+<nve-message-card title="Tips">Merk at du bør lage en kopi av den originale funksjonen slik at du kan bruke den dersom valideringen lykkes.</nve-message-card>
 
 #### Egen tekst for siste knapp
 
@@ -53,129 +53,133 @@ Denne funksjonen henter gjeldende trinnindeks ved å bruke getCurrentIndex-metod
 
 Denne funksjonen lar deg flytte til et bestemt trinn ved å bruke selectStep-metoden. Den utløser en CustomEvent med select-step og ønsket trinnindeks. Dette er nyttig når du trenger å navigere til et spesifikt trinn programmatisk basert på visse betingelser.
 
-::: info
-Merk at selectStep-funksjonen har følgende condition:
-if (this.steps[event.detail.index - 1].state == StepState.NotStarted) return;
-:::
+<nve-message-card title="Tips">
+  Merk at selectStep-funksjonen har følgende condition:
+  if (this.steps[event.detail.index - 1].state == StepState.NotStarted) return;
+</nve-message-card>
 
-```vue
+<CodeExamplePreview onlyCode="true">
+
+```html
 <template>
   <nve-stepper ref="stepper" :steps="steps"></nve-stepper>
 </template>
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+  import { onMounted, ref } from 'vue';
 
-import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
-import 'nve-designsystem/components/nve-button/nve-button.component';
-import 'nve-designsystem/components/nve-icon/nve-icon.component';
+  import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+  import 'nve-designsystem/components/nve-button/nve-button.component';
+  import 'nve-designsystem/components/nve-icon/nve-icon.component';
 
-import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
-import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+  import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+  import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
 
-const steps: StepProps[] = [
-  {
-    title: 'Kategorisering',
-    description: 'Lorem Ipsum',
-    state: StepState.Started,
-    isSelected: true,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Beskrivelse',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Kontakt info',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Oppsumering',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-];
+  const steps: StepProps[] = [
+    {
+      title: 'Kategorisering',
+      description: 'Lorem Ipsum',
+      state: StepState.Started,
+      isSelected: true,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Beskrivelse',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Kontakt info',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Oppsumering',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+  ];
 
-// Get a reference to the stepper component
-const stepper = ref<HTMLElement | null>(null);
+  // Get a reference to the stepper component
+  const stepper = ref<HTMLElement | null>(null);
 
-onMounted(() => {
-  initializeStepper();
-  logCurrentIndex();
-});
+  onMounted(() => {
+    initializeStepper();
+    logCurrentIndex();
+  });
 
-// Function to initialize the stepper component
-const initializeStepper = () => {
-  if (stepper.value) {
-    const nveStepper = stepper.value as unknown as INveStepper;
+  // Function to initialize the stepper component
+  const initializeStepper = () => {
+    if (stepper.value) {
+      const nveStepper = stepper.value as unknown as INveStepper;
 
-    // Override the original nextStep method
-    overrideNextStep(nveStepper);
-    // Override the finishSteps method with custom logic
-    overrideFinishSteps(nveStepper);
-  }
-};
-
-// Function to override the nextStep method with custom validation
-const overrideNextStep = (nveStepper: INveStepper) => {
-  // Store a reference to the original nextStep method, binding 'this' to 'nveStepper'
-  const originalNextStep = nveStepper.nextStep.bind(nveStepper);
-
-  nveStepper.nextStep = () => {
-    // Perform custom validation before advancing to the next step
-    if (validateCurrentStep(nveStepper)) {
-      console.log('Validation success');
-      originalNextStep();
-    } else {
-      console.log('Validation failed');
+      // Override the original nextStep method
+      overrideNextStep(nveStepper);
+      // Override the finishSteps method with custom logic
+      overrideFinishSteps(nveStepper);
     }
   };
-};
 
-// Function to override the finishSteps method with custom logic
-const overrideFinishSteps = (nveStepper: INveStepper) => {
-  nveStepper.finishSteps = () => {
-    console.log('Custom finish steps logic executed!');
-    // Add your custom logic here
+  // Function to override the nextStep method with custom validation
+  const overrideNextStep = (nveStepper: INveStepper) => {
+    // Store a reference to the original nextStep method, binding 'this' to 'nveStepper'
+    const originalNextStep = nveStepper.nextStep.bind(nveStepper);
+
+    nveStepper.nextStep = () => {
+      // Perform custom validation before advancing to the next step
+      if (validateCurrentStep(nveStepper)) {
+        console.log('Validation success');
+        originalNextStep();
+      } else {
+        console.log('Validation failed');
+      }
+    };
   };
-};
 
-// Function to validate the current step
-const validateCurrentStep = (nveStepper: INveStepper) => {
-  const currentIndex = nveStepper.getCurrentIndex();
-  // Example condition: Ensure the description is not empty
-  return steps[currentIndex].description.trim() !== '';
-};
+  // Function to override the finishSteps method with custom logic
+  const overrideFinishSteps = (nveStepper: INveStepper) => {
+    nveStepper.finishSteps = () => {
+      console.log('Custom finish steps logic executed!');
+      // Add your custom logic here
+    };
+  };
 
-// Function to log the current step index
-const logCurrentIndex = () => {
-  if (stepper.value) {
-    const nveStepper = stepper.value as unknown as INveStepper;
+  // Function to validate the current step
+  const validateCurrentStep = (nveStepper: INveStepper) => {
     const currentIndex = nveStepper.getCurrentIndex();
-    console.log(`Current step index: ${currentIndex}`);
-  }
-};
+    // Example condition: Ensure the description is not empty
+    return steps[currentIndex].description.trim() !== '';
+  };
 
-// Function to move to a specific step
-// NOTE that the selectStep function has the condition:
-//    if (this.steps[event.detail.index - 1].state == StepState.NotStarted) {
-//        return; }
-const moveToStep = (index: number) => {
-  if (stepper.value) {
-    const nveStepper = stepper.value as unknown as INveStepper;
-    nveStepper.selectStep(new CustomEvent('select-step', { detail: { index } }));
-    console.log(`Moved to step index: ${index}`);
-  }
-};
+  // Function to log the current step index
+  const logCurrentIndex = () => {
+    if (stepper.value) {
+      const nveStepper = stepper.value as unknown as INveStepper;
+      const currentIndex = nveStepper.getCurrentIndex();
+      console.log(`Current step index: ${currentIndex}`);
+    }
+  };
+
+  // Function to move to a specific step
+  // NOTE that the selectStep function has the condition:
+  // if (this.steps[event.detail.index - 1].state == StepState.NotStarted) {
+  // return; }
+  const moveToStep = (index: number) => {
+    if (stepper.value) {
+      const nveStepper = stepper.value as unknown as INveStepper;
+      nveStepper.selectStep(new CustomEvent('select-step', { detail: { index } }));
+      console.log(`Moved to step index: ${index}`);
+    }
+  };
 </script>
 ```
+
+</CodeExamplePreview>
 
 <SandboxPreview>
 
@@ -194,109 +198,109 @@ import "nve-designsystem/components/nve-icon/nve-icon.component";
 import { StepProps } from "nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js";
 import { StepState } from "nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js";
 const steps: StepProps[] = [
-  {
-    title: 'Kategorisering',
-    description: 'Lorem Ipsum',
-    state: StepState.Started,
-    isSelected: true,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Beskrivelse',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Kontakt info',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Oppsumering',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
+{
+title: 'Kategorisering',
+description: 'Lorem Ipsum',
+state: StepState.Started,
+isSelected: true,
+readyForEntrance: true,
+},
+{
+title: 'Beskrivelse',
+description: 'Lorem Ipsum',
+state: StepState.NotStarted,
+isSelected: false,
+readyForEntrance: true,
+},
+{
+title: 'Kontakt info',
+description: 'Lorem Ipsum',
+state: StepState.NotStarted,
+isSelected: false,
+readyForEntrance: true,
+},
+{
+title: 'Oppsumering',
+description: 'Lorem Ipsum',
+state: StepState.NotStarted,
+isSelected: false,
+readyForEntrance: true,
+},
 ];
 
 // Get a reference to the stepper component
 const stepper = ref<HTMLElement | null>(null);
 
 onMounted(() => {
-  initializeStepper();
-  logCurrentIndex();
+initializeStepper();
+logCurrentIndex();
 });
 
 // Function to initialize the stepper component
 const initializeStepper = () => {
-  if (stepper.value) {
-    const nveStepper = stepper.value as unknown as INveStepper;
+if (stepper.value) {
+const nveStepper = stepper.value as unknown as INveStepper;
 
     // Override the original nextStep method
     overrideNextStep(nveStepper);
     // Override the finishSteps method with custom logic
     overrideFinishSteps(nveStepper);
-  }
+
+}
 };
 
 // Function to override the nextStep method with custom validation
 const overrideNextStep = (nveStepper: INveStepper) => {
-  // Store a reference to the original nextStep method, binding 'this' to 'nveStepper'
-  const originalNextStep = nveStepper.nextStep.bind(nveStepper);
+// Store a reference to the original nextStep method, binding 'this' to 'nveStepper'
+const originalNextStep = nveStepper.nextStep.bind(nveStepper);
 
-  nveStepper.nextStep = () => {
-    // Perform custom validation before advancing to the next step
-    if (validateCurrentStep(nveStepper)) {
-      console.log('Validation success');
-      originalNextStep();
-    } else {
-      console.log('Validation failed');
-    }
-  };
+nveStepper.nextStep = () => {
+// Perform custom validation before advancing to the next step
+if (validateCurrentStep(nveStepper)) {
+console.log('Validation success');
+originalNextStep();
+} else {
+console.log('Validation failed');
+}
+};
 };
 
 // Function to override the finishSteps method with custom logic
 const overrideFinishSteps = (nveStepper: INveStepper) => {
-  nveStepper.finishSteps = () => {
-    console.log('Custom finish steps logic executed!');
-    // Add your custom logic here
-  };
+nveStepper.finishSteps = () => {
+console.log('Custom finish steps logic executed!');
+// Add your custom logic here
+};
 };
 
 // Function to validate the current step
 const validateCurrentStep = (nveStepper: INveStepper) => {
-  const currentIndex = nveStepper.getCurrentIndex();
-  // Example condition: Ensure the description is not empty
-  return steps[currentIndex].description.trim() !== '';
+const currentIndex = nveStepper.getCurrentIndex();
+// Example condition: Ensure the description is not empty
+return steps[currentIndex].description.trim() !== '';
 };
 
 // Function to log the current step index
 const logCurrentIndex = () => {
-  if (stepper.value) {
-    const nveStepper = stepper.value as unknown as INveStepper;
-    const currentIndex = nveStepper.getCurrentIndex();
-    console.log(`Current step index: ${currentIndex}`);
-  }
+if (stepper.value) {
+const nveStepper = stepper.value as unknown as INveStepper;
+const currentIndex = nveStepper.getCurrentIndex();
+console.log(`Current step index: ${currentIndex}`);
+}
 };
 
 // Function to move to a specific step
 // NOTE that the selectStep function has the condition:
-//    if (this.steps[event.detail.index - 1].state == StepState.NotStarted) {
-//        return; }
+// if (this.steps[event.detail.index - 1].state == StepState.NotStarted) {
+// return; }
 const moveToStep = (index: number) => {
-  if (stepper.value) {
-    const nveStepper = stepper.value as unknown as INveStepper;
-    nveStepper.selectStep(new CustomEvent('select-step', { detail: { index } }));
-    console.log(`Moved to step index: ${index}`);
-  }
+if (stepper.value) {
+const nveStepper = stepper.value as unknown as INveStepper;
+nveStepper.selectStep(new CustomEvent('select-step', { detail: { index } }));
+console.log(`Moved to step index: ${index}`);
+}
 };
 </script>
-
 ```
 
 </SandboxPreview>
@@ -308,60 +312,64 @@ Eksemplet viser hvordan du bruker en horisontal nve-stepper med standardinnstill
 ### orientation
 
 Property orientation har valgene: 'horisontal' | 'vertikal' der 'horisontal' er default.
-:::info
+<nve-message-card title="Tips">
 Merk: Du må bruke orientation="horizontal", ikke :orientation="horizontal".
-:::
+</nve-message-card>
 
 ### spaceBetweenSteps
 
 Du kan justere avstanden mellom stegene ved å sende et tall til spaceBetweenSteps. Default er 200.
 
-```vue
+<CodeExamplePreview onlyCode="true">
+
+```html
 <template>
   <nve-stepper :steps="steps" orientation="vertical" :spaceBetweenSteps="100"></nve-stepper>
 </template>
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+  import { onMounted, ref } from 'vue';
 
-import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
-import 'nve-designsystem/components/nve-button/nve-button.component';
-import 'nve-designsystem/components/nve-icon/nve-icon.component';
+  import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+  import 'nve-designsystem/components/nve-button/nve-button.component';
+  import 'nve-designsystem/components/nve-icon/nve-icon.component';
 
-import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
-import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+  import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+  import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
 
-const steps: StepProps[] = [
-  {
-    title: 'Kategorisering',
-    description: 'Lorem Ipsum',
-    state: StepState.Started,
-    isSelected: true,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Beskrivelse',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Kontakt info',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Oppsumering',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-];
+  const steps: StepProps[] = [
+    {
+      title: 'Kategorisering',
+      description: 'Lorem Ipsum',
+      state: StepState.Started,
+      isSelected: true,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Beskrivelse',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Kontakt info',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Oppsumering',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+  ];
 </script>
 ```
+
+</CodeExamplePreview>
 
 <SandboxPreview>
 
@@ -426,7 +434,7 @@ Før du administrerer at kontrollen av det siste trinnet er riktig, bør du skri
 
 For å legge til valideringslogikk før du går til neste trinn, kan du skrive over komponentens nextStep-funksjon. Dette gjør det mulig å kontrollere om gjeldende trinn er gyldig før du går videre. Nedenfor finner du et eksempel på hvordan du kan skrive over nextStep-funksjonen og inkludere egen valideringslogikk.
 
-<Card title="Tips" variant="info">Merk at du bør lage en kopi av den originale funksjonen slik at du kan bruke den dersom valideringen lykkes.</Card>
+<nve-message-card title="Tips">Merk at du bør lage en kopi av den originale funksjonen slik at du kan bruke den dersom valideringen lykkes.</nve-message-card>
 
 #### Egen tekst for siste knapp uten standardknapper
 
@@ -446,7 +454,9 @@ En property som angir om standardknappene skal vises eller ikke.
 
 Denne funksjonen henter gjeldende trinnindeks ved å bruke getCurrentIndex-metoden til stepper-komponenten og logger den til konsollen. Dette er nyttig for feilsøking eller for å spore hvilket trinn brukeren er på.
 
-```vue
+<CodeExamplePreview onlyCode="true">
+
+```html
 <template>
   <div>
     <nve-stepper ref="stepper" :steps="steps" :hideStepButtons="true"></nve-stepper>
@@ -462,117 +472,119 @@ Denne funksjonen henter gjeldende trinnindeks ved å bruke getCurrentIndex-metod
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+  import { onMounted, ref } from 'vue';
 
-import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
-import 'nve-designsystem/components/nve-button/nve-button.component';
-import 'nve-designsystem/components/nve-icon/nve-icon.component';
+  import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+  import 'nve-designsystem/components/nve-button/nve-button.component';
+  import 'nve-designsystem/components/nve-icon/nve-icon.component';
 
-import { INveStepper } from 'nve-designsystem/components/nve-stepper/nve-stepper.component';
-import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
-import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+  import { INveStepper } from 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+  import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+  import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
 
-const steps: StepProps[] = [
-  {
-    title: 'Kategorisering',
-    description: 'Lorem Ipsum',
-    state: StepState.Started,
-    isSelected: true,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Beskrivelse',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Kontakt info',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Oppsumering',
-    description: 'Lorem Ipsum',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-];
+  const steps: StepProps[] = [
+    {
+      title: 'Kategorisering',
+      description: 'Lorem Ipsum',
+      state: StepState.Started,
+      isSelected: true,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Beskrivelse',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Kontakt info',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Oppsumering',
+      description: 'Lorem Ipsum',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+  ];
 
-const stepper = ref<INveStepper | null>(null);
-const isLastStep = ref(false);
+  const stepper = ref<INveStepper | null>(null);
+  const isLastStep = ref(false);
 
-onMounted(() => {
-  initializeStepper();
-  updateIsLastStep();
-});
+  onMounted(() => {
+    initializeStepper();
+    updateIsLastStep();
+  });
 
-// Initialize the stepper and override its methods
-const initializeStepper = () => {
-  if (stepper.value) {
-    const nveStepper = stepper.value;
+  // Initialize the stepper and override its methods
+  const initializeStepper = () => {
+    if (stepper.value) {
+      const nveStepper = stepper.value;
 
-    // Override nextStep method
-    const originalNextStep = nveStepper.nextStep.bind(nveStepper);
-    nveStepper.nextStep = () => {
-      if (validateCurrentStep(nveStepper)) {
-        console.log('Validation success');
-        originalNextStep();
+      // Override nextStep method
+      const originalNextStep = nveStepper.nextStep.bind(nveStepper);
+      nveStepper.nextStep = () => {
+        if (validateCurrentStep(nveStepper)) {
+          console.log('Validation success');
+          originalNextStep();
+          updateIsLastStep();
+        } else {
+          console.log('Validation failed');
+        }
+      };
+
+      // Override prevStep method
+      const originalPrevStep = nveStepper.prevStep.bind(nveStepper);
+      nveStepper.prevStep = () => {
+        originalPrevStep();
         updateIsLastStep();
-      } else {
-        console.log('Validation failed');
-      }
-    };
+      };
 
-    // Override prevStep method
-    const originalPrevStep = nveStepper.prevStep.bind(nveStepper);
-    nveStepper.prevStep = () => {
-      originalPrevStep();
-      updateIsLastStep();
-    };
+      // Override finishSteps method
+      nveStepper.finishSteps = () => {
+        console.log('Custom finish steps logic executed!');
+        // Add your custom logic here
+      };
+    }
+  };
 
-    // Override finishSteps method
-    nveStepper.finishSteps = () => {
-      console.log('Custom finish steps logic executed!');
-      // Add your custom logic here
-    };
-  }
-};
+  // Validate the current step
+  const validateCurrentStep = (nveStepper: INveStepper) => {
+    const currentIndex = nveStepper.getCurrentIndex();
+    return steps[currentIndex].description.trim() !== '';
+  };
 
-// Validate the current step
-const validateCurrentStep = (nveStepper: INveStepper) => {
-  const currentIndex = nveStepper.getCurrentIndex();
-  return steps[currentIndex].description.trim() !== '';
-};
+  // Update the isLastStep flag based on the current step index
+  const updateIsLastStep = () => {
+    if (stepper.value) {
+      isLastStep.value = stepper.value.getCurrentIndex() === steps.length - 1;
+    }
+  };
 
-// Update the isLastStep flag based on the current step index
-const updateIsLastStep = () => {
-  if (stepper.value) {
-    isLastStep.value = stepper.value.getCurrentIndex() === steps.length - 1;
-  }
-};
+  // Handle custom next/finish button click
+  const handleNextStepOrFinish = () => {
+    if (isLastStep.value && stepper.value) {
+      stepper.value.finishSteps();
+    } else if (stepper.value) {
+      stepper.value.nextStep();
+    }
+  };
 
-// Handle custom next/finish button click
-const handleNextStepOrFinish = () => {
-  if (isLastStep.value && stepper.value) {
-    stepper.value.finishSteps();
-  } else if (stepper.value) {
-    stepper.value.nextStep();
-  }
-};
-
-// Handle custom previous button click
-const handlePrevStep = () => {
-  if (stepper.value) {
-    stepper.value.prevStep();
-  }
-};
+  // Handle custom previous button click
+  const handlePrevStep = () => {
+    if (stepper.value) {
+      stepper.value.prevStep();
+    }
+  };
 </script>
 ```
+
+</CodeExamplePreview>
 
 <SandboxPreview>
 
@@ -726,51 +738,55 @@ Det er mulig å bruke mobilutseende selv på desktop-enheter ved å sette proper
 En property som angir om standardknappene skal vises eller ikke.
 Hvis du velger å skjule standardknappene, se eksempelet "Stepper uten standardknapper" hvordan du implementerer dine egne knapper.
 
-```vue
+<CodeExamplePreview onlyCode="true">
+
+```html
 <template>
   <nve-stepper :steps="steps" :displayMobileVersion="true"> </nve-stepper>
 </template>
 
 <script setup lang="ts">
-import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
-import 'nve-designsystem/components/nve-button/nve-button.component';
-import 'nve-designsystem/components/nve-icon/nve-icon.component';
+  import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+  import 'nve-designsystem/components/nve-button/nve-button.component';
+  import 'nve-designsystem/components/nve-icon/nve-icon.component';
 
-import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
-import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+  import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+  import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
 
-const steps: StepProps[] = [
-  {
-    title: 'Kategorisering',
-    description: '',
-    state: StepState.Started,
-    isSelected: true,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Beskrivelse',
-    description: '',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Kontakt info',
-    description: '',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-  {
-    title: 'Oppsumering',
-    description: '',
-    state: StepState.NotStarted,
-    isSelected: false,
-    readyForEntrance: true,
-  },
-];
+  const steps: StepProps[] = [
+    {
+      title: 'Kategorisering',
+      description: '',
+      state: StepState.Started,
+      isSelected: true,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Beskrivelse',
+      description: '',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Kontakt info',
+      description: '',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+    {
+      title: 'Oppsumering',
+      description: '',
+      state: StepState.NotStarted,
+      isSelected: false,
+      readyForEntrance: true,
+    },
+  ];
 </script>
 ```
+
+</CodeExamplePreview>
 
 <SandboxPreview>
 

--- a/doc-site/introduction/forDevelopers/validation.md
+++ b/doc-site/introduction/forDevelopers/validation.md
@@ -2,10 +2,9 @@
 
 # Validering av input
 
-<Card title="Tips" variant="info">
-Komponentene du skal validere må ligge inni en &lt;form&gt;, fordi validering utføres når `submit`-eventet fyres av.
-
-</Card>
+<nve-message-card title="Tips">
+  Komponentene du skal validere må ligge inni en &lt;form&gt;, fordi validering utføres når submit-eventet fyres av.
+</nve-message-card>
 
 Vi tilbyr en forenklet variant av Shoelace sin måte å validere input på. Du bør lese om [hvordan Shoelace gjør det](https://shoelace.style/getting-started/form-controls).
 

--- a/doc-site/introduction/forDevelopers/vue.md
+++ b/doc-site/introduction/forDevelopers/vue.md
@@ -108,4 +108,4 @@ Hvis du ikke ser komponenten når du kjører sida, sjekk om du har importert den
 
 Les også om [bruk av Shoelace-komponenter i Vue](https://shoelace.style/frameworks/vue). Det meste der gjelder for Nve-komponenter også.
 
-<Card title="Tips" variant="info">Bruke både opening og closing tag individuelt. &lt;nve-button /&gt; funker ikke i Vue.</Card>
+<nve-message-card title="Tips">Bruke både opening og closing tag individuelt. &lt;nve-button /&gt; funker ikke i Vue.</nve-message-card>

--- a/doc-site/introduction/home.md
+++ b/doc-site/introduction/home.md
@@ -5,14 +5,12 @@ TODO: Legg til tab komponent
 
 Designsystemet samler og tilgjengeliggjør verktøy, filer, komponenter og designretningslinjer som brukes av designere og utviklere for å lage gode og konsekvente brukeropplevelser i NVE og Varsoms digitale tjenester. Designsystemet skal sette NVE og Varsoms profiler i kontekst. Med andre ord vise deg hvorfor, hvor, når og hvordan du bruker og videreutvikler innhold i designsystemet for å skape gevinster og tettere samarbeid på tvers av roller og produkter.
 
-<Card title="Designsystemets formål" variant="info">
-
-- Sikre visuell og funksjonell konsistens i forskjellige produkter og kanaler
-- Sentral kvalitetssikring og tilpassing til krav som universell utforming
-- Gjøre det enklere å komme i gang med design og utvikling i NVE og Varsom
-- Styrke kommunikasjon og samarbeid mellom design og utvikling
-
-</Card>
+<nve-message-card title="Designsystemets formål">
+<span>- Sikre visuell og funksjonell konsistens i forskjellige produkter og kanaler</span>
+<span>- Sentral kvalitetssikring og tilpassing til krav som universell utforming</span>
+<span>- Gjøre det enklere å komme i gang med design og utvikling i NVE og Varsom</span>
+<span>- Styrke kommunikasjon og samarbeid mellom design og utvikling</span>
+</nve-message-card>
 
 ## Våre prinsipper
 

--- a/src/components/nve-alert/nve-alert.component.ts
+++ b/src/components/nve-alert/nve-alert.component.ts
@@ -3,7 +3,10 @@ import styles from './nve-alert.styles';
 import { customElement, property } from 'lit/decorators.js';
 
 /**
- * Brukes til å vise viktige beskjeder enten på en side eller som en enkel popup
+ * Brukes til å vise viktige beskjeder enten på en side eller som en enkel popup.
+ *
+ * Hvis du trenger å vise en statisk varsling med mer informasjon, kan det hende at
+ * nve-message-card er et bedre valg.
  */
 @customElement('nve-alert')
 export default class NveAlert extends SlAlert {

--- a/src/components/nve-message-card/nve-message-card.component.ts
+++ b/src/components/nve-message-card/nve-message-card.component.ts
@@ -1,0 +1,137 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import { INveComponent } from '@interfaces/NveComponent.interface';
+import styles from './nve-message-card.styles';
+import '../nve-icon/nve-icon.component';
+
+/** 
+Brukes som veiledning i skjemaer eller som en informasjon til brukere. 
+*
+*
+* Hvis du skal vise en popup som er et resultat av brukerinteraksjon (som for eksempel varsler, feil, osv.), 
+* bør du gjerne bruke nve-alert. Nve-message-card skal inneholde mer informasjon og skal i utgangspunktet være 
+* en statisk komponent. Den er ment for å hjelpe brukere, for eksempel i skjemaer.
+* @dependency nve-icon
+*
+* @slot subheader - Ekstra informasjon i header seksjonen
+* @slot footer - Ekstra informasjon i footer seksjonen
+*
+* @event nve-hide - Emittes når kortet lukkes.
+*
+* @csspart base - hoved komponent kontainer.
+* @csspart header - header seksjonen.
+* @csspart subheader - subheader seksjonen.
+* @csspart title - tittel i header seksjonen.
+* @csspart footer - footer seksjonen.
+*/
+@customElement('nve-message-card')
+export default class NveMessageCard extends LitElement implements INveComponent {
+  @property({ reflect: true, type: String }) testId: string = '';
+  /** Bestemmer sterkere bakgrunnsfarge */
+  @property({ type: Boolean, reflect: true }) emphasized: boolean = false;
+  /** Bestemmer om størrelsen */
+  @property({ reflect: true }) size: 'default' | 'compact' | 'simple' = 'default';
+  /** Bestemmer om kort skal vise lukk knappen i høyre hjørnet */
+  @property({ type: Boolean, reflect: true }) closable: boolean = false;
+  /** Viser ikonen ved siden i header seksjonen */
+  @property({ reflect: true }) showIcon: 'true' | 'false' = 'true';
+  /** Tittel i header seksjonen */
+  @property({ reflect: true }) title: string = '';
+  /** Beskrivelse tekst under tittelen */
+  @property({ reflect: true }) text: string = '';
+  /** Man kan velge ikon i headeren, enten kommer en default en */
+  @property({ reflect: true }) iconTitle: string = '';
+  /** Bestemmer variant farge */
+  @property({ reflect: true }) variant: 'neutral' | 'primary' | 'warning' | 'danger' | 'success' = 'primary';
+  //vurdere showheader
+  static styles = [styles];
+
+  constructor() {
+    super();
+  }
+
+  private handleClose() {
+    const element = this.shadowRoot?.querySelector('.message-card');
+
+    element?.classList.add('message-card-remove');
+
+    this.dispatchEvent(
+      new CustomEvent('nve-hide', {
+        detail: { message: 'Message card is being hidden' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    // Fjerne fra DOMen etter transition er ferdig
+    element?.addEventListener(
+      'transitionend',
+      () => {
+        this.remove();
+      },
+      { once: true }
+    );
+  }
+
+  private determineIcon() {
+    if (this.iconTitle) {
+      return this.iconTitle;
+    } else {
+      switch (this.variant) {
+        case 'neutral':
+        case 'primary':
+          return 'info';
+        case 'warning':
+          return 'warning';
+        case 'danger':
+          return 'error';
+        case 'success':
+          return 'check_circle';
+      }
+    }
+  }
+
+  render() {
+    return html`
+      <div
+        part="base"
+        class="${classMap({
+          'message-card': true,
+          'message-card--neutral': this.variant === 'neutral',
+          'message-card--primary': this.variant === 'primary',
+          'message-card--warning': this.variant === 'warning',
+          'message-card--danger': this.variant === 'danger',
+          'message-card--success': this.variant === 'success',
+        })}"
+      >
+        <div class="message-card__header-container">
+          <div part="header" class="message-card__header">
+            <slot part="subheader" name="subheader" class="message-card__subheader"></slot>
+            <div part="title" class="message-card__header-title">
+              ${this.showIcon === 'true' ? html`<nve-icon name=${this.determineIcon()}></nve-icon>` : null}
+              ${this.title ? html`<span>${this.title}</span>` : null}
+            </div>
+          </div>
+          ${this.closable
+            ? html`<button type="button" class="message-card__close-btn" @click=${this.handleClose}>
+                <nve-icon name="close"></nve-icon>
+              </button>`
+            : null}
+        </div>
+        ${this.size !== 'simple'
+          ? html` <slot part="body" class="message-card__body" aria-live="assertive"></slot>
+              <slot name="footer" part="footer"></slot>`
+          : null}
+      </div>
+    `;
+  }
+}
+
+//skal den også forsvinne etter en bestemt tid?
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-message-card': NveMessageCard;
+  }
+}

--- a/src/components/nve-message-card/nve-message-card.styles.ts
+++ b/src/components/nve-message-card/nve-message-card.styles.ts
@@ -1,0 +1,176 @@
+import { css } from 'lit';
+
+export default css`
+  :host {
+    --button-hover: rgba(0, 0, 0, 0.1);
+  }
+
+  .message-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    border-radius: var(--border-radius-small);
+    padding: var(--spacing-large);
+    gap: var(--spacing-small);
+    align-self: stretch;
+    color: var(--neutrals-foreground-primary, #0d0d0e);
+    opacity: 1;
+    transition: opacity 0.3s 0s;
+  }
+
+  .message-card__header-container {
+    display: flex;
+    width: 100%;
+  }
+
+  .message-card__subheader {
+    font: var(--label-x-small-light);
+  }
+
+  .message-card__header {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: var(--spacing-small);
+    overflow: hidden;
+  }
+
+  /* tittelen blir kuttet hvis for langt i utgangspunktet */
+  .message-card__header-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    font: var(--header-x-small);
+    :is(span) {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .message-card__body {
+    font: var(--body-medium);
+  }
+
+  .message-card__close-btn {
+    border: none;
+    background: none;
+    width: 28px;
+    height: 28px;
+    font-size: unset;
+    background-color: unset;
+    color: inherit;
+    border-radius: 50%;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* brukes når man lukker kortet*/
+  .message-card-remove {
+    opacity: 0;
+  }
+
+  nve-icon::part(icon) {
+    display: unset;
+    font-size: 24px;
+  }
+
+  /** Varianter */
+
+  .message-card--neutral {
+    background: var(--neutrals-background-primary, #fff);
+    .message-card__close-btn:hover {
+      background-color: var(--button-hover);
+    }
+  }
+
+  .message-card--danger {
+    background: var(--feedback-background-default-error);
+    .message-card__close-btn:hover {
+      background-color: var(--button-hover);
+    }
+  }
+
+  .message-card--warning {
+    background: var(--feedback-background-default-warning);
+    .message-card__close-btn:hover {
+      background-color: var(--button-hover);
+    }
+  }
+
+  .message-card--success {
+    background: var(--feedback-background-default-success);
+    .message-card__close-btn:hover {
+      background-color: var(--button-hover);
+    }
+  }
+
+  .message-card--primary {
+    background: var(--feedback-background-subtle-info);
+    .message-card__close-btn:hover {
+      background-color: var(--button-hover);
+    }
+  }
+
+  /** Sterkere farger */
+
+  :host([emphasized]) .message-card--neutral {
+    background: var(--neutrals-background-secondary);
+    .message-card__close-btn:hover {
+      background-color: var(--button-hover);
+    }
+  }
+
+  :host([emphasized]) .message-card--danger {
+    color: var(--feedback-foreground-emphasized-error);
+    background: var(--feedback-background-emphasized-error);
+    .message-card__close-btn:hover {
+      background-color: var(--feedback-background-default-error);
+      color: var(--neutrals-foreground-primary);
+    }
+  }
+
+  :host([emphasized]) .message-card--warning {
+    color: var(--feedback-foreground-emphasized-warning);
+    background: var(--feedback-background-emphasized-warning);
+    .message-card__close-btn:hover {
+      background-color: var(--feedback-background-default-warning);
+    }
+  }
+
+  :host([emphasized]) .message-card--success {
+    color: var(--feedback-foreground-emphasized-success);
+    background: var(--feedback-background-emphasized-success);
+    .message-card__close-btn:hover {
+      background-color: var(--feedback-background-default-success);
+      color: var(--neutrals-foreground-primary);
+    }
+  }
+
+  :host([emphasized]) .message-card--primary {
+    color: var(--feedback-foreground-emphasized-info);
+    background: var(--feedback-background-emphasized-info);
+    .message-card__close-btn:hover {
+      background-color: var(--button-hover);
+    }
+  }
+
+  /** Størrelser */
+
+  :host([size='compact']) .message-card,
+  :host([size='simple']) .message-card {
+    padding: var(--spacing-small);
+    gap: var(--spacing-x-small);
+  }
+
+  :host([size='simple']) .message-card__header-title {
+    font: var(--label-small-light);
+  }
+
+  :host([size='simple']) nve-icon::part(icon) {
+    font-size: 20px;
+  }
+`;


### PR DESCRIPTION
Message-card ligner på alert men det er ikke det samme. message-card skal brukes som en lengre boks med teksten for  å gi brukere ekstra info i skjemaer f.eks. Jeg lagde den fordi vi skal bruke den i ds dokumentasjonen som tips, varsel bokser. 

CodeExamplePreview.vue ble endret til å bruke iife for å kjøre scripter. Grunnen er at når man kjører en script i global scopet lagrer variabler, og når man går til en annen side og kommer tilbake den klager at variabler allerede ble definert. Iife gjør at scopet er lokalt, og den blir ødelagt når vi bytter siden (du kan sjekke problemet i nve-alert f.eks der vi bruker en script for å lukke alerten). 

ComponentMethods begrenser nå visning av private og lit sine lifecycle metoder. Vi trenger ikke å vise dem.

Message-card lukk knappen gjør det automatisk at korter blir fjernet fra DOMen. Vi trenger ikke å beholde en gjemt komponent tenker jeg. Hvis vi mener at vi trenger å beholde den, vi kan alltid endre det. Samme anbefaler jeg å gjøre med alerten. Alert egentlig trenger å bli skrevet om til vår egen komponent uten å bruke shoelace. Grunnen er at teksten og tittelen brukes som :after og :before i cssen. Det gjør at man f.eks ikke kan selecte teksten i alerten og kopiere den. Alert komponent er veldig enkelt, og den vil ikke trenge så mye arbeid. 

Oppdaterte også et par sider, nå brukes nve-message-card i stedet for Card noen steder, også lagde ny variant på kode preview at den viser kun kode der det trengs (i stepper dok sida).