### PR TITLE
docs: Oppfordring om å sjekke Shoelace-dok for komponenter basert på Shoelace

### DIFF
--- a/doc-site/.vitepress/theme/components/apidoc/ComponentDescription.vue
+++ b/doc-site/.vitepress/theme/components/apidoc/ComponentDescription.vue
@@ -14,9 +14,19 @@
   </div>
 
   <p v-if="parent">
-    Arvet fra:
+    Arvet fra
     <span v-if="parentDocUrl">
-      <a :href="parentDocUrl" target="_blank">{{ parent.name }}</a>
+      <a :href="parentDocUrl" target="_blank">{{ parent.name }}</a
+      >.
+      <p />
+      <nve-message-card
+        :v-if="parent?.name?.startsWith('sl-')"
+        size="compact"
+        title="Sjekk også Shoelace-dokumentasjonen"
+      >
+        Denne komponenten bygger på en Shoelace-komponent. Sjekke også dokumentasjonen i Shoelace for å få full oversikt
+        over hvordan komponenten funker.</nve-message-card
+      >
     </span>
     <span v-else> {{ parent.name }}</span>
   </p>

--- a/doc-site/.vitepress/theme/components/apidoc/ComponentDescription.vue
+++ b/doc-site/.vitepress/theme/components/apidoc/ComponentDescription.vue
@@ -24,7 +24,7 @@
         size="compact"
         title="Sjekk også Shoelace-dokumentasjonen"
       >
-        Denne komponenten bygger på en Shoelace-komponent. Sjekke også dokumentasjonen i Shoelace for å få full oversikt
+        Denne komponenten bygger på en Shoelace-komponent. Sjekk også dokumentasjonen i Shoelace for å få full oversikt
         over hvordan komponenten funker.</nve-message-card
       >
     </span>


### PR DESCRIPTION
Det er lett å glemme at komponentene våre kanskje har flere muligheter enn det vi har valgt å dokumentere selv.
Har derfor lagt inn denne på "komponentsida" for hver komponent som arver fra Shoelace:

![image](https://github.com/user-attachments/assets/3fd47c16-f951-493a-9c11-b594e09c69a0)


