### PR TITLE
feat(#239): Vise også saker som gjelder planlagte komponenter i komponentoversikten

### DIFF
--- a/doc-site/.vitepress/theme/github.services.ts
+++ b/doc-site/.vitepress/theme/github.services.ts
@@ -33,8 +33,10 @@ export const fetchIssues = async (): Promise<Map<string, Issue[]>> => {
       });
       response.data.forEach((issue: any) => {
         issue.labels.forEach((label: any) => {
-          //sjekker om denne saken er merka med et komponentnavn
-          if (componentNames.value.includes(label.name)) {
+          // Sjekker om denne saken er merka med et komponentnavn. 
+          // Vi sjekker ikke mot komponentregisteret, 
+          // for vi vil også ha med navn på komponenter som ikke er laget ennå 
+          if (label.name?.startsWith('nve-')) {
             const issuesForThisComponent = issuesPerComponent.get(label.name) || [];
             issuesForThisComponent.push({
               title: issue.title,


### PR DESCRIPTION
Nå viser vi link til github-saker også for komponenter som ikke er laget ennå:

![image](https://github.com/user-attachments/assets/6842cf54-1dc0-4d2b-a61f-cb465fcac1bc)

Closes #239.
