### PR TITLE
Fikser for hover og darkmode på farger

### DIFF
--- a/doc-site/components/nve-button.md
+++ b/doc-site/components/nve-button.md
@@ -15,14 +15,13 @@ layout: component
 ### Varianter
 
 Bruk `variant` for å velge farge. `default` er standard.
-`success` og `warning` skal ikke brukes.
+`success` og `warning` skal ikke brukes. Vi bruker heller ikke `outline`-attributt, men `neutral`-variant
 
 <CodeExamplePreview>
 
 ```html
-<nve-button>default</nve-button>
 <nve-button variant="primary">primary</nve-button>
-<nve-button variant="secondary">secondary</nve-button>
+<nve-button>default</nve-button>
 <nve-button variant="neutral">neutral</nve-button>
 <nve-button variant="text">text</nve-button>
 <nve-button variant="danger">danger</nve-button>

--- a/src/components/nve-button/nve-button.component.ts
+++ b/src/components/nve-button/nve-button.component.ts
@@ -9,14 +9,13 @@ import { INveComponent } from '@interfaces/NveComponent.interface';
  * Disse feltene skal ikke brukes: circle, caret og pill
  */
 @customElement('nve-button')
-export default class NveButton extends SlButton implements INveComponent{
+export default class NveButton extends SlButton implements INveComponent {
   constructor() {
     super();
   }
   static styles = [SlButton.styles, styles];
   @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'large';
-  @property({reflect: true, type: String}) testId: string = '';
-
+  @property({ reflect: true, type: String }) testId: string = '';
 }
 
 declare global {

--- a/src/components/nve-button/nve-button.styles.ts
+++ b/src/components/nve-button/nve-button.styles.ts
@@ -8,7 +8,7 @@ export default css`
     align-items: center;
     box-sizing: border-box;
     position: relative;
-    border:none;
+    border: none;
     min-width: 119px;
   }
 
@@ -103,57 +103,63 @@ export default css`
   }
 
   /* PRIMARY */
-  .button--standard.button--primary {
-    background-color:  var(--interactive-primary-background-default, #0D0D0E);
-    border-color: var(--interactive-primary-background-default);
+  :host([variant='primary']) .button--standard.button {
+    background-color: var(--interactive-primary-background-default);
     color: var(--interactive-primary-foreground-default);
+    border: none;
   }
-  .button--standard.button--primary:hover:not(.button--disabled),
-  .button--standard.button--primary:active:not(.button--disabled) {
-    border-color: var(--interactive-primary-background-hover);
-    background: var(--interactive-primary-background-hover, #3C3F44);
+  :host([variant='primary']) .button--standard.button:hover:not(.button--disabled),
+  :host([variant='primary']) .button--standard.button:active:not(.button--disabled) {
+    background: var(--interactive-primary-background-hover);
     color: var(--interactive-primary-foreground-default);
   }
 
-  /* SECONDARY */
-  .button--standard.button--default {
-    border-color: var(--interactive-secondary-background-default);
+  /* DEFAULT, aka SECONDARY */
+  :host:not([variant]) .button--standard.button,
+  :host([variant='secondary']) .button--standard.button,
+  :host([variant='default']) .button--standard.button {
     background: var(--interactive-secondary-background-default);
     color: var(--interactive-secondary-foreground-default);
-    border: none !important;
+    border: none;
   }
-  .button--standard.button--default:hover:not(.button--disabled) {
-    border-color: var(--interactive-secondary-background-hover);
+  :host:not([variant]) .button--standard.button:hover:not(.button--disabled),
+  :host([variant='secondary']) .button--standard.button:hover:not(.button--disabled),
+  :host([variant='default']) .button--standard.button:hover:not(.button--disabled) {
     background: var(--interactive-secondary-background-hover);
-    color: var(--sl-color-neutral-700);
+    color: var(--interactive-secondary-foreground-hover);
   }
 
-  /* GHOST */
-  .button--outline.button--neutral,
-  .button--standard.button--neutral {
+  /* TEXT aka GHOST */
+  :host([variant='text']) .button.button--standard,
+  :host([variant='ghost']) .button.button--standard {
     color: var(--interactive-ghost-foreground-default);
     background-color: transparent;
-  }
-  .button--standard.button--neutral {
     border-radius: var(--border-radius-small, 4px);
-    border: var(--border-width-default, 1px) solid  #878C94;
+    border: none;
   }
-  .button--standard.button--neutral:hover:not(.button--disabled) {
-    background-color: white;
+  :host([variant='text']) .button.button--standard:hover:not(.button--disabled),
+  :host([variant='ghost']) .button.button--standard:hover:not(.button--disabled) {
+    background-color: var(--interactive-ghost-background-hover);
     color: var(--interactive-ghost-foreground-hover);
   }
 
-  /* OUTLINE */
-  .button--outline.button--neutral,
-  .button--outline.button--neutral:active:not(.button--disabled) {
+  /* NEUTRAL, aka OUTLINE */
+  :host([variant='neutral']) .button.button--standard,
+  :host([variant='outline']) .button.button--standard,
+  :host([outline]) .button.button {
     color: var(--interactive-outlined-foreground-default);
     border-color: var(--interactive-outlined-border-default);
+    border-width: var(--border-width-default);
+    border-style: solid;
     background-color: transparent;
   }
-  .button--outline.button--neutral:hover:not(.button--disabled),
-  .button--outline.button--neutral.button--checked:not(.button--disabled) {
+  :host([variant='neutral']) .button.button--standard:hover:not(.button--disabled),
+  :host([variant='outline']) .button.button--standard:hover:not(.button--disabled),
+  :host([outline]) .button.button:hover:not(.button--disabled) {
     border-color: var(--interactive-outlined-border-hover);
-    color: var(--interactive-outlined-foreground-default); 
+    color: var(--interactive-outlined-foreground-hover);
+    border-width: var(--border-width-default);
+    border-style: solid;
     background-color: transparent;
   }
 


### PR DESCRIPTION
Endret en del på hvordan vi setter farge på knappene. Bruker nå [variant]-attributten på host istedenfor SL-klassene, det gir bedre muligheter

"Secondary" i dokumentasjonen er tatt bort, det er "default" som skal brukes
Siden vi nå bruker [variant]-selector så har jeg da også lagt til mulighet i css til å bruke <nve-button variant="ghost" /> (samme secondary og outline som variant) siden det er det designsystemet vel bruker.

Merk at vi ikke får overskrevet mulige varianter i shoelace, de er hardkodet som
    variant: 'default' | 'primary' | 'success' | 'neutral' | 'warning' | 'danger' | 'text';