### PR TITLE
feat: change label to bold

### DIFF
--- a/src/components/nve-radio-group/nve-radio-group.styles.ts
+++ b/src/components/nve-radio-group/nve-radio-group.styles.ts
@@ -37,7 +37,7 @@ export default css`
   :host::part(form-control-label) {
     display: flex;
     color: var(--neutrals-foreground-primary);
-    font: var(--label-small-light);
+    font: var(--label-small);
     margin-bottom: unset;
     text-align: left;
   }


### PR DESCRIPTION
Changed label in `nve-radio-group` to bold to match the other labels in the design system

**Before:**
![image](https://github.com/user-attachments/assets/ce9598e4-437b-465f-844c-a87ee3e31b3f)

**After:**

![image](https://github.com/user-attachments/assets/ad320791-0f9c-46c3-9d5d-a0d97608d1ce)
