### PR TITLE
fix: Designer-endringer accordion

### DIFF
--- a/doc-site/components/nve-accordion.md
+++ b/doc-site/components/nve-accordion.md
@@ -195,21 +195,6 @@ Viser accordion uten padding til venstre og høyre, og med en border under. Sett
 
 </CodeExamplePreview>
 
-### Høyrejustering chevron
-
-Shoelace har chevron (dropdown-ikonet) til høyre, men vi har det til venstre. Dersom du ønsker å ha det til høyre, så kan du angi det med `rightalignedchevron`
-
-<CodeExamplePreview>
-
-```html
-<nve-accordion summary="Ikon til høyre" rightalignedchevron>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-  aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-</nve-accordion>
-```
-
-</CodeExamplePreview>
-
 ### Tilpassing av tittel-sporet
 
 Man kan bruke `summary` for å sette tittel, men kan også angi det som et eget spor dersom det er nødvendig

--- a/doc-site/components/nve-accordion.md
+++ b/doc-site/components/nve-accordion.md
@@ -97,7 +97,7 @@ Accordion er designet for å fungere uavhengig, men du kan simulere en gruppe de
 
 ### Varianter
 
-Vi har mye av de samme variantene her som i andre steder av løsningen. `none` er standard, og har ingen bakgrunn. `neutral` har her hvit bakgrunn.
+Vi har mye av de samme variantene her som i andre steder av løsningen. `none` er standard, og har ingen bakgrunn eller padding på sidene. `neutral` har her hvit bakgrunn.
 
 <CodeExamplePreview>
 

--- a/src/components/nve-accordion/nve-accordion.component.ts
+++ b/src/components/nve-accordion/nve-accordion.component.ts
@@ -15,8 +15,6 @@ export default class NveAccordion extends SlDetails implements INveComponent {
   /** Variant. Setter farge på bakgrunn og tekst */
   @property({ type: String, reflect: true }) variant: 'none' | 'neutral' | 'info' | 'success' | 'warning' | 'error' =
     'none';
-  /** Dropdown-ikon vises til høyre, ikke venstre */
-  @property({ type: Boolean, reflect: false }) rightalignedchevron: boolean = false;
   /** border rundt hele komponenten */
   @property({ type: Boolean, reflect: false }) border: boolean = false;
   /** kompakt visning uten sidepadding og border under */

--- a/src/components/nve-accordion/nve-accordion.styles.ts
+++ b/src/components/nve-accordion/nve-accordion.styles.ts
@@ -46,6 +46,9 @@ export default css`
     --_hover-text-color: var(--neutrals-foreground-primary);
     --_border-color: var(--neutrals-border-default);
     --_left_border-color: var(--brand-primary);
+    .details {
+      padding-inline: 0;
+    }
   }
 
   :host([variant='neutral']) {
@@ -95,10 +98,12 @@ export default css`
 
   :host([border]) .details {
     border: 1px solid var(--_border-color, var(--_text-color));
+    padding-inline: var(--spacing-large);
   }
 
   :host([leftstroke]) .details {
     border-left: 5px solid var(--_left_border-color, var(--_border-color, var(--_text-color)));
+    padding-inline: var(--spacing-medium);
   }
 
   :host([compact]) .details {

--- a/src/components/nve-accordion/nve-accordion.styles.ts
+++ b/src/components/nve-accordion/nve-accordion.styles.ts
@@ -20,7 +20,7 @@ export default css`
   }
   .details__content {
     padding: 0;
-    padding-top: var(--spacing-large);
+    padding-top: var(--spacing-small);
   }
   .details:not(.details--disabled) {
     .details__summary-icon:hover {
@@ -33,6 +33,7 @@ export default css`
     /* Overstyrer shoelace sin animasjon. */
     rotate: 90deg;
     border-radius: var(--border-radius-small);
+    font-size: var(--font-size-medium);
   }
   .details--open .details__summary-icon {
     rotate: 270deg;
@@ -98,11 +99,6 @@ export default css`
 
   :host([leftstroke]) .details {
     border-left: 5px solid var(--_left_border-color, var(--_border-color, var(--_text-color)));
-  }
-
-  :host([rightalignedchevron]) .details__summary {
-    order: 0;
-    margin-inline-start: 0;
   }
 
   :host([compact]) .details {


### PR DESCRIPTION
Mindre endringer på accordion etter input fra designer
* Ikonstørrelse for chevron er nå 24px
* Tok bort mulighet for å høyrejustere chevron
* Minsket spacing mellom tittel og content