### PR TITLE
fix: rette .css stier i global.css

### DIFF
--- a/src/components/nve-button/nve-button.component.ts
+++ b/src/components/nve-button/nve-button.component.ts
@@ -8,7 +8,6 @@ import { INveComponent } from '@interfaces/NveComponent.interface';
  * Bruk href for å gjøre den om til en link.
  * Disse feltene skal ikke brukes:caret og pill
  * Circle attributte skal brukes kun når man viser bare et ikon.
- *
  */
 @customElement('nve-button')
 export default class NveButton extends SlButton implements INveComponent {


### PR DESCRIPTION
Fikser et feil etter [denne PRen](https://github.com/NVE/Designsystem/pull/439).
Nå skal vi importere riktig nve-designsystem.css i global.css etter bygging. 