### PR TITLE
fix(nve-radio): Skriftstørrelse på stor variant av nve-radio

### DIFF
--- a/doc-site/components/nve-radio-group.md
+++ b/doc-site/components/nve-radio-group.md
@@ -50,6 +50,30 @@ Bruk `orientation` for å velge retning. `vertical` er standard.
 
 </CodeExamplePreview>
 
+### Størrelse
+
+Bruk `size` for å sette størrelse. `medium` er standard.
+<CodeExamplePreview>
+
+```html
+<nve-radio-group size="small" label="Vennligst velg en av disse">
+  <nve-radio value="valg1">Valg 1</nve-radio>
+  <nve-radio value="valg2">Valg 2</nve-radio>
+</nve-radio-group>
+<br />
+<nve-radio-group label="Vennligst velg en av disse">
+  <nve-radio value="valg1">Valg 1</nve-radio>
+  <nve-radio value="valg2">Valg 2</nve-radio>
+</nve-radio-group>
+<br />
+<nve-radio-group size="large" label="Vennligst velg en av disse">
+  <nve-radio value="valg1">Valg 1</nve-radio>
+  <nve-radio value="valg2">Valg 2</nve-radio>
+</nve-radio-group>
+```
+
+</CodeExamplePreview>
+
 ### Valgt verdi
 
 `value` gir deg valgt radioknapp sin `value`. Klikk på elementet og sjekk konsollet for å se `value`.
@@ -81,7 +105,7 @@ Du kan også sette `value` selv.
 ### Deaktivering
 
 Bruk `disabled` for å deaktivere hele gruppa.
-TODO: Dette virker ikke, må fikses.
+TODO: Dette virker ikke, må fikses. Men du kan deaktivere enkelt-elementer i gruppa.
 
 <CodeExamplePreview>
 

--- a/doc-site/components/nve-radio.md
+++ b/doc-site/components/nve-radio.md
@@ -1,1 +1,35 @@
-Se [nve-radio-group](./nve-radio-group.html)
+---
+layout: component
+---
+
+## Eksempler
+
+Se også [nve-radio-group](./nve-radio-group.html)
+
+### Størrelse
+
+Bruk `size` for å sette størrelse. `medium` er standard.
+Du kan også sette størrelse for `nve-radio-group`, og dette vil overstyre evt. størrelse satt på `nve-radio`.
+<CodeExamplePreview>
+
+```html
+<nve-radio size="small">Liten</nve-radio>
+<nve-radio>Middels</nve-radio>
+<nve-radio size="large">Stor</nve-radio>
+```
+
+</CodeExamplePreview>
+
+### Deaktivering
+
+Bruk `disabled` for å deaktivere.
+
+<CodeExamplePreview>
+
+```html
+<nve-radio disabled>Denne kan du ikke velge</nve-radio>
+
+<nve-radio>Denne kan du velge</nve-radio>
+```
+
+</CodeExamplePreview>

--- a/src/components/nve-radio/nve-radio.styles.ts
+++ b/src/components/nve-radio/nve-radio.styles.ts
@@ -48,7 +48,7 @@ export default css`
 
   .radio {
     display: flex;
-    font: var(--label-x-small-light);
+    font: var(--label-small-light);
     color: var(--neutrals-foreground-primary);
     background-color: var(--neutrals-background-primary);
     gap: var(--spacing-x-small, 0.5rem); /* sett gap */


### PR DESCRIPTION
Fixes  #316, fixes #320.

Har også dokumentert bruk av størrelse på `nve-radio` og `nve-radio-group`.
Så vidt jeg kunne se er det allerede riktig størrelse på ikoner/avkrysningsbokser.

`nve-checkbox` skal iflg. vårt designsystem ha en fast størrelse, og dette er dokumentert i JsDoc, se https://designsystem.nve.no/components/nve-checkbox.html

 