### PR TITLE
fix: Størrelse på ikon i small nve-button var 24px, ikke 20

### DIFF
--- a/doc-site/components/nve-button.md
+++ b/doc-site/components/nve-button.md
@@ -62,7 +62,9 @@ Bruk `prefix` spor for å vise noe foran knapp teksten, f.eks et ikon.
 <CodeExamplePreview>
 
 ```html
+<nve-button size="small"><nve-icon slot="prefix" name="warning"></nve-icon>Varsel</nve-button>
 <nve-button><nve-icon slot="prefix" name="warning"></nve-icon>Varsel</nve-button>
+<nve-button size="large"><nve-icon slot="prefix" name="warning"></nve-icon>Varsel</nve-button>
 ```
 
 </CodeExamplePreview>
@@ -93,7 +95,7 @@ Bruk `loading` for å legge til ei snurre.
 
 ### Kun ikon
 
-Knapper med kun ikon kan brukes ved å sette `nve-icon` i den standard sporet.
+Knapper med kun ikon kan brukes ved å sette `nve-icon` i standardsporet.
 
 <CodeExamplePreview>
 

--- a/src/components/nve-button/nve-button.styles.ts
+++ b/src/components/nve-button/nve-button.styles.ts
@@ -54,14 +54,22 @@ export default css`
     --track-width: 2.5px;
     position: relative;
     top: 0;
-    font-size: 24px;
+    font-size: var(--font-size-large);
     left: 0;
     margin-right: var(--spacing-x-small);
   }
 
   :host ::slotted(nve-icon) {
-    font-size: 24px;
+    font-size: var(--font-size-large);
     color: var(--nve-icon-color);
+  }
+
+  :host([size='small']) ::slotted(nve-icon) {
+    font-size: var(--font-size-medium);
+  }
+
+  :host([size='large']) ::slotted(nve-icon) {
+    font-size: var(--font-size-large); // large og medium har samme ikonstr i figma
   }
 
   :host::part(label) {


### PR DESCRIPTION
Når man brukte en <nve-button size="small"> med et nve-icon i prefix/suffix -slot så var ikonet 24px høyt. Det skal være 20.
Sjekket også Figma for "large" button. Denne er 24px, akkurat som default