### PR TITLE
feat(nve-icon-button): Added new component

### DIFF
--- a/doc-site/components/nve-button.md
+++ b/doc-site/components/nve-button.md
@@ -69,7 +69,7 @@ Bruk `loading` for å legge til ei snurre.
 
 ### Kun ikon
 
-Knapper med kun ikon i prefix eller suffix kan også brukes:
+Knapper med kun ikon i prefix eller suffix kan også brukes. Det finnes en dedikert [nve-icon-button](./nve-icon-button) komponent som kan passe bedre til din behov.
 
 <CodeExamplePreview>
 

--- a/doc-site/components/nve-icon-button.md
+++ b/doc-site/components/nve-icon-button.md
@@ -1,0 +1,85 @@
+---
+layout: component
+---
+
+<CodeExamplePreview>
+
+```html
+<nve-icon-button iconName="more_vert" label="åpner meny"> </nve-icon-button>
+```
+
+</CodeExamplePreview>
+
+<nve-message-card variant="warning" title="Obs!"> 
+<span>Vær oppmerksom på at <b>label</b>-egenskapen ikke er obligatorisk, men den bør brukes for å sikre en optimal tilgjengelighetserfaring.
+Den bør inneholde en kort beskrivelse av hva knappen gjør.</span>
+</nve-message-card>
+
+## Eksempler
+
+### Variant
+
+Bruk `variant` for å velge farge. `default` er standard.
+
+<CodeExamplePreview>
+
+```html
+<nve-icon-button iconName="more_vert"></nve-icon-button>
+<nve-icon-button variant="primary" iconName="more_vert"></nve-icon-button>
+<nve-icon-button variant="neutral" iconName="more_vert"></nve-icon-button>
+<nve-icon-button variant="text" iconName="more_vert"></nve-icon-button>
+<nve-icon-button variant="danger" iconName="more_vert"></nve-icon-button>
+```
+
+</CodeExamplePreview>
+
+### Rund knapp
+
+Bruk `circle` hvis du vil ha en rund knapp.
+
+<CodeExamplePreview>
+
+```html
+<nve-icon-button circle iconName="more_vert"></nve-icon-button>
+<nve-icon-button circle loading iconName="more_vert"></nve-icon-button>
+```
+
+</CodeExamplePreview>
+
+### Størrelse
+
+Bruk `size` for å endre størrelse. `large` er standard.
+
+<CodeExamplePreview>
+
+```html
+<nve-icon-button iconName="more_vert" size="small"></nve-icon-button>
+<nve-icon-button iconName="more_vert" size="medium"></nve-icon-button>
+<nve-icon-button iconName="more_vert"></nve-icon-button>
+```
+
+</CodeExamplePreview>
+
+### Disabled
+
+Bruk `disabled` for å deaktivere knappen.
+
+<CodeExamplePreview>
+
+```html
+<nve-icon-button disabled iconName="more_vert"></nve-icon-button>
+```
+
+</CodeExamplePreview>
+
+### Loading
+
+Bruk `loading` for å vise spinner. Alle andre ikon navn blir ignorert når loading er med.
+
+<CodeExamplePreview>
+
+```html
+<nve-icon-button loading iconName="more_vert"></nve-icon-button>
+```
+
+</CodeExamplePreview>

