### PR TITLE
La til funksjonalitet for at createNewComponent også legger til komponenten i nve-designsystem

### DIFF
--- a/scripts/createNewComponent.js
+++ b/scripts/createNewComponent.js
@@ -98,8 +98,6 @@ const addComponentToExports = () => {
   const lines = existingComponentFile.split(/\r?\n/);
   const exports = lines.filter((l) => l.startsWith('export'));
   const comments = lines.filter((l) => !l.startsWith('export') && !!l);
-  console.dir(comments.length);
-  console.dir(exports.length);
   exports.push(`export { default as ${className} } from './components/${componentName}/${componentName}.component';`);
   exports.sort();
   const newFile = `${comments.join('\r\n')}

--- a/scripts/createNewComponent.js
+++ b/scripts/createNewComponent.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import chalk from 'chalk';
 import nextTask from './nextTask.js';
-import process, { exit } from 'process';
+import process from 'process';
 
 const componentName = process.argv[2];
 

--- a/src/nve-designsystem.ts
+++ b/src/nve-designsystem.ts
@@ -1,4 +1,5 @@
 /** Alle komponenter som er tilgjengelige, i alfabetisk rekkefølge. */
+/** Denne filen blir genererert av npm run add-component */
 export { default as NveAlert } from './components/nve-alert/nve-alert.component';
 export { default as NveBadge } from './components/nve-badge/nve-badge.component';
 export { default as NveButton } from './components/nve-button/nve-button.component';


### PR DESCRIPTION
Når man kjører `npm run add-component nve-xxxx` så ble ikke den nye komponenten eksportert fra nve-designsystem.ts - listen.
La til kode slik at den legges til der (og sorteres alfabetisk)