### PR TITLE
Fixes #227 . nve-input får nå et øye-ikon dersom den er readonly

### DIFF
--- a/doc-site/components/nve-input.md
+++ b/doc-site/components/nve-input.md
@@ -71,14 +71,16 @@ Du kan også vise et låse-ikon ved å legge `nve-icon` i sporet `suffix`.
 
 ### Skrivebeskyttet
 
-Bruk `readonly` for å stenge mulighet for å endre innholdet
+Bruk `readonly` for å stenge mulighet for å endre innholdet. Input-feltet får da et ikon dersom suffix-slot ikke er satt
 
 <CodeExamplePreview>
 
 ```html
-<nve-input readonly value="Dette får du ikke endret"></nve-input>
-
-<nve-input value="men dette kan du endre"></nve-input>
+<nve-input id="in1" readonly value="Dette får du ikke endret"></nve-input>
+<nve-input id="in2" readonly value="Dette får du heller ikke endret, og vi har lagt på et ikon spesifikt her">
+  <nve-icon slot="suffix" name="asterisk" />
+</nve-input>
+<nve-input id="in3" value="men dette kan du endre"></nve-input>
 ```
 
 </CodeExamplePreview>

--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -87,13 +87,10 @@ export default class NveInput extends SlInput implements INveComponent {
     if (changedProperties.has('readonly') && this.shadowRoot) {
       const oldReadOnly: boolean | undefined = changedProperties.get('readonly');
       const newReadonly = this.readonly;
-      console.dir(oldReadOnly);
-      console.dir(newReadonly);
       if (!oldReadOnly && newReadonly) {
         //readonly endret fra falsy til true
         //Sjekker om vi har et ikon i suffix-slot allerede. Dersom vi har det, så skipper vi
         if (!(this.shadowRoot.querySelector('slot[name=suffix]') as HTMLSlotElement).assignedElements().length) {
-          //debugger;
           const nveIcon = document.createElement('nve-icon');
           nveIcon.setAttribute('id', 'readonly-icon');
           nveIcon.setAttribute('name', 'visibility');

--- a/src/components/nve-input/nve-input.component.ts
+++ b/src/components/nve-input/nve-input.component.ts
@@ -84,6 +84,33 @@ export default class NveInput extends SlInput implements INveComponent {
     if (!hasDataUserInvalidAttr) {
       this.resetValidation();
     }
+    if (changedProperties.has('readonly') && this.shadowRoot) {
+      const oldReadOnly: boolean | undefined = changedProperties.get('readonly');
+      const newReadonly = this.readonly;
+      console.dir(oldReadOnly);
+      console.dir(newReadonly);
+      if (!oldReadOnly && newReadonly) {
+        //readonly endret fra falsy til true
+        //Sjekker om vi har et ikon i suffix-slot allerede. Dersom vi har det, så skipper vi
+        if (!(this.shadowRoot.querySelector('slot[name=suffix]') as HTMLSlotElement).assignedElements().length) {
+          //debugger;
+          const nveIcon = document.createElement('nve-icon');
+          nveIcon.setAttribute('id', 'readonly-icon');
+          nveIcon.setAttribute('name', 'visibility');
+          nveIcon.setAttribute('slot', 'suffix');
+          this.appendChild(nveIcon);
+        }
+      } else if (!newReadonly && oldReadOnly) {
+        //endret fra true til false
+        const readonlyIcon = (this.shadowRoot.querySelector('slot[name=suffix]') as HTMLSlotElement)
+          .assignedElements()
+          .find((x) => x.id === 'readonly-icon');
+
+        if (readonlyIcon) {
+          readonlyIcon.remove();
+        }
+      }
+    }
   }
 
   private updateInputId() {

--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -77,6 +77,14 @@ export default css`
     border-color: var(--neutrals-background-secondary);
     background: var(--neutrals-background-secondary);
   }
+  :host([readonly]) :is(:hover, .input--focused) {
+    border-color: transparent;
+    background: var(--neutrals-background-secondary);
+    outline: none;
+  }
+  :host([readonly]) .input.input--standard:hover:not(.input--disabled) {
+    border-color: transparent !important;
+  }
 
   /* Gir rød ramme ved valideringsfeil  */
   :host([data-user-invalid])::part(base) {


### PR DESCRIPTION
Finnes også logikk for å legge til/fjerne ikonet dersom readonly endres. Og dersom det er noe i suffix-slot så bruker vi det ikke.