### PR TITLE
fix(nve-input): hindre validering der hvor det ønskes

### DIFF
--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -34,6 +34,8 @@ export default class NveInput extends SlInput implements INveComponent {
    * Brukes for å kunne identifisere komponenten
    */
   @property({ type: String, reflect: true }) inputId?: string;
+  /** Brukes for å hindre nettleseren fra å validere feltet */
+  @property({ type: Boolean }) noValidation = false;
 
   @state() protected alreadyInvalid = false;
 
@@ -92,6 +94,9 @@ export default class NveInput extends SlInput implements INveComponent {
   }
 
   private makeInvalid() {
+    if (this.noValidation) {
+      return;
+    }
     this.showErrorIcon();
     this.showErrorMessage();
     this.alreadyInvalid = true;


### PR DESCRIPTION
Noen ganger validerer nettleseren selv om det ikke er ønsket som f.eks i dato type. noValidation attribute skal hindre fra validering. 