### PR TITLE
Endre "low" og "emphasized"-attributter. Gjelder nve-badge, nve-message-card og nve-alert

### DIFF
--- a/doc-site/components/nve-alert.md
+++ b/doc-site/components/nve-alert.md
@@ -65,14 +65,43 @@ Bruk `leftstroke` for å vise en fet strek på venstre side.
 
 ### Emphasized
 
-Bruk `emphasized` for å få litt mørkere bakgrunnsfarge.
+Bruk `saturation="emphasized"` for å få litt mørkere bakgrunnsfarge.
 
 <CodeExamplePreview arrangeComponentsVertically>
 
 ```html
-<nve-alert variant="warning" text="Emphasized" emphasized open> </nve-alert>
-
-<nve-alert variant="warning" text="Ikke emphasized" open> </nve-alert>
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem">
+  <nve-alert variant="warning" text="Emphasized" saturation="emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert variant="warning" text="Ikke emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert variant="success" text="Emphasized" saturation="emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert variant="success" text="Ikke emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert variant="neutral" text="Emphasized" saturation="emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert variant="neutral" text="Ikke emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert variant="danger" text="Emphasized" saturation="emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert variant="danger" text="Ikke emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert text="Emphasized" saturation="emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+  <nve-alert text="Ikke emphasized" open>
+    <nve-icon slot="icon" name="info"></nve-icon>
+  </nve-alert>
+</div>
 ```
 
 </CodeExamplePreview>

--- a/doc-site/components/nve-badge.md
+++ b/doc-site/components/nve-badge.md
@@ -45,7 +45,7 @@ Bruk `size` for å velge størrelse. `medium` er standard.
 
 ### Low
 
-Bruk `saturation="low"` for lysere bakgrunnsfarge. Teksten vil også skifte farge.
+Bruk `saturation="subtle"` for lysere bakgrunnsfarge. Teksten vil også skifte farge.
 
 <CodeExamplePreview>
 
@@ -53,12 +53,12 @@ Bruk `saturation="low"` for lysere bakgrunnsfarge. Teksten vil også skifte farg
 <dl>
   <dt>lav metning</dt>
   <dd>
-    <nve-badge saturation="low">primary</nve-badge>
-    <nve-badge saturation="low" variant="neutral">neutral</nve-badge>
-    <nve-badge saturation="low" variant="success">success</nve-badge>
-    <nve-badge saturation="low" variant="warning">warning</nve-badge>
-    <nve-badge saturation="low" variant="danger">danger</nve-badge>
-    <nve-badge saturation="low" variant="brand">brand</nve-badge>
+    <nve-badge saturation="subtle">primary</nve-badge>
+    <nve-badge saturation="subtle" variant="neutral">neutral</nve-badge>
+    <nve-badge saturation="subtle" variant="success">success</nve-badge>
+    <nve-badge saturation="subtle" variant="warning">warning</nve-badge>
+    <nve-badge saturation="subtle" variant="danger">danger</nve-badge>
+    <nve-badge saturation="subtle" variant="brand">brand</nve-badge>
   </dd>
   <dt>vanlig</dt>
   <dd>

--- a/doc-site/components/nve-badge.md
+++ b/doc-site/components/nve-badge.md
@@ -45,20 +45,20 @@ Bruk `size` for å velge størrelse. `medium` er standard.
 
 ### Low
 
