### PR TITLE
Fix 363 . Ikonet for å åpne/lukke var alltid sort, selv på darkmode

### DIFF
--- a/src/components/nve-accordion-item/nve-accordion-item.styles.ts
+++ b/src/components/nve-accordion-item/nve-accordion-item.styles.ts
@@ -34,6 +34,7 @@ export default css`
     rotate: 90deg;
     border-radius: var(--border-radius-small);
     font-size: var(--font-size-medium);
+    fill: currentColor;
   }
   .details--open .details__summary-icon {
     rotate: 270deg;


### PR DESCRIPTION
Enkel fiks, bare setter fill på ikonet til currentColor