### PR TITLE
fix(nve-link-card): css outline og tab accessibility

### DIFF
--- a/src/components/nve-link-card/nve-link-card.component.ts
+++ b/src/components/nve-link-card/nve-link-card.component.ts
@@ -37,7 +37,7 @@ export default class NveLinkCard extends LitElement implements INveComponent {
 
   static styles = [styles];
 
-    /**
+  /**
    * Standard nedlastingsfunksjon som brukes hvis downloadHandler ikke er overstyrt. 
    * Bruker lenken (href) til å laste ned en fil.
    */
@@ -71,10 +71,12 @@ export default class NveLinkCard extends LitElement implements INveComponent {
    * Alt + Klikk: Laster ned lenken (hvis det er en fil).
    * Hvis customClickHandler er definert, overstyres standard klikkatferd.
    */
-  private handleClick(event: MouseEvent) {
+  private handleClick(event: MouseEvent | KeyboardEvent) {
     // Overstyr standard klikkatferd med customClickHandler om den finnes
     if (this.customClickHandler) {
-      this.customClickHandler(event);
+      if (event instanceof MouseEvent) {
+        this.customClickHandler(event);
+      }
       return;
     }
     if (this.href && (event.ctrlKey || event.metaKey)) {
@@ -104,6 +106,16 @@ export default class NveLinkCard extends LitElement implements INveComponent {
         break;
     }
   }
+
+/**
+ * Denne er lagt til slik man klikke på cardet ved bruk av tastaturet.
+ */
+  private handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.handleClick(event);
+    }
+  }
+
   /**
    * Returnerer ikonnavnet som vises på kortet basert på clickAction.
    */
@@ -119,7 +131,7 @@ export default class NveLinkCard extends LitElement implements INveComponent {
 
   render() {
     return html`
-      <a part="link-card" class="link-card link-card--${this.size} link-card--${this.variant}" @click="${this.handleClick}">
+    <a part="link-card" class="link-card link-card--${this.size} link-card--${this.variant}" @click="${this.handleClick}" @keydown="${this.handleKeyDown}" tabindex="0">
         <div class="link-card__content">
           <div part="title" class="link-card__title">${this.title}</div>
           ${this.additionalText ? html`<div part="additional-text" class="link-card__additional-text">${this.additionalText}</div>` : nothing }

--- a/src/components/nve-link-card/nve-link-card.component.ts
+++ b/src/components/nve-link-card/nve-link-card.component.ts
@@ -131,7 +131,7 @@ export default class NveLinkCard extends LitElement implements INveComponent {
 
   render() {
     return html`
-    <a part="link-card" class="link-card link-card--${this.size} link-card--${this.variant}" @click="${this.handleClick}" @keydown="${this.handleKeyDown}" tabindex="0">
+    <a part="link-card" class="link-card link-card--${this.size} link-card--${this.variant}" tabindex="0" @click="${this.handleClick}" @keydown="${this.handleKeyDown}">
         <div class="link-card__content">
           <div part="title" class="link-card__title">${this.title}</div>
           ${this.additionalText ? html`<div part="additional-text" class="link-card__additional-text">${this.additionalText}</div>` : nothing }

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -11,6 +11,14 @@ export default css`
     cursor: pointer;
   }
 
+  .link-card--outline {
+     outline: var(--interactive-primary-foreground-border-focus, #008FFB)
+  }
+
+  .link-card__title {
+    transition: text-decoration 0.3s;
+  }
+
   .link-card:hover .link-card__title {
     text-decoration: underline;
   }

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -3,7 +3,7 @@ export default css`
   .link-card {
     border-radius: var(--borderRadius-large, 6px);
     padding: var(--spacing-medium, 16px) var(--spacing-large, 24px);
-    transition: background-color 0.3s, border-color 0.3s;
+    transition: background-color 0.3s, outline-color 0.3s;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -83,6 +83,7 @@ export default css`
 
   .link-card--secondary {
     background: var(--neutrals-background-secondary, #E4E5E7);  
+    transition: outline-color 0.5s;
   }
 
   .link-card--secondary:hover {

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -12,10 +12,14 @@ export default css`
   }
 
   .link-card:hover .link-card__title {
-  text-decoration: underline;
-}
+    text-decoration: underline;
+  }
 
-  .link-card--small {
+  .link-card:active {
+    outline: var(--interactive-primary-foreground-border-focus, #008FFB) solid 2px;
+    }
+
+  .link-card--small {nve-designsystem.css
     min-height: 40px;
     padding: var(--spacing-small, 12px) var(--spacing-medium, 16px);
   }
@@ -36,8 +40,6 @@ export default css`
     font-weight: 400;
     line-height: 150%;
   }
-
-
 
   .link-card__title--small {
     font-size: 0.875rem;
@@ -85,6 +87,6 @@ export default css`
 
   .link-card--secondary:hover {
     border-radius: var(--borderRadius-large, 6px);
-    border: 2px solid var(--neutrals-foreground-primary, #0D0D0E);
+    outline: var(--neutrals-foreground-primary, #0D0D0E) solid 2px;
   }
 `;

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -17,7 +17,7 @@ export default css`
 
   .link-card:active {
     outline: var(--interactive-primary-foreground-border-focus, #008FFB) solid 2px;
-    }
+  }
 
   .link-card--small {nve-designsystem.css
     min-height: 40px;

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -3,21 +3,18 @@ export default css`
   .link-card {
     border-radius: var(--borderRadius-large, 6px);
     padding: var(--spacing-medium, 16px) var(--spacing-large, 24px);
-    transition: background-color 0.3s, outline-color 0.3s;
+    transition: all 0.3s ease;
     border: 2px solid transparent;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
     cursor: pointer;
+    text-decoration: none;
   }
 
   .link-card:focus {
     outline: var(--interactive-primary-foreground-border-focus, #008FFB) solid 2px;
-  }
-
-  .link-card__title {
-    transition: text-decoration 0.3s;
   }
 
   .link-card:hover .link-card__title {

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -10,7 +10,6 @@ export default css`
     justify-content: space-between;
     align-items: center;
     cursor: pointer;
-    text-decoration: none;
   }
 
   .link-card:focus {
@@ -25,7 +24,7 @@ export default css`
     outline: var(--interactive-primary-foreground-border-focus, #008FFB) solid 2px;
   }
 
-  .link-card--small {nve-designsystem.css
+  .link-card--small {
     min-height: 40px;
     padding: var(--spacing-small, 12px) var(--spacing-medium, 16px);
   }

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -88,7 +88,6 @@ export default css`
 
   .link-card--secondary {
     background: var(--neutrals-background-secondary, #E4E5E7);  
-    transition: outline-color 0.3s;
   }
 
   .link-card--secondary:hover {

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -12,8 +12,8 @@ export default css`
     cursor: pointer;
   }
 
-  .link-card--outline {
-     outline: var(--interactive-primary-foreground-border-focus, #008FFB)
+  .link-card:focus {
+    outline: var(--interactive-primary-foreground-border-focus, #008FFB) solid 2px;
   }
 
   .link-card__title {

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -83,7 +83,7 @@ export default css`
 
   .link-card--secondary {
     background: var(--neutrals-background-secondary, #E4E5E7);  
-    transition: outline-color 0.5s;
+    transition: outline-color 0.3s;
   }
 
   .link-card--secondary:hover {

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -4,6 +4,7 @@ export default css`
     border-radius: var(--borderRadius-large, 6px);
     padding: var(--spacing-medium, 16px) var(--spacing-large, 24px);
     transition: background-color 0.3s, outline-color 0.3s;
+    border: 2px solid transparent;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -96,6 +97,6 @@ export default css`
 
   .link-card--secondary:hover {
     border-radius: var(--borderRadius-large, 6px);
-    outline: var(--neutrals-foreground-primary, #0D0D0E) solid 2px;
+    border: 2px solid var(--neutrals-foreground-primary, #0D0D0E);
   }
 `;


### PR DESCRIPTION
- Endret fra border til outline på :hover slik at innholdet ikke forskyver seg på hover.
- Lagt til en blå outline på css :active (pressed) når brukeren klikker på cardet, slik som beskrevet i Figmaskissene.
- Gjort det mulig å tabbe på cardene for bedre tilgjengelighet, lagt til en handleKeyDown funksjon slik tastaturbruker kan klikke på det ved å trykke "Enter" tasten.

fixes #451