-Bruk `low` for lysere bakgrunnsfarge. Teksten blir da svart for alle varianter.
+Bruk `saturation="low"` for lysere bakgrunnsfarge. Teksten vil også skifte farge.
 
 <CodeExamplePreview>
 
 ```html
 <dl>
-  <dt>low</dt>
+  <dt>lav metning</dt>
   <dd>
-    <nve-badge low>primary</nve-badge>
-    <nve-badge low variant="neutral">neutral</nve-badge>
-    <nve-badge low variant="success">success</nve-badge>
-    <nve-badge low variant="warning">warning</nve-badge>
-    <nve-badge low variant="danger">danger</nve-badge>
-    <nve-badge low variant="brand">brand</nve-badge>
+    <nve-badge saturation="low">primary</nve-badge>
+    <nve-badge saturation="low" variant="neutral">neutral</nve-badge>
+    <nve-badge saturation="low" variant="success">success</nve-badge>
+    <nve-badge saturation="low" variant="warning">warning</nve-badge>
+    <nve-badge saturation="low" variant="danger">danger</nve-badge>
+    <nve-badge saturation="low" variant="brand">brand</nve-badge>
   </dd>
   <dt>vanlig</dt>
   <dd>

--- a/doc-site/components/nve-message-card.md
+++ b/doc-site/components/nve-message-card.md
@@ -57,16 +57,16 @@ Forskjellen mellom `compact` og `simple` er at `simple` viser kun tittel og ikon
 
 ### Emphasized
 
-Bruk `emphasized` for å vise sterkere bakgrunnsfarge.
+Bruk `saturation="emphasized"` for å vise sterkere bakgrunnsfarge.
 
 <CodeExamplePreview>
 
 ```html
-<nve-message-card emphasized title="Tittel">Primary</nve-message-card>
-<nve-message-card emphasized variant="neutral" title="Tittel">Neutral</nve-message-card>
-<nve-message-card emphasized variant="warning" title="Tittel">Warning</nve-message-card>
-<nve-message-card emphasized variant="danger" title="Tittel">Danger</nve-message-card>
-<nve-message-card emphasized variant="success" title="Tittel">Success</nve-message-card>
+<nve-message-card saturation="emphasized" title="Tittel">Primary</nve-message-card>
+<nve-message-card saturation="emphasized" variant="neutral" title="Tittel">Neutral</nve-message-card>
+<nve-message-card saturation="emphasized" variant="warning" title="Tittel">Warning</nve-message-card>
+<nve-message-card saturation="emphasized" variant="danger" title="Tittel">Danger</nve-message-card>
+<nve-message-card saturation="emphasized" variant="success" title="Tittel">Success</nve-message-card>
 ```
 
 </CodeExamplePreview>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MIT",
   "homepage": "https://github.com/NVE/Designsystem/",
-  "version": "0.1.87",
+  "version": "0.2.1",
   "customElements": "custom-elements.json",
   "exports": {
     ".": {

--- a/src/components/nve-alert/nve-alert.component.ts
+++ b/src/components/nve-alert/nve-alert.component.ts
@@ -1,6 +1,7 @@
 import SlAlert from '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import styles from './nve-alert.styles';
 import { customElement, property } from 'lit/decorators.js';
+import { PropertyValues } from 'lit';
 
 /**
  * Brukes til å vise viktige beskjeder enten på en side eller som en enkel popup.
@@ -18,7 +19,7 @@ export default class NveAlert extends SlAlert {
   /** Tynnere beskrivelse tekst */
   @property({ reflect: true }) text: string = '';
   /** Bestemmer sterkere bakgrunnsfarge */
-  @property({ type: Boolean, reflect: true }) emphasized: boolean = false;
+  @property({ type: String, reflect: false }) saturation: 'emphasized' | null = null;
   /** Ramme linje til venstre  */
   @property({ type: Boolean, reflect: true }) leftStroke: boolean = false;
 
@@ -27,7 +28,7 @@ export default class NveAlert extends SlAlert {
     styles,
   ];
 
-  updated(changedProperties: any) {
+  updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
     if (changedProperties.has('title')) {
       this.style.setProperty('--nve-alert-title', `"${this.title}"`);

--- a/src/components/nve-alert/nve-alert.styles.ts
+++ b/src/components/nve-alert/nve-alert.styles.ts
@@ -93,7 +93,7 @@ export default css`
 
   /* emphasized */
   :host([variant='neutral']) .alert,
-  :host([emphasized]) .alert {
+  :host([saturation='emphasized']) .alert {
     color: var(--interactive-primary-foreground-default);
     .alert__icon {
       color: var(--interactive-primary-foreground-default) !important;
@@ -102,7 +102,7 @@ export default css`
       stroke: var(--interactive-primary-foreground-default) !important;
     }
   }
-  :host([emphasized][variant='warning']) .alert {
+  :host([saturation='emphasized'][variant='warning']) .alert {
     color: var(--feedback-foreground-default-warning);
     .alert__icon {
       color: var(--feedback-foreground-default-warning) !important;
@@ -111,40 +111,40 @@ export default css`
       stroke: var(--feedback-foreground-default-warning) !important;
     }
   }
-  :host([emphasized]) .alert--primary {
+  :host([saturation='emphasized']) .alert--primary {
     background-color: var(--feedback-background-emphasized-info);
     & sl-icon-button::part(base):hover {
       background: var(--feedback-background-subtle-info);
       stroke: var(--feedback-background-emphasized-info) !important;
     }
   }
-  :host([emphasized]) .alert--danger {
+  :host([saturation='emphasized']) .alert--danger {
     background-color: var(--feedback-background-emphasized-error);
     & sl-icon-button::part(base):hover {
       background: var(--feedback-background-subtle-error);
       stroke: var(--feedback-background-emphasized-error) !important;
     }
   }
-  :host([emphasized]) .alert--success {
+  :host([saturation='emphasized']) .alert--success {
     background-color: var(--feedback-background-emphasized-success);
     & sl-icon-button::part(base):hover {
       background: var(--feedback-background-subtle-success);
       stroke: var(--feedback-background-emphasized-success) !important;
     }
   }
-  :host([emphasized]) .alert--neutral {
+  :host([saturation='emphasized']) .alert--neutral {
     background-color: var(--neutrals-foreground-primary);
     & sl-icon-button::part(base):hover {
       background: var(--feedback-background-subtle-neutral, #f7f7f8);
       stroke: var(--neutrals-foreground-primary) !important;
     }
   }
-  :host([emphasized]) .alert--warning {
+  :host([saturation='emphasized']) .alert--warning {
     background-color: var(--feedback-background-emphasized-warning);
   }
 
   /* leftStroke */
-  :host([leftStroke][emphasized]) .alert,
+  :host([leftStroke][saturation='emphasized']) .alert,
   :host([leftStroke]) .alert {
     border-left: 6px solid;
   }
@@ -165,19 +165,19 @@ export default css`
   }
 
   /* leftStroke and emphasized */
-  :host([leftStroke][emphasized]) .alert--primary {
+  :host([leftStroke][saturation='emphasized']) .alert--primary {
     border-color: var(--feedback-background-default-info);
   }
-  :host([leftStroke][emphasized]) .alert--danger {
+  :host([leftStroke][saturation='emphasized']) .alert--danger {
     border-color: var(--feedback-background-default-error);
   }
-  :host([leftStroke][emphasized]) .alert--success {
+  :host([leftStroke][saturation='emphasized']) .alert--success {
     border-color: var(--feedback-background-subtle-success);
   }
-  :host([leftStroke][emphasized]) .alert--neutral {
+  :host([leftStroke][saturation='emphasized']) .alert--neutral {
     border-color: var(--neutrals-foreground-subtle);
   }
-  :host([leftStroke][emphasized]) .alert--warning {
+  :host([leftStroke][saturation='emphasized']) .alert--warning {
     border-color: var(--feedback-background-default-warning);
   }
 `;

--- a/src/components/nve-badge/nve-badge.component.ts
+++ b/src/components/nve-badge/nve-badge.component.ts
@@ -22,25 +22,25 @@ export default class NveBadge extends LitElement {
     | 'brand' = 'primary';
   /** Størrelse på komponenten */
   @property({ type: String, reflect: true }) size: 'small' | 'medium' | 'large' = 'medium';
-  /** Viser Low variant, High er default */
-  @property({ type: Boolean, reflect: true }) low = false;
+  /** Viser lav metning, default er at denne ikke er satt */
+  @property({ type: String, reflect: false }) saturation: 'low' | null = null;
   render() {
     return html`
       <span
         part="base"
         class=${classMap({
-      badge: true,
-      'badge--primary': this.variant === 'primary',
-      'badge--success': this.variant === 'success',
-      'badge--neutral': this.variant === 'neutral',
-      'badge--warning': this.variant === 'warning',
-      'badge--danger': this.variant === 'danger',
-      'badge--brand': this.variant === 'brand',
-      'badge--small': this.size === 'small',
-      'badge--medium': this.size === 'medium',
-      'badge--large': this.size === 'large',
-      low: this.low,
-    })}
+          badge: true,
+          'badge--primary': this.variant === 'primary',
+          'badge--success': this.variant === 'success',
+          'badge--neutral': this.variant === 'neutral',
+          'badge--warning': this.variant === 'warning',
+          'badge--danger': this.variant === 'danger',
+          'badge--brand': this.variant === 'brand',
+          'badge--small': this.size === 'small',
+          'badge--medium': this.size === 'medium',
+          'badge--large': this.size === 'large',
+          'saturation--low': this.saturation === 'low',
+        })}
         role="status"
       >
         <slot></slot>

--- a/src/components/nve-badge/nve-badge.component.ts
+++ b/src/components/nve-badge/nve-badge.component.ts
@@ -23,7 +23,7 @@ export default class NveBadge extends LitElement {
   /** Størrelse på komponenten */
   @property({ type: String, reflect: true }) size: 'small' | 'medium' | 'large' = 'medium';
   /** Viser lav metning, default er at denne ikke er satt */
-  @property({ type: String, reflect: false }) saturation: 'low' | null = null;
+  @property({ type: String, reflect: false }) saturation: 'subtle' | null = null;
   render() {
     return html`
       <span
@@ -39,7 +39,7 @@ export default class NveBadge extends LitElement {
           'badge--small': this.size === 'small',
           'badge--medium': this.size === 'medium',
           'badge--large': this.size === 'large',
-          'saturation--low': this.saturation === 'low',
+          'saturation--subtle': this.saturation === 'subtle',
         })}
         role="status"
       >

--- a/src/components/nve-badge/nve-badge.styles.ts
+++ b/src/components/nve-badge/nve-badge.styles.ts
@@ -45,29 +45,29 @@ export default css`
   }
 
   /* Low modifiers */
-  .low {
+  .saturation--low {
     color: var(--neutrals-foreground-primary, #00131c);
   }
 
-  .badge--brand.low {
+  .badge--brand.saturation--low {
     background-color: var(--brand-light);
   }
 
-  .badge--neutral.low {
+  .badge--neutral.saturation--low {
     background-color: var(--feedback-background-subtle-neutral, #f7f7f8);
   }
 
-  .badge--primary.low {
+  .badge--primary.saturation--low {
     background-color: var(--feedback-background-default-info, #ceeaff);
   }
 
-  .badge--success.low {
+  .badge--success.saturation--low {
     background-color: var(--feedback-background-default-success, #cbf9cb);
   }
-  .badge--warning.low {
+  .badge--warning.saturation--low {
     background-color: var(--feedback-background-default-warning, #ffe8a5);
   }
-  .badge--danger.low {
+  .badge--danger.saturation--low {
     background-color: var(--feedback-background-default-error, #ffd8de);
   }
 

--- a/src/components/nve-badge/nve-badge.styles.ts
+++ b/src/components/nve-badge/nve-badge.styles.ts
@@ -45,29 +45,29 @@ export default css`
   }
 
   /* Low modifiers */
-  .saturation--low {
+  .saturation--subtle {
     color: var(--neutrals-foreground-primary, #00131c);
   }
 
-  .badge--brand.saturation--low {
+  .badge--brand.saturation--subtle {
     background-color: var(--brand-light);
   }
 
-  .badge--neutral.saturation--low {
+  .badge--neutral.saturation--subtle {
     background-color: var(--feedback-background-subtle-neutral, #f7f7f8);
   }
 
-  .badge--primary.saturation--low {
+  .badge--primary.saturation--subtle {
     background-color: var(--feedback-background-default-info, #ceeaff);
   }
 
-  .badge--success.saturation--low {
+  .badge--success.saturation--subtle {
     background-color: var(--feedback-background-default-success, #cbf9cb);
   }
-  .badge--warning.saturation--low {
+  .badge--warning.saturation--subtle {
     background-color: var(--feedback-background-default-warning, #ffe8a5);
   }
-  .badge--danger.saturation--low {
+  .badge--danger.saturation--subtle {
     background-color: var(--feedback-background-default-error, #ffd8de);
   }
 

--- a/src/components/nve-message-card/nve-message-card.component.ts
+++ b/src/components/nve-message-card/nve-message-card.component.ts
@@ -30,7 +30,7 @@ Brukes som veiledning i skjemaer eller som en informasjon til brukere.
 export default class NveMessageCard extends LitElement implements INveComponent {
   @property({ reflect: true, type: String }) testId: string = '';
   /** Bestemmer sterkere bakgrunnsfarge */
-  @property({ type: Boolean, reflect: true }) emphasized: boolean = false;
+  @property({ type: String, reflect: false }) saturation: 'emphasized' | null = null;
   /** Bestemmer om størrelsen */
   @property({ reflect: true }) size: 'default' | 'compact' | 'simple' = 'default';
   /** Bestemmer om kort skal vise lukk knappen i høyre hjørnet */

--- a/src/components/nve-message-card/nve-message-card.styles.ts
+++ b/src/components/nve-message-card/nve-message-card.styles.ts
@@ -117,14 +117,14 @@ export default css`
 
   /** Sterkere farger */
 
-  :host([emphasized]) .message-card--neutral {
+  :host([saturation='emphasized']) .message-card--neutral {
     background: var(--neutrals-background-secondary);
     .message-card__close-btn:hover {
       background-color: var(--button-hover);
     }
   }
 
-  :host([emphasized]) .message-card--danger {
+  :host([saturation='emphasized']) .message-card--danger {
     color: var(--feedback-foreground-emphasized-error);
     background: var(--feedback-background-emphasized-error);
     .message-card__close-btn:hover {
@@ -133,7 +133,7 @@ export default css`
     }
   }
 
-  :host([emphasized]) .message-card--warning {
+  :host([saturation='emphasized']) .message-card--warning {
     color: var(--feedback-foreground-emphasized-warning);
     background: var(--feedback-background-emphasized-warning);
     .message-card__close-btn:hover {
@@ -141,7 +141,7 @@ export default css`
     }
   }
 
-  :host([emphasized]) .message-card--success {
+  :host([saturation='emphasized']) .message-card--success {
     color: var(--feedback-foreground-emphasized-success);
     background: var(--feedback-background-emphasized-success);
     .message-card__close-btn:hover {
@@ -150,7 +150,7 @@ export default css`
     }
   }
 
-  :host([emphasized]) .message-card--primary {
+  :host([saturation='emphasized']) .message-card--primary {
     color: var(--feedback-foreground-emphasized-info);
     background: var(--feedback-background-emphasized-info);
     .message-card__close-btn:hover {


### PR DESCRIPTION
Skrev om:
"low" på nve-badge 
"emphasized" på nve-message-card
"emphasized" på nve-alert

til å bruke "saturation"-attributt istedenfor (med subtle/emphasized). 
Merk at vi også går bort fra "low" og bruker "subtle" istedenfor. Dette er fra Figma