### PR TITLE
Gjort bedre plass til beskrivelse i egenskaps-tabell

### DIFF
--- a/doc-site/.vitepress/theme/components/apidoc/ComponentFields.vue
+++ b/doc-site/.vitepress/theme/components/apidoc/ComponentFields.vue
@@ -10,24 +10,24 @@
   <table>
     <tr>
       <td>Navn</td>
-      <td>
-        <a href="https://lit.dev/docs/components/properties/#reflected-attributes" target="_blank">A</a>
-      </td>
       <td>Type</td>
       <td>Arvet fra</td>
       <td>Beskrivelse</td>
+      <td>
+        <a href="https://lit.dev/docs/components/properties/#reflected-attributes" target="_blank">A</a>
+      </td>
     </tr>
     <tr v-for="field in fields" :key="field.name">
       <td>{{ field.name }}</td>
-      <td>
-        <nve-icon v-if="field.reflects" name="Check" />
-      </td>
       <td>
         {{ field.type?.text }}
         <span v-if="field.default"> = {{ field.default }}</span>
       </td>
       <td>{{ field.inheritedFrom?.name }}</td>
       <td>{{ field.description }}</td>
+      <td>
+        <nve-icon v-if="field.reflects" name="Check" />
+      </td>
     </tr>
   </table>
 </template>

--- a/doc-site/.vitepress/theme/components/apidoc/ComponentFields.vue
+++ b/doc-site/.vitepress/theme/components/apidoc/ComponentFields.vue
@@ -10,9 +10,10 @@
   <table>
     <tr>
       <td>Navn</td>
-      <td>Attributt-synk</td>
+      <td>
+        <a href="https://lit.dev/docs/components/properties/#reflected-attributes" target="_blank">A</a>
+      </td>
       <td>Type</td>
-      <td>Standardverdi</td>
       <td>Arvet fra</td>
       <td>Beskrivelse</td>
     </tr>
@@ -21,8 +22,10 @@
       <td>
         <nve-icon v-if="field.reflects" name="Check" />
       </td>
-      <td>{{ field.type?.text }}</td>
-      <td>{{ field.default }}</td>
+      <td>
+        {{ field.type?.text }}
+        <span v-if="field.default"> = {{ field.default }}</span>
+      </td>
       <td>{{ field.inheritedFrom?.name }}</td>
       <td>{{ field.description }}</td>
     </tr>


### PR DESCRIPTION
Her er et eksempel på at beskrivelses-kolonna blir kutta:
https://designsystem.nve.no/components/nve-button.html#egenskaper

Har gjort noen små-endringer for å gi bedre plass til beskrivelses-kolonna:

- Redusert bredde på attributtsynk-kolonna ved å endre overskrit til "A". Har heller lagt inn en link til hva "A" betyr
- Flytta attributtsynk-kolonna lengst til høyre
- Slått sammen type- og standard-verdi-kolonnene til en kolonne med dette formatet: `<type> = <standardverdi>`

Sånn ser det ut nå:
![image](https://github.com/user-attachments/assets/b3cd80ec-c5cc-4857-bcd5-78d8d9cf95ec)
