### PR TITLE
Fixes #364 Kan nå ha en textlabel-attributt på nve-option

### DIFF
--- a/doc-site/components/nve-option.md
+++ b/doc-site/components/nve-option.md
@@ -1,1 +1,5 @@
+---
+layout: component
+---
+
 Se [nve-select](./nve-select.html)

--- a/doc-site/components/nve-select.md
+++ b/doc-site/components/nve-select.md
@@ -2,6 +2,8 @@
 layout: component
 ---
 
+Se også [nve-option](./nve-option.html)
+
 <CodeExamplePreview>
 
 ```html
@@ -127,6 +129,24 @@ Bruk `requiredlabel` hvis du vil vise noe annet enn `*Obligatorisk`. Feltet må 
 
   <nve-button type="submit">Submit</nve-button>
 </form>
+```
+
+</CodeExamplePreview>
+
+### Bruk ulik tekst for select og option
+
+Bruk `textLabel` dersom du ønsker at teksten som vises i selve select-feltet ikke skal være all teksten som er i option.
+
+<CodeExamplePreview>
+
+```html
+<nve-select value="valg2" label="Endre denne hvis du ikke vil ha foreslått valg" multiple>
+  <nve-option value="valg1" textLabel="Valg 1">
+    <span>Valg 1</span> - <span>Denne teksten vil ikke vises når denne er valgt</span>
+  </nve-option>
+  <nve-option value="valg2"><span>Valg 2</span> - <span>Denne teksten blir med når den er valgt</span></nve-option>
+  <nve-option value="valg3">Valg 3</nve-option>
+</nve-select>
 ```
 
 </CodeExamplePreview>

--- a/doc-site/components/nve-select.md
+++ b/doc-site/components/nve-select.md
@@ -135,7 +135,7 @@ Bruk `requiredlabel` hvis du vil vise noe annet enn `*Obligatorisk`. Feltet må 
 
 ### Bruk ulik tekst for select og option
 
-Bruk `textLabel` dersom du ønsker at teksten som vises i selve select-feltet ikke skal være all teksten som er i option.
+Bruk `textLabel` i `nve-option` dersom du ønsker at teksten som vises i selve select-feltet ikke skal være all teksten som er i option.
 
 <CodeExamplePreview>
 

--- a/src/components/nve-option/nve-option.component.ts
+++ b/src/components/nve-option/nve-option.component.ts
@@ -1,6 +1,7 @@
 import SlOption from '@shoelace-style/shoelace/dist/components/option/option.js';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import styles from './nve-option.styles';
+import { PropertyValues } from 'lit';
 /**
  * Representerer et valg i nve-select.
  */
@@ -10,9 +11,13 @@ export default class NveOption extends SlOption {
     super();
   }
   static styles = [SlOption.styles, styles];
+  /**
+   * Tekst som vises i select når denne er valgt. Default er at all råtekst vises.
+   */
+  @property() textLabel: string | undefined = undefined;
 
   /* Setter filled attributt på option når parent-select er filled, for å få annen hover-farge*/
-  firstUpdated(changedProperties: any): void {
+  firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
     const select = this.closest('nve-select');
     if (select?.hasAttribute('filled')) {
@@ -20,6 +25,16 @@ export default class NveOption extends SlOption {
     } else {
       this.toggleAttribute('filled', false);
     }
+  }
+
+  /**
+   * Gir tilbake plain-tekst-label som vises i select
+   */
+  override getTextLabel(): string {
+    if (this.textLabel) {
+      return this.textLabel;
+    }
+    return super.getTextLabel();
   }
 }
 

--- a/src/components/nve-select/nve-select.component.ts
+++ b/src/components/nve-select/nve-select.component.ts
@@ -2,6 +2,7 @@ import SlSelect from '@shoelace-style/shoelace/dist/components/select/select.js'
 import { customElement, property } from 'lit/decorators.js';
 import styles from './nve-select.styles';
 import NveOption from '../nve-option/nve-option.component';
+import { PropertyValues } from 'lit';
 
 /**
  * En nedtrekksliste, også kjent som rullgardin eller drop-down list. Kjært barn har mange navn.
@@ -41,7 +42,7 @@ export default class NveSelect extends SlSelect {
   }
   static styles = [SlSelect.styles, styles];
 
-  protected firstUpdated(changedProperties: any) {
+  protected firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);
     if (this.requiredLabel) {
       this.style.setProperty('--sl-input-required-content', `"${this.requiredLabel}"`);
@@ -50,7 +51,7 @@ export default class NveSelect extends SlSelect {
     popup?.setAttribute('distance', '3');
   }
 
-  updated(changedProperties: any) {
+  updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
     const hasDataUserInvalidAttr = this.hasAttribute('data-user-invalid');
     if (hasDataUserInvalidAttr) {
@@ -68,7 +69,6 @@ export default class NveSelect extends SlSelect {
     const popup = this.shadowRoot?.querySelector('sl-popup') as HTMLElement;
     popup?.classList.add('select--focused');
   }
-
   // @ts-ignore
   private handleOptionClick(event: MouseEvent) {
     const target = event.target as HTMLElement;
@@ -118,6 +118,7 @@ export default class NveSelect extends SlSelect {
   private getAllOptions() {
     return [...this.querySelectorAll<NveOption>('nve-option')];
   }
+
   // @ts-ignore
   private getFirstOption() {
     return this.querySelector<NveOption>('nve-option');


### PR DESCRIPTION
I Kontroll har vi et eksempel hvor nve-option har "bilde - bildenavn - bildetekst", men når den er valgt skal vi kun vise bildetekst i selve select'en. 

Select kaller getTextLabel() -funksjonen på valgte elementer , så vi overskriver getTextLabel på nve-option en og sender med en ekstra attributt på nve-option.

Default er at vi kun kaller super.getTextLabel dersom textLabel ikke er satt.