--- a/scripts/createNewComponent.js
+++ b/scripts/createNewComponent.js
@@ -38,7 +38,7 @@ const createComponentFile = () => {
   @customElement('${componentName}')
   export default class ${className} extends LitElement implements INveComponent {
 
-  @property({reflect: true, type: String}) testId: string = '';
+  @property({reflect: true, type: String}) testId: string | undefined = undefined;
 
   static styles = [styles];
 

--- a/src/components/nve-button/nve-button.component.ts
+++ b/src/components/nve-button/nve-button.component.ts
@@ -15,7 +15,7 @@ export default class NveButton extends SlButton implements INveComponent {
   }
   static styles = [SlButton.styles, styles];
   @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'large';
-  @property({ reflect: true, type: String }) testId: string = '';
+  @property({ reflect: true, type: String }) testId: string | undefined = undefined;
 }
 
 declare global {

--- a/src/components/nve-button/nve-button.styles.ts
+++ b/src/components/nve-button/nve-button.styles.ts
@@ -9,6 +9,8 @@ export default css`
     box-sizing: border-box;
     position: relative;
     border: none;
+    min-width: 48px;
+    transition: background-color 0.3s ease;
   }
 
   .button ::slotted(nve-badge) {
@@ -21,6 +23,7 @@ export default css`
 
   :host::part(spinner) {
     --track-color: none;
+    --track-width: 2.5px;
     position: relative;
     top: 0;
     left: 0;

--- a/src/components/nve-icon-button/nve-icon-button.component.ts
+++ b/src/components/nve-icon-button/nve-icon-button.component.ts
@@ -1,0 +1,53 @@
+import { html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { INveComponent } from '@interfaces/NveComponent.interface';
+import styles from './nve-icon-button.styles';
+import '../nve-icon/nve-icon.component';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import NveButton from '../nve-button/nve-button.component';
+
+/**
+ * Knapp som viser kun ikon. Den har de samme egenskapene som en vanlig nve-button.
+ *
+ * @dependency nve-icon
+ * @dependency nve-button
+ */
+@customElement('nve-icon-button')
+export default class NveIconButton extends NveButton implements INveComponent {
+  @property({ reflect: true, type: String }) testId: string | undefined = undefined;
+  /** Navnet på ikonet som skal vises */
+  @property({ reflect: true, type: String }) iconName: string = '';
+  /** Den blir lest av hjelpemidler. Bruk den for optimal universell utforming og beskriv hva knappen gjør */
+  @property({ reflect: true, type: String }) label: string | undefined = undefined;
+  static styles = [styles];
+
+  constructor() {
+    super();
+  }
+
+  render() {
+    return html`
+      <nve-button
+        aria-label=${ifDefined(this.label ? this.label : undefined)}
+        loading=${ifDefined(this.loading ? true : undefined)}
+        disabled=${ifDefined(this.disabled ? true : undefined)}
+        size=${this.size}
+        variant=${this.variant}
+        testId=${ifDefined(this.testId ? this.testId : undefined)}
+      >
+        ${ifDefined(this.loading)
+          ? ''
+          : html`<nve-icon
+              testId=${ifDefined(this.testId ? 'icon-${this.testId}' : undefined)}
+              name=${this.iconName}
+            ></nve-icon>`}
+      </nve-button>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-icon-button': NveIconButton;
+  }
+}

--- a/src/components/nve-icon-button/nve-icon-button.styles.ts
+++ b/src/components/nve-icon-button/nve-icon-button.styles.ts
@@ -1,0 +1,30 @@
+import { css } from 'lit';
+
+export default css`
+  :host::part(base) {
+    min-width: 0;
+    padding: 0px var(--spacing-small);
+    gap: 0;
+  }
+
+  :host::part(spinner) {
+    margin-right: 0;
+    font-size: 24px;
+  }
+
+  :host([size='medium'])::part(base) {
+    padding: 0px var(--spacing-x-small);
+  }
+
+  :host([size='small'])::part(base) {
+    padding: 0px var(--spacing-xx-small, 4px);
+  }
+
+  :host([size='small']) ::slotted(nve-icon) {
+    font-size: 24px;
+  }
+
+  :host([circle])::part(base) {
+    border-radius: 50%;
+  }
+`;

--- a/src/interfaces/NveComponent.interface.ts
+++ b/src/interfaces/NveComponent.interface.ts
@@ -1,11 +1,11 @@
 /**
- * Interface som alle komponenter må ha før de deler felles funksjonalitet. 
+ * Interface som alle komponenter må ha før de deler felles funksjonalitet.
  * INveComponent
  */
 export interface INveComponent {
-    /**
-   * En unik identifikator for testformål. 
-   * Standardverdien er en tom streng, men du kan angi id-en til komponenten med for eksempel testId="example_id"
+  /**
+   * En unik identifikator for testformål.
+   * Standardverdien er undefined (så at den ikke vises i DOMen hvis man ikke skal bruke den), men du kan angi id-en til komponenten med for eksempel testId="example_id"
    */
-    testId:string;
+  testId: string | undefined;
 }


### PR DESCRIPTION
Ny komponent nve-icon-button. Den arver fra nve-button, men kun viser ikonen. 

Måtte bruke iconName siden name property allerede eksisterer på knappen, og jeg ville ikke overskrive den

Jeg måtte justere selve nve-button litt fordi det var en del endringer som påvirket hvordan icon knapp vises. 
F.eks størrelse på ikonen skal alltid være 24px. Før `small`hadde ikon med 20px. 

Jeg la til transisjon på nve-button også, den burde være 0.3s. Per i dag er det shoelace sin transisjon som varer 0.5ms. 