### PR TITLE
Viser saker i Github merka med komponentnavn i komponentoversikten

### DIFF
--- a/doc-site/.vitepress/theme/components/CodeExamplePreview.vue
+++ b/doc-site/.vitepress/theme/components/CodeExamplePreview.vue
@@ -17,7 +17,7 @@ const scriptElements = ref<HTMLScriptElement[]>([]);
 
 withDefaults(
   defineProps<{
-    onlyCode: boolean;
+    onlyCode?: boolean;
   }>(),
   {
     onlyCode: false,

--- a/doc-site/.vitepress/theme/components/ComponentIssues.vue
+++ b/doc-site/.vitepress/theme/components/ComponentIssues.vue
@@ -1,8 +1,10 @@
 <!-- Viser alle saker i Github knytta til denne komponenten -->
 <template>
   <div v-if="showHeader">
-    <h2 id="issues">Feil / oppgaver / PR</h2>
-    <a class="header-anchor" href="#issues" aria-label='Permalink to "Issues"'>&ZeroWidthSpace;</a>
+    <h2 id="issues">
+      Feil / oppgaver / PR
+      <a class="header-anchor" href="#issues" aria-label='Permalink to "Issues"'>&ZeroWidthSpace;</a>
+    </h2>
   </div>
   <ul v-if="issues?.length > 0">
     <li v-for="issue of issues">

--- a/doc-site/.vitepress/theme/components/ComponentIssues.vue
+++ b/doc-site/.vitepress/theme/components/ComponentIssues.vue
@@ -1,0 +1,42 @@
+<!-- Viser alle saker i Github knytta til denne komponenten -->
+<template>
+  <div v-if="showHeader">
+    <h2 id="issues">Feil / oppgaver / PR</h2>
+    <a class="header-anchor" href="#issues" aria-label='Permalink to "Issues"'>&ZeroWidthSpace;</a>
+  </div>
+  <ul v-if="issues?.length > 0">
+    <li v-for="issue of issues">
+      <a :href="issue.url" target="_blank">{{ issue.title }} <span v-if="issue.isPullRequest"> (PR) </span></a>
+    </li>
+  </ul>
+  <p v-else v-if="showHeader">
+    Ingen som vi vet om. Hvis du finner noe muffens, registrer en feil under
+    <a href="https://github.com/NVE/Designsystem/issues" target="_blank">Issues i Github</a> og merk den med
+    <span class="code">{{ componentName }}</span
+    >.
+  </p>
+</template>
+
+<script setup lang="ts">
+import { computed, defineProps } from 'vue';
+import githubStore from '../github.store';
+
+const props = defineProps<{
+  componentName: string;
+  showHeader?: boolean;
+}>();
+
+const issues = computed(() => githubStore.issuesForComponent(props.componentName));
+</script>
+
+<style scoped>
+ul {
+  margin: 0;
+}
+
+.code {
+  background-color: #f0f0f0;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+</style>

--- a/doc-site/.vitepress/theme/components/ComponentLayout.vue
+++ b/doc-site/.vitepress/theme/components/ComponentLayout.vue
@@ -2,6 +2,7 @@
 <script setup lang="ts">
 import { useRoute } from 'vitepress';
 import { computed } from 'vue';
+import ComponentIssues from './ComponentIssues.vue';
 import ComponentEvents from './apidoc/ComponentEvents.vue';
 import ComponentFields from './apidoc/ComponentFields.vue';
 import ComponentMethods from './apidoc/ComponentMethods.vue';
@@ -48,6 +49,9 @@ const componentName = computed(() => {
             <div class="vp-doc">
               <h1 style="margin-bottom: 32px">{{ componentName }}</h1>
               <ComponentDescription :componentName="componentName" />
+
+              <ComponentIssues :componentName="componentName" showHeader />
+              <p>&nbsp;</p>
 
               <Content />
 

--- a/doc-site/.vitepress/theme/components/ComponentOverview.vue
+++ b/doc-site/.vitepress/theme/components/ComponentOverview.vue
@@ -27,16 +27,16 @@
               Status er satt til ferdig, men komponenten finnes ikke
             </div>
             <div v-else>
-              <nve-badge :variant="getBadgeVariant(component.statusCode)" low>
+              <nve-tag :variant="getBadgeVariant(component.statusCode)" size="small">
                 {{ component.statusCode }}
-              </nve-badge>
+              </nve-tag>
             </div>
           </td>
           <td>
             <span class="status-design-container">
-              <nve-badge :variant="getBadgeVariant(component.statusDesign)" low>
+              <nve-tag :variant="getBadgeVariant(component.statusDesign)" size="small">
                 {{ component.statusDesign }}
-              </nve-badge>
+              </nve-tag>
               <a
                 v-if="component.nodeId"
                 title="Åpne i Figma"
@@ -61,69 +61,40 @@
       </tbody>
       <tfoot>
         <tr>
-          <td>Antall planlagte komponenter: {{ componentStatuses.length }}</td>
-          <td>
-            <!-- Antall komponenter i biblioteket per status -->
-            <nve-badge variant="success" low
-              >Ferdig: {{ componentStatuses.filter((status) => status.statusCode === 'Ferdig').length }}</nve-badge
-            >
-            <br />
-            <nve-badge variant="warning" low
-              >Under arbeid:
-              {{ componentStatuses.filter((status) => status.statusCode === 'Under arbeid').length }}</nve-badge
-            >
-            <br />
-            <nve-badge variant="neutral" low
-              >Skal revideres / under revidering:
-              {{
-                componentStatuses.filter(
-                  (status) => status.statusCode === 'Skal revideres' || status.statusCode === 'Revideres'
-                ).length
-              }}</nve-badge
-            >
-            <br />
-            <nve-badge variant="brand" low
-              >Trenger kvalitetssjekk:
-              {{
-                componentStatuses.filter((status) => status.statusCode === 'Trenger kvalitetssjekk').length
-              }}</nve-badge
-            >
-            <br />
-            <nve-badge variant="brand" low
-              >Ukjent: {{ componentStatuses.filter((status) => status.statusCode == null).length }}</nve-badge
-            >
-          </td>
-          <td>
-            <!-- Antall komponenter i Figma per status -->
-            <nve-badge variant="success" low
-              >Ferdig: {{ componentStatuses.filter((status) => status.statusDesign === 'Ferdig').length }}</nve-badge
-            >
-            <br />
-            <nve-badge variant="warning" low
-              >Under arbeid:
-              {{ componentStatuses.filter((status) => status.statusDesign === 'Under arbeid').length }}</nve-badge
-            >
-            <br />
-            <nve-badge variant="neutral" low
-              >Skal revideres / under revidering:
-              {{
-                componentStatuses.filter(
-                  (status) => status.statusDesign === 'Skal revideres' || status.statusDesign === 'Revideres'
-                ).length
-              }}</nve-badge
-            >
-            <br />
-            <nve-badge variant="brand" low
-              >Trenger kvalitetssjekk:
-              {{
-                componentStatuses.filter((status) => status.statusDesign === 'Trenger kvalitetssjekk').length
-              }}</nve-badge
-            >
-            <br />
-            <nve-badge variant="brand" low
-              >Ukjent: {{ componentStatuses.filter((status) => status.statusDesign == null).length }}</nve-badge
-            >
-          </td>
+          <th rowspan="7">Antall komponenter</th>
+          <td>{{ codeStatusCount('Ferdig') }}</td>
+          <td>{{ designStatusCount('Ferdig') }}</td>
+          <td><nve-tag variant="success" size="small">Ferdig</nve-tag></td>
+        </tr>
+        <tr>
+          <td>{{ codeStatusCount('Under arbeid') }}</td>
+          <td>{{ designStatusCount('Under arbeid') }}</td>
+          <td><nve-tag variant="warning" size="small">Under arbeid</nve-tag></td>
+        </tr>
+        <tr>
+          <td>{{ codeStatusCount('Ikke påbegynt') }}</td>
+          <td>{{ designStatusCount('Ikke påbegynt') }}</td>
+          <td><nve-tag variant="info" size="small">Ikke påbegynt</nve-tag></td>
+        </tr>
+        <tr>
+          <td>{{ codeStatusCount('Skal revideres') }}</td>
+          <td>{{ designStatusCount('Skal revideres') }}</td>
+          <td><nve-tag variant="neutral" size="small">Skal revideres</nve-tag></td>
+        </tr>
+        <tr>
+          <td>{{ codeStatusCount('Revideres') }}</td>
+          <td>{{ designStatusCount('Revideres') }}</td>
+          <td><nve-tag variant="neutral" size="small">Revideres</nve-tag></td>
+        </tr>
+        <tr>
+          <td>{{ codeStatusCount('Trenger kvalitetssjekk') }}</td>
+          <td>{{ designStatusCount('Trenger kvalitetssjekk') }}</td>
+          <td><nve-tag variant="error" size="small">Trenger kvalitetssjekk</nve-tag></td>
+        </tr>
+        <tr>
+          <td>{{ componentStatuses.filter((s) => s.statusCode !== undefined).length }}</td>
+          <td>{{ componentStatuses.filter((s) => s.statusDesign !== undefined).length }}</td>
+          <td><nve-tag variant="neutral" size="small">Alle planlagte</nve-tag></td>
         </tr>
       </tfoot>
     </table>
@@ -153,9 +124,11 @@ interface ComponentStatus {
   statusCode: string;
 }
 
-defineProps<{
+const props = defineProps<{
   componentStatuses: ComponentStatus[];
 }>();
+
+props.componentStatuses.sort((a, b) => a.name.localeCompare(b.name));
 
 const linkToFigmaComponent = (figmaId: string) => {
   return `https://www.figma.com/file/0eXhyUrUF7fWi1VaphfpEu/04---%E2%9D%96-Komponenter?node-id=${figmaId}`;
@@ -163,6 +136,14 @@ const linkToFigmaComponent = (figmaId: string) => {
 
 const isComponent = (name: string): boolean => {
   return componentNames.value.some((component) => component === name);
+};
+
+const codeStatusCount = (status: string | null): number => {
+  return props.componentStatuses.filter((s) => s.statusCode == status).length;
+};
+
+const designStatusCount = (status: string | null): number => {
+  return props.componentStatuses.filter((s) => s.statusDesign == status).length;
 };
 
 const issues = ref<Map<string, Issue[]>>(new Map<string, Issue[]>());
@@ -180,14 +161,14 @@ const getBadgeVariant = (status: string) => {
     case 'Ferdig':
       return 'success';
     case 'Ikke påbegynt':
-      return 'primary';
+      return 'info';
     case 'Revideres':
     case 'Skal revideres':
       return 'neutral';
     case 'Under arbeid':
       return 'warning';
     case 'Trenger kvalitetssjekk':
-      return 'brand';
+      return 'error';
     default:
       return '';
   }
@@ -231,6 +212,10 @@ th {
 .dark td {
   background-color: black;
   color: white;
+}
+
+tfoot > tr > td {
+  text-align: right;
 }
 
 .status {

--- a/doc-site/.vitepress/theme/components/ComponentOverview.vue
+++ b/doc-site/.vitepress/theme/components/ComponentOverview.vue
@@ -17,7 +17,7 @@
         <tr>
           <th>Komponent</th>
           <th>Status kode</th>
-          <th>Status design</th>
+          <th colspan="2">Status design</th>
           <th>Feil / oppgaver / PR</th>
         </tr>
       </thead>
@@ -37,21 +37,21 @@
               </nve-tag>
             </div>
           </td>
-          <td>
-            <span class="status-design-container">
-              <nve-tag :variant="getBadgeVariant(component.statusDesign)" size="small">
-                {{ component.statusDesign }}
-              </nve-tag>
-              <a
-                v-if="component.nodeId"
-                title="Åpne i Figma"
-                :href="linkToFigmaComponent(component.nodeId)"
-                target="_blank"
-                class="figma-link"
-              >
-                <img src="/assets/figma-logo.svg" class="figma-icon" alt="figma-logo" />
-              </a>
-            </span>
+          <td class="status-design">
+            <nve-tag :variant="getBadgeVariant(component.statusDesign)" size="small">
+              {{ component.statusDesign }}
+            </nve-tag>
+          </td>
+          <td class="figma-link-cell">
+            <a
+              v-if="component.nodeId"
+              title="Åpne i Figma"
+              :href="linkToFigmaComponent(component.nodeId)"
+              target="_blank"
+              class="figma-link"
+            >
+              <img src="/assets/figma-logo.svg" class="figma-icon" alt="figma-logo" />
+            </a>
           </td>
           <td>
             <ul v-if="issuesForComponent(component.name)?.length > 0">
@@ -66,34 +66,38 @@
       </tbody>
       <tfoot>
         <tr>
+          <!-- Separarer sammendraget fra resten av tabellen, så det ser ut som en egen tabell -->
+          <td class="divider-row"></td>
+        </tr>
+        <tr>
           <th rowspan="7">Antall komponenter</th>
           <td>{{ codeStatusCount('Ferdig') }}</td>
-          <td>{{ designStatusCount('Ferdig') }}</td>
+          <td colspan="2">{{ designStatusCount('Ferdig') }}</td>
           <td><nve-tag variant="success" size="small">Ferdig</nve-tag></td>
         </tr>
         <tr>
           <td>{{ codeStatusCount('Under arbeid') }}</td>
-          <td>{{ designStatusCount('Under arbeid') }}</td>
+          <td colspan="2">{{ designStatusCount('Under arbeid') }}</td>
           <td><nve-tag variant="warning" size="small">Under arbeid</nve-tag></td>
         </tr>
         <tr>
           <td>{{ codeStatusCount('Ikke påbegynt') }}</td>
-          <td>{{ designStatusCount('Ikke påbegynt') }}</td>
+          <td colspan="2">{{ designStatusCount('Ikke påbegynt') }}</td>
           <td><nve-tag variant="info" size="small">Ikke påbegynt</nve-tag></td>
         </tr>
         <tr>
           <td>{{ codeStatusCount('Skal revideres') }}</td>
-          <td>{{ designStatusCount('Skal revideres') }}</td>
+          <td colspan="2">{{ designStatusCount('Skal revideres') }}</td>
           <td><nve-tag variant="neutral" size="small">Skal revideres</nve-tag></td>
         </tr>
         <tr>
           <td>{{ codeStatusCount('Trenger kvalitetssjekk') }}</td>
-          <td>{{ designStatusCount('Trenger kvalitetssjekk') }}</td>
+          <td colspan="2">{{ designStatusCount('Trenger kvalitetssjekk') }}</td>
           <td><nve-tag variant="error" size="small">Trenger kvalitetssjekk</nve-tag></td>
         </tr>
         <tr>
           <td>{{ componentStatuses.filter((s) => s.statusCode !== undefined).length }}</td>
-          <td>{{ componentStatuses.filter((s) => s.statusDesign !== undefined).length }}</td>
+          <td colspan="2">{{ componentStatuses.filter((s) => s.statusDesign !== undefined).length }}</td>
           <td><nve-tag variant="neutral" size="small">Alle planlagte</nve-tag></td>
         </tr>
       </tfoot>
@@ -105,7 +109,7 @@
 import LinkButton from './LinkButton.vue';
 import { componentNames } from '../customElementsManifest.store';
 import { fetchIssues, Issue } from '../github.services';
-import { ref, defineProps, onMounted } from 'vue';
+import { ref, onMounted } from 'vue';
 
 interface ComponentStatus {
   /** Navn på komponenten. F.eks. nve-button */
@@ -215,21 +219,20 @@ th {
 
 tfoot > tr > td {
   text-align: right;
+  background-color: white;
 }
 
-.status {
-  display: inline-block;
-  background-color: #e0e0e0;
-  padding: 2px 5px;
-  border-radius: 3px;
-  margin-right: 10px;
+.divider-row {
+  border: none;
 }
 
-.status-design-container {
-  display: flex;
-  justify-content: start;
-  align-items: center;
-  gap: 1rem;
+.status-design {
+  border-right: none;
+}
+
+.figma-link-cell {
+  width: 2rem;
+  border-left: none;
 }
 
 .figma-icon {
@@ -239,5 +242,9 @@ tfoot > tr > td {
 
 .figma-link {
   text-decoration: none;
+}
+
+ul {
+  margin: 0;
 }
 </style>

--- a/doc-site/.vitepress/theme/components/ComponentOverview.vue
+++ b/doc-site/.vitepress/theme/components/ComponentOverview.vue
@@ -6,6 +6,11 @@
     :openInNewTab="true"
   />
 
+  <nve-message-card
+    title="Merk saker og PR'er i Github med komponentnavn for å se dem her"
+    size="simple"
+  ></nve-message-card>
+
   <div>
     <table>
       <thead>
@@ -13,7 +18,7 @@
           <th>Komponent</th>
           <th>Status kode</th>
           <th>Status design</th>
-          <th>Feil / oppgaver</th>
+          <th>Feil / oppgaver / PR</th>
         </tr>
       </thead>
       <tbody>

--- a/doc-site/.vitepress/theme/components/ComponentOverview.vue
+++ b/doc-site/.vitepress/theme/components/ComponentOverview.vue
@@ -87,11 +87,6 @@
           <td><nve-tag variant="neutral" size="small">Skal revideres</nve-tag></td>
         </tr>
         <tr>
-          <td>{{ codeStatusCount('Revideres') }}</td>
-          <td>{{ designStatusCount('Revideres') }}</td>
-          <td><nve-tag variant="neutral" size="small">Revideres</nve-tag></td>
-        </tr>
-        <tr>
           <td>{{ codeStatusCount('Trenger kvalitetssjekk') }}</td>
           <td>{{ designStatusCount('Trenger kvalitetssjekk') }}</td>
           <td><nve-tag variant="error" size="small">Trenger kvalitetssjekk</nve-tag></td>
@@ -167,7 +162,6 @@ const getBadgeVariant = (status: string) => {
       return 'success';
     case 'Ikke påbegynt':
       return 'info';
-    case 'Revideres':
     case 'Skal revideres':
       return 'neutral';
     case 'Under arbeid':

--- a/doc-site/.vitepress/theme/components/ComponentOverview.vue
+++ b/doc-site/.vitepress/theme/components/ComponentOverview.vue
@@ -13,6 +13,7 @@
           <th>Komponent</th>
           <th>Status kode</th>
           <th>Status design</th>
+          <th>Feil / oppgaver</th>
         </tr>
       </thead>
       <tbody>
@@ -46,6 +47,15 @@
                 <img src="/assets/figma-logo.svg" class="figma-icon" alt="figma-logo" />
               </a>
             </span>
+          </td>
+          <td>
+            <ul v-if="issuesForComponent(component.name)?.length > 0">
+              <li v-for="issue of issuesForComponent(component.name)">
+                <a :href="issue.url" target="_blank"
+                  >{{ issue.title }} <span v-if="issue.isPullRequest"> (PR) </span></a
+                >
+              </li>
+            </ul>
           </td>
         </tr>
       </tbody>
@@ -123,6 +133,8 @@
 <script setup lang="ts">
 import LinkButton from './LinkButton.vue';
 import { componentNames } from '../customElementsManifest.store';
+import { fetchIssues, Issue } from '../github.services';
+import { ref, defineProps, onMounted } from 'vue';
 
 interface ComponentStatus {
   /** Navn på komponenten. F.eks. nve-button */
@@ -151,6 +163,16 @@ const linkToFigmaComponent = (figmaId: string) => {
 
 const isComponent = (name: string): boolean => {
   return componentNames.value.some((component) => component === name);
+};
+
+const issues = ref<Map<string, Issue[]>>(new Map<string, Issue[]>());
+
+onMounted(async () => {
+  issues.value = await fetchIssues();
+});
+
+const issuesForComponent = (componentName: string): Issue[] => {
+  return issues.value.get(componentName) || [];
 };
 
 const getBadgeVariant = (status: string) => {

--- a/doc-site/.vitepress/theme/components/ComponentOverview.vue
+++ b/doc-site/.vitepress/theme/components/ComponentOverview.vue
@@ -54,13 +54,7 @@
             </a>
           </td>
           <td>
-            <ul v-if="issuesForComponent(component.name)?.length > 0">
-              <li v-for="issue of issuesForComponent(component.name)">
-                <a :href="issue.url" target="_blank"
-                  >{{ issue.title }} <span v-if="issue.isPullRequest"> (PR) </span></a
-                >
-              </li>
-            </ul>
+            <ComponentIssues :componentName="component.name" />
           </td>
         </tr>
       </tbody>
@@ -108,8 +102,7 @@
 <script setup lang="ts">
 import LinkButton from './LinkButton.vue';
 import { componentNames } from '../customElementsManifest.store';
-import { fetchIssues, Issue } from '../github.services';
-import { ref, onMounted } from 'vue';
+import ComponentIssues from './ComponentIssues.vue';
 
 interface ComponentStatus {
   /** Navn på komponenten. F.eks. nve-button */
@@ -148,16 +141,6 @@ const codeStatusCount = (status: string | null): number => {
 
 const designStatusCount = (status: string | null): number => {
   return props.componentStatuses.filter((s) => s.statusDesign == status).length;
-};
-
-const issues = ref<Map<string, Issue[]>>(new Map<string, Issue[]>());
-
-onMounted(async () => {
-  issues.value = await fetchIssues();
-});
-
-const issuesForComponent = (componentName: string): Issue[] => {
-  return issues.value.get(componentName) || [];
 };
 
 const getBadgeVariant = (status: string) => {

--- a/doc-site/.vitepress/theme/github.services.ts
+++ b/doc-site/.vitepress/theme/github.services.ts
@@ -1,0 +1,58 @@
+/**
+ * Funksjoner for å hente data fra designsystem-repo'et i Github
+ * For å koble en sak eller PR i Github til en komponent, merk den med komponent-navnet, f.eks. `nve-checkbox`
+ */
+import { request } from '@octokit/request';
+import { componentNames } from './customElementsManifest.store';
+
+/**
+ * En sak eller PR i Github
+ */
+export interface Issue {
+  title: string;
+  url: string;
+  isPullRequest: boolean;
+}
+
+/**
+ * Henter saker (issues) og pull requests fra Github-repoet
+ * @returns Saker og PR-er gruppert på komponentnavn
+ */
+export const fetchIssues = async (): Promise<Map<string, Issue[]>> => {
+  let done = false;
+  const pageSize = 10;
+  let page = 1;
+
+  const issuesPerComponent = new Map<string, Issue[]>();
+
+  while (!done) {
+    try {
+      const response = await request(`GET /repos/NVE/Designsystem/issues`, {
+        per_page: pageSize,
+        page: page,
+      });
+      response.data.forEach((issue: any) => {
+        issue.labels.forEach((label: any) => {
+          //sjekker om denne saken er merka med et komponentnavn
+          if (componentNames.value.includes(label.name)) {
+            const issuesForThisComponent = issuesPerComponent.get(label.name) || [];
+            issuesForThisComponent.push({
+              title: issue.title,
+              url: issue.html_url,
+              isPullRequest: issue.pull_request,
+            });
+            issuesPerComponent.set(label.name, issuesForThisComponent);
+          }
+        });
+      });
+      done = response.data.length < pageSize; // hvis denne sida var full, må vi prøve å hente en side til for å se om det er flere
+      console.log(`Fant ${response.data.length} issues i side ${page}.`);
+      page++;
+    } catch (error) {
+      console.error(error);
+      done = true;
+    }
+  }
+  console.log(`Fant ${issuesPerComponent.size} komponenter med issues`);
+  return issuesPerComponent;
+};

--- a/doc-site/.vitepress/theme/github.services.ts
+++ b/doc-site/.vitepress/theme/github.services.ts
@@ -20,7 +20,7 @@ export interface Issue {
  */
 export const fetchIssues = async (): Promise<Map<string, Issue[]>> => {
   let done = false;
-  const pageSize = 10;
+  const pageSize = 100;
   let page = 1;
 
   const issuesPerComponent = new Map<string, Issue[]>();

--- a/doc-site/.vitepress/theme/github.store.ts
+++ b/doc-site/.vitepress/theme/github.store.ts
@@ -1,0 +1,25 @@
+/**
+ * Tilbyr data fra designsystem-repo'et i Github
+ * For å koble en sak eller PR i Github til en komponent, merk den med komponent-navnet, f.eks. `nve-checkbox`
+ */
+
+import { fetchIssues, Issue } from './github.services';
+import { reactive, ref } from 'vue';
+
+export const issues = ref<Map<string, Issue[]>>(new Map<string, Issue[]>());
+issues.value = await fetchIssues(); //initiell lasting av saker
+
+/**
+ * Hent åpne saker og PR-er knytta til komponent.
+ *
+ * @param componentName navn på komponenten, f.eks. `nve-checkbox`
+ * @returns en liste av saker eller tom liste hvis ingen saker er knytta til komponenten
+ */
+const issuesForComponent = (componentName: string): Issue[] => {
+  return issues.value.get(componentName) || [];
+};
+
+const githubStore = reactive({
+  issuesForComponent,
+});
+export default githubStore;

--- a/doc-site/.vitepress/theme/github.store.ts
+++ b/doc-site/.vitepress/theme/github.store.ts
@@ -7,7 +7,11 @@ import { fetchIssues, Issue } from './github.services';
 import { reactive, ref } from 'vue';
 
 export const issues = ref<Map<string, Issue[]>>(new Map<string, Issue[]>());
-issues.value = await fetchIssues(); //initiell lasting av saker
+
+//initiell lasting av saker
+fetchIssues().then((data) => {
+  issues.value = data;
+});
 
 /**
  * Hent åpne saker og PR-er knytta til komponent.

--- a/doc-site/components/Komponentoversikt.md
+++ b/doc-site/components/Komponentoversikt.md
@@ -113,7 +113,7 @@ nodeId er ID til komponent-sida i Figma. Den ligger som en parameter i URL'en ti
   },
   {
     name: 'nve-dialog',
-    nodeId: '1360-4722',
+    nodeId: undefined,
     description: undefined,
     statusDesign: undefined,
     statusCode: 'Ferdig'

--- a/doc-site/components/Komponentoversikt.md
+++ b/doc-site/components/Komponentoversikt.md
@@ -325,7 +325,7 @@ nodeId er ID til komponent-sida i Figma. Den ligger som en parameter i URL'en ti
     name: 'nve-tree',
     nodeId: '3769-59546',
     description: undefined,
-    statusDesign: 'Under revidering',
+    statusDesign: 'Under arbeid',
     statusCode: 'Ikke påbegynt'
   }
 ]" />

--- a/doc-site/package-lock.json
+++ b/doc-site/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@octokit/request": "^9.1.3",
         "vitepress": "^1.3.0"
       }
     },
@@ -638,6 +639,61 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+      "dev": true
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
+      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^10.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
+      "integrity": "sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+      "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^22.2.0"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.18.1",
@@ -1579,6 +1635,12 @@
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "dev": true
     },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
+      "dev": true
+    },
     "node_modules/vite": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
@@ -2079,6 +2141,52 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
+    },
+    "@octokit/endpoint": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^7.0.2"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+      "dev": true
+    },
+    "@octokit/request": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
+      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^10.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^7.0.2"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
+      "integrity": "sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^13.0.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+      "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^22.2.0"
+      }
     },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.18.1",
@@ -2712,6 +2820,12 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "dev": true
+    },
+    "universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
       "dev": true
     },
     "vite": {

--- a/doc-site/package.json
+++ b/doc-site/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@octokit/request": "^9.1.3",
     "vitepress": "^1.3.0"
   }
 }


### PR DESCRIPTION
Vi viser nå alle åpne *issues* fra repoet vårt i komponentoversikten og på sida for hver komponent. Issues er i denne sammenheng både saker og pull requests.
![image](https://github.com/user-attachments/assets/096e8878-f09d-43b2-bb97-a7db9c87991c)

En sak må merkes med komponentnavn for at vi skal vite at saken hører til en bestemt komponent. 
![image](https://github.com/user-attachments/assets/bd23c93d-70f5-43a5-8eee-315d87e400b8)

NB! Alle issues merka med komponentnavn blir vist. Det samme gjelder PR'er. PR'er som _ikke_ er merka med komponentnavn, men er koblet til en komponent gjennom en sak, vises ikke. Årsaken er at endepunktet jeg bruker, gir ingen kobling mellom sak og PR. Dette kan vi sikkert få til på sikt, men det krever mer koding.
Her er dokumentasjon på endepunktet jeg bruker:
https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues

Jeg har også forenklet koden for å summere antall komponenter og forsøkt å gjøre oversikten litt penere, bla.a. ved å bruke nve-tag i stedet for nve-badge.
 


