### PR TITLE
docs: Oppdatert introduksjonssida for utviklere

### DIFF
--- a/doc-site/.vitepress/config.mts
+++ b/doc-site/.vitepress/config.mts
@@ -62,7 +62,7 @@ export default defineConfig({
           {
             text: 'For utviklere',
             items: [
-              { text: 'Utvikling', link: '/introduction/forDevelopers/development' },
+              { text: 'Les dette først', link: '/introduction/forDevelopers/development' },
               { text: 'Importering av filer', link: '/introduction/forDevelopers/import' },
               { text: 'Bruk i Vue', link: '/introduction/forDevelopers/vue' },
               { text: 'Validering', link: '/introduction/forDevelopers/validation' },

--- a/doc-site/introduction/designelementer/animasjoner.md
+++ b/doc-site/introduction/designelementer/animasjoner.md
@@ -1,34 +1,32 @@
 <PageHeader title="Animasjoner" imagePath="Animasjoner" pageLevel=1></PageHeader>
-TODO: Legg til tab komponent
 
-Animasjon er et kraftig verktøy som effektivt veileder brukere og styrer oppmerksomheten mot det essensielle. Gjennom å skape sømløse overganger tilfører animasjon en moderne dimensjon til vår visuelle profil. Vi bruker animasjon for å skape særpreg som gir en helhetlig brukeropplevelse, kamuflere nedlastningstid og skape fokus i brukergrensesnittet. 
+Animasjon er et kraftig verktøy som effektivt veileder brukere og styrer oppmerksomheten mot det essensielle. Gjennom å skape sømløse overganger tilfører animasjon en moderne dimensjon til vår visuelle profil. Vi bruker animasjon for å skape særpreg som gir en helhetlig brukeropplevelse, kamuflere nedlastningstid og skape fokus i brukergrensesnittet.
 
 ## Animasjonshastighet
+
 Animasjonshastighet refererer til hvor raskt eller sakte bevegelsene i en animasjon utføres. Det påvirker opplevelsen av animasjonen og brukerens persepsjon. Riktig animasjonshastighet er avgjørende for å oppnå ønsket effekt: for rask animasjon kan virke kaotisk eller forvirrende, mens for treg animasjon kan føles kjedelig eller ineffektiv. Tilpasning av animasjonshastigheten er en viktig designdel, og det bør balanseres for å gi en smidig, engasjerende og brukervennlig opplevelse
 
 ### Animate-short (100 ms)
+
 En rask animasjonshastighet på 100 millisekunder bidrar til å opprettholde flyt i brukeropplevelsen, samtidig som den gir en følelse av umiddelbar respons, noe som forbedrer interaktiviteten og opplevelsen av responsivt design.
 
 ### Animate-medium (300ms)
+
 Animate-medium (300ms)
-En animasjonshastighet på 300 millisekunder gir en balansert opplevelse av respons og smidighet i brukergrensesnittet. Den moderate hastigheten tillater jevne overganger og gir brukerne tilstrekkelig tid til å registrere endringer uten å oppleve forsinkelse. 
-
-
+En animasjonshastighet på 300 millisekunder gir en balansert opplevelse av respons og smidighet i brukergrensesnittet. Den moderate hastigheten tillater jevne overganger og gir brukerne tilstrekkelig tid til å registrere endringer uten å oppleve forsinkelse.
 
 ### Animate-long (600 ms)
+
 Animate-long (600 ms)
-En animasjonshastighet på 600 millisekunder passer godt for lengre animasjoner, da den gir tilstrekkelig tid til å tydelig formidle komplekse eller detaljerte bevegelser. 
+En animasjonshastighet på 600 millisekunder passer godt for lengre animasjoner, da den gir tilstrekkelig tid til å tydelig formidle komplekse eller detaljerte bevegelser.
 
-Den langsommere hastigheten gir brukerne muligheten til å absorbere informasjonen gradvis uten å føle seg overveldet. 
-
+Den langsommere hastigheten gir brukerne muligheten til å absorbere informasjonen gradvis uten å føle seg overveldet.
 
 Valget av animasjonshastighet bør tilpasses den spesifikke konteksten, bruksområdet og den ønskede brukeropplevelsen for å sikre en harmonisk og engasjerende interaksjon.
 
-
 ## Animering i Figma
+
 Komponenter fra deisgnsystemet er allerede ferdig animert i forskjellige states. Skal du lage andre animasjoner anbefales det å velge en av tre hastigheter i forhold til komplekisteten.
-
-
 
 All animasjon skal settes som enten; dissolve, eller smart animate (Ease in & out) + duration (100ms, 300ms eller 600ms).
 
@@ -38,7 +36,7 @@ All animasjon skal settes som enten; dissolve, eller smart animate (Ease in & ou
 
 </nve-alert>
 
-<hr> 
+<hr>
 
 **Les om fler designelementer på**
 <nve-button variant="neutral" href="https://nve.frontify.com/document/397706#/introduksjon/designsystem"><nve-icon name="open_in_new" slot="suffix"></nve-icon>Profil og primitiver</nve-button>

--- a/doc-site/introduction/designelementer/avstander.md
+++ b/doc-site/introduction/designelementer/avstander.md
@@ -1,5 +1,4 @@
 <PageHeader title="Avstander og luft" imagePath="avstander og luft" pageLevel=1></PageHeader>
-TODO: Legg til tab komponent
 
 # Avstander og luft
 

--- a/doc-site/introduction/designelementer/farger.md
+++ b/doc-site/introduction/designelementer/farger.md
@@ -1,5 +1,4 @@
 <PageHeader title="Farger" imagePath="tokens" pageLevel=1></PageHeader>
-TODO: Legg til tab komponent
 
 ## Farger
 

--- a/doc-site/introduction/designelementer/tokens.md
+++ b/doc-site/introduction/designelementer/tokens.md
@@ -1,13 +1,14 @@
 <PageHeader title="Tokens" imagePath="tokens" pageLevel=1></PageHeader>
-TODO: Legg til tab komponent
 
 ### Designelementer
+
 For å kunne jobbe med designsystemet er det noen par designelementer du burde gjøre deg kjent med. Tokens er elementer du måte komme til å forholde deg til fremover.
+
 <hr>
 
 # Design tokens
- 
-Design tokens er en samling av "designegenskaper", som farger, typografi, luft og andre primitiver. Disse tokensene fungerer som byggeklosser for designsystemet, og gir en effektiv måte å organisere og implementere designbeslutninger på tvers av ulike plattformer og enheter. Ved å bruke design tokens kan designere og utviklere opprettholde en enhetlig visuell identitet mens de forenkler samarbeidet og tilpasningen til ulike deler av et prosjekt. 
+
+Design tokens er en samling av "designegenskaper", som farger, typografi, luft og andre primitiver. Disse tokensene fungerer som byggeklosser for designsystemet, og gir en effektiv måte å organisere og implementere designbeslutninger på tvers av ulike plattformer og enheter. Ved å bruke design tokens kan designere og utviklere opprettholde en enhetlig visuell identitet mens de forenkler samarbeidet og tilpasningen til ulike deler av et prosjekt.
 
 <img src="../../assets/images/tokens.png" width="auto">
 
@@ -15,9 +16,9 @@ I NVE er design tokens en samling av standardiserte verdier som styrer utseendet
 
 Samlet sett gir design tokens en strukturert tilnærming til designsystemet hos NVE, noe som gir en mer effektiv, konsistent og samarbeidsvennlig designprosess.
 
-
 #### Bruk av tokens
-Designsystemet har en tokenstruktur som brukes både i for deisgnere og kode. 
+
+Designsystemet har en tokenstruktur som brukes både i for deisgnere og kode.
 
 For designere som jobber i Figma er det gjennom Figma sine "Variabler" du kan sette token på det du lager. Disse har helt lik struktur og navnkonvensjon som Token studio. Token studio er en plugin for Figma, som vi bruker for å holde oversikt og koble design verdier til tokens, som omskrives og publiseres opp til GitHub.
 
@@ -25,31 +26,33 @@ TODO: Bruke tokens som utvikler
 
 ### Tokensstruktur
 
-
 <img src="../../assets/images/tokens2.png" width="auto">
 
 #### Rå-verdier
+
 Dataen knyttet til token-navnet. Dette er ikke tokens men endelig verdier (for eksempel: RGB-farger eller pikselverdier).
 
 #### Global tokens (base-tokens)
+
 Global tokens (base-tokens)
 En token brukt på tvers av designsystemet. Dette er det motsatte av en komponentspesifikk token.
 
 #### Alias tokens
+
 Alias tokens
 En token som refererer til en annen token, i stedet for å referere til en hardkodet verdi.
 
 #### Component specific tokens
+
 Component specific tokens
 En token brukt for en bestemt komponent.
 
 #### Private tokens
+
 Private tokens
 Tokenene i denne nivået lagrer vi ekstra rå verdiene vi ikke bruker og bygger oss en bank med verdier som kan brukes for videre ekspansjon og endringer.
 
-
 <hr>
-
 
 **Les om fler designelementer på**
 <LinkButton URL="https://nve.frontify.com/" text="Profil og primitiver" :openInNewTab="true"/>

--- a/doc-site/introduction/designelementer/typography.md
+++ b/doc-site/introduction/designelementer/typography.md
@@ -1,5 +1,4 @@
 <PageHeader title="Typografi" imagePath="typografi" pageLevel=1></PageHeader>
-TODO: Legg til tab komponent
 
 ## Typografi
 

--- a/doc-site/introduction/designelementer/visuellform.md
+++ b/doc-site/introduction/designelementer/visuellform.md
@@ -1,41 +1,34 @@
 <PageHeader title="Visuell form" imagePath="Visuell form" pageLevel=1></PageHeader>
-TODO: Legg til tab komponent
-
 
 Her finner du designsystemet retningslinjer for border width, border radius og skygger.
 
-
 ## Border width
 
-Det er to alternative tykkelser på border i designsystemet: Default og Strong.  Default er standard-tykkelsen, og brukes i de fleste tilfeller. Strong brukes når en border har behov for kontrast til default-borders, og skal skille seg ut. Bruk farge for å lage et større hierarki i borders. 
+Det er to alternative tykkelser på border i designsystemet: Default og Strong. Default er standard-tykkelsen, og brukes i de fleste tilfeller. Strong brukes når en border har behov for kontrast til default-borders, og skal skille seg ut. Bruk farge for å lage et større hierarki i borders.
 
  <img src="../../assets/images/border.png" width="auto" >
 
-
 ## Border radius
-Border radius brukes konsekvent for å skille mellom elementer som er interaktive og ikke interaktive. Vi deler objekter inn i to kategorier: “Container” og “Interactive”. 
+
+Border radius brukes konsekvent for å skille mellom elementer som er interaktive og ikke interaktive. Vi deler objekter inn i to kategorier: “Container” og “Interactive”.
 
  <img src="../../assets/images/radius.png" width="auto" >
 
-
-
 ### Container
-Containers er objekter som ikke er interaktive, og de skal aldri ha avrundede hjørner (borderRadius.none). 
+
+Containers er objekter som ikke er interaktive, og de skal aldri ha avrundede hjørner (borderRadius.none).
 
 ### Interactive
+
 Interactive er interaktive objekter, som skal ha avrundede hjørner. Disse kan også deles inn i to kategorier: Interactive Small og Interactive Large. Interactive Small er små interaktive objekter som skal ha en 4px border radius. Interactive Large er større interaktive objekter som skal ha en 6px border radius.
 
-
 ## Skygger
+
 Skygge brukes til å få et element til å skille seg ut fra overflaten for å skape dybde. NVE har ett “flat” design, og skygger skal kun brukes på elementer som ligger over andre elementer, som f.eks. en sticky knapp som alltid ligger over annet innhold på siden. Skygge skal brukes forsiktig og kun på overlegg.
 
  <img src="../../assets/images/skygger.png" width="auto" >
 
-
-Du kan bruke to nivåer med skygge: Soft og Hard. Soft brukes på overlappende elementer når bakgrunnen er nedtonet og hovedsaklig består av lyse og nøytrale farger. Hard brukes på overlappende elementer når bakgrunnen er støyete og består av mange ulike farger, som f.eks. over et kart eller et bilde. 
-
-
-
+Du kan bruke to nivåer med skygge: Soft og Hard. Soft brukes på overlappende elementer når bakgrunnen er nedtonet og hovedsaklig består av lyse og nøytrale farger. Hard brukes på overlappende elementer når bakgrunnen er støyete og består av mange ulike farger, som f.eks. over et kart eller et bilde.
 
 **Les om fler designelementer på**
 <LinkButton URL="https://nve.frontify.com/" text="Profil og primitiver" :openInNewTab="true"/>

--- a/doc-site/introduction/forDesigner/contribution.md
+++ b/doc-site/introduction/forDesigner/contribution.md
@@ -1,5 +1,4 @@
 <PageHeader title="For designere" imagePath="designer" pageLevel=2></PageHeader>
-TODO: Legge til tab komponent
 
 ## Bidrag
 

--- a/doc-site/introduction/forDesigner/design.md
+++ b/doc-site/introduction/forDesigner/design.md
@@ -1,5 +1,4 @@
 <PageHeader title="For designere" imagePath="designer"  pageLevel=2></PageHeader>
-TODO: Legge til tab komponent
 
 Designsystem samler og tilgjengeliggjør verktøy, filer, komponenter og designretningslinjer som brukes av designere og utviklere for å lage gode og konsekvente brukeropplevelser i NVEs digitale tjenester.
 

--- a/doc-site/introduction/forDesigner/getStarted.md
+++ b/doc-site/introduction/forDesigner/getStarted.md
@@ -1,5 +1,4 @@
 <PageHeader title="For designere" imagePath="designer"  pageLevel=2></PageHeader>
-TODO: Legge til tab komponent
 
 # Kom igang
 

--- a/doc-site/introduction/forDevelopers/development.md
+++ b/doc-site/introduction/forDevelopers/development.md
@@ -1,17 +1,17 @@
 <PageHeader title="For utviklere" imagePath="developer"  pageLevel=2></PageHeader>
-TODO: Legg til tab komponent
 
 Her er litt generell info for for utviklere som skal bruke NVE Designsystem.
 
 Alle komponentene er [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components), og dette gjør at de skal kunne brukes i de fleste web-applikasjoner, uavhengig av rammeverk.
 Komponentene er ferdig utformet med NVE sitt design.
 
-Mange av komponentene er basert på [Shoelace](https://shoelace.style/). Det meste som står i [Shoelace-dokumentasjonen om bruk av komponenter](https://shoelace.style/getting-started/usage) gjelder også for nve-komponenter. NB! For mange av komponentene som er baserert på Shoelace må du også se i Shoelace-dokumentasjonenen for å få et komplett bilde av hva du kan gjøre med komponenten.
+Mange av komponentene er basert på [Shoelace](https://shoelace.style/). Det meste som står i [Shoelace-dokumentasjonen om bruk av komponenter](https://shoelace.style/getting-started/usage) gjelder også for nve-komponenter. 
+NB! For mange av komponentene som er baserert på Shoelace må du også se i Shoelace-dokumentasjonenen for å få et komplett bilde av hva du kan gjøre med komponenten.
 
 Kildekoden til komponentene finner du i [GitHub](https://github.com/NVE/Designsystem).
 
-Designsystemet utvikles på dugnad og etter behov.
+Designsystemet utvikles på dugnad og etter behov. Vi vil gjerne ha bidrag fra deg!
 
-Finner du feil i dokumentasjon eller komponenter, gi beskjed ved å [registrere en sak i Jira](https://nveprojects.atlassian.net/browse/DS-132) eller huk tak i f.eks. Cathrine, Joel, Marcin eller Øystein. Kanskje noen allerede jobber med akkurat dette problemet ?
+Finner du feil i dokumentasjon eller komponenter, sjekk aktuell komponent i [komponentoversikten](https://designsystem.nve.no/components/Komponentoversikt.html) om feilen allerede er registrert. Om ikke, [registrer en sak i Github](https://github.com/NVE/Designsystem/issues). Gi gjerne saken til deg selv om du ønsker å fikse problemet med en gang, men det kan være lurt å melde fra om dette også på [FUX-forum i Teams](https://teams.microsoft.com/l/channel/19%3A3vNPKWAB1NfvK_GxsEsNWj04elWJ8WrylwsoZF9KaOY1%40thread.tacv2/FUX%20Forum?groupId=ec755ca5-8bfc-4a59-b502-d9721ef8eda4&tenantId=bc8d840d-60c9-410b-b4fb-11b86806780c&ngc=true&allowXTenantAccess=true) , så folk får vite at noen er på saken. Der kan man også stille spørsmål om man lurer på noe.
 
-Er det småting som bør fikses, lag gjerne en [pull request i Github](https://github.com/NVE/Designsystem/pulls), men les [readme](https://github.com/NVE/Designsystem) først. Readme inneholder både tips og en del kjøreregler for _utvikling_ av designsystemet.
+Skal du gjøre endringer, les [readme](https://github.com/NVE/Designsystem) først. Readme inneholder både tips og en del kjøreregler for _utvikling_ av designsystemet.

--- a/doc-site/introduction/forDevelopers/development.md
+++ b/doc-site/introduction/forDevelopers/development.md
@@ -1,17 +1,21 @@
 <PageHeader title="For utviklere" imagePath="developer"  pageLevel=2></PageHeader>
 
-Her er litt generell info for for utviklere som skal bruke NVE Designsystem.
+Her er litt generell info for utviklere som skal bruke NVE Designsystem.
 
 Alle komponentene er [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components), og dette gjør at de skal kunne brukes i de fleste web-applikasjoner, uavhengig av rammeverk.
 Komponentene er ferdig utformet med NVE sitt design.
 
-Mange av komponentene er basert på [Shoelace](https://shoelace.style/). Det meste som står i [Shoelace-dokumentasjonen om bruk av komponenter](https://shoelace.style/getting-started/usage) gjelder også for nve-komponenter. 
+Mange av komponentene er basert på [Shoelace](https://shoelace.style/). Det meste som står i [Shoelace-dokumentasjonen om bruk av komponenter](https://shoelace.style/getting-started/usage) gjelder også for nve-komponenter.
 NB! For mange av komponentene som er baserert på Shoelace må du også se i Shoelace-dokumentasjonenen for å få et komplett bilde av hva du kan gjøre med komponenten.
 
 Kildekoden til komponentene finner du i [GitHub](https://github.com/NVE/Designsystem).
 
 Designsystemet utvikles på dugnad og etter behov. Vi vil gjerne ha bidrag fra deg!
 
-Finner du feil i dokumentasjon eller komponenter, sjekk aktuell komponent i [komponentoversikten](https://designsystem.nve.no/components/Komponentoversikt.html) om feilen allerede er registrert. Om ikke, [registrer en sak i Github](https://github.com/NVE/Designsystem/issues). Gi gjerne saken til deg selv om du ønsker å fikse problemet med en gang, men det kan være lurt å melde fra om dette også på [FUX-forum i Teams](https://teams.microsoft.com/l/channel/19%3A3vNPKWAB1NfvK_GxsEsNWj04elWJ8WrylwsoZF9KaOY1%40thread.tacv2/FUX%20Forum?groupId=ec755ca5-8bfc-4a59-b502-d9721ef8eda4&tenantId=bc8d840d-60c9-410b-b4fb-11b86806780c&ngc=true&allowXTenantAccess=true) , så folk får vite at noen er på saken. Der kan man også stille spørsmål om man lurer på noe.
+Finner du feil i dokumentasjon eller komponenter, sjekk aktuell komponent i [komponentoversikten](https://designsystem.nve.no/components/Komponentoversikt.html) om feilen allerede er registrert. Om ikke, [registrer en sak i Github](https://github.com/NVE/Designsystem/issues). Gi gjerne saken til deg selv om du ønsker å fikse problemet med en gang, men det kan være lurt å melde fra om dette også på [FUX-forum i Teams](https://teams.microsoft.com/l/channel/19%3A3vNPKWAB1NfvK_GxsEsNWj04elWJ8WrylwsoZF9KaOY1%40thread.tacv2/FUX%20Forum?groupId=ec755ca5-8bfc-4a59-b502-d9721ef8eda4&tenantId=bc8d840d-60c9-410b-b4fb-11b86806780c&ngc=true&allowXTenantAccess=true), så folk får vite at noen er på saken. Der kan man også stille spørsmål om man lurer på noe.
 
-Skal du gjøre endringer, les [readme](https://github.com/NVE/Designsystem) først. Readme inneholder både tips og en del kjøreregler for _utvikling_ av designsystemet.
+<nve-message-card title="Les readme">Les Readme før du endrer noe i Designsystemet. Der finner du tips og en del kjøreregler for utvikling av designsystemet.
+<slot name="Footer">
+<a href="https://github.com/NVE/Designsystem" target="_blank">Link til readme</a>
+</slot>
+</nve-message-card>

--- a/doc-site/introduction/forDevelopers/vue.md
+++ b/doc-site/introduction/forDevelopers/vue.md
@@ -1,5 +1,4 @@
 <PageHeader title="For utviklere" imagePath="developer"  pageLevel=2></PageHeader>
-TODO: Legge til tab komponent
 
 # Bruk av designsystemet i Vue 3
 

--- a/doc-site/introduction/forDevelopers/vue.md
+++ b/doc-site/introduction/forDevelopers/vue.md
@@ -107,5 +107,3 @@ const count = ref(0);
 Hvis du ikke ser komponenten når du kjører sida, sjekk om du har importert den riktig.
 
 Les også om [bruk av Shoelace-komponenter i Vue](https://shoelace.style/frameworks/vue). Det meste der gjelder for Nve-komponenter også.
-
-<nve-message-card title="Tips">Bruke både opening og closing tag individuelt. &lt;nve-button /&gt; funker ikke i Vue.</nve-message-card>

--- a/doc-site/introduction/home.md
+++ b/doc-site/introduction/home.md
@@ -1,5 +1,4 @@
 <PageHeader title="Introduksjon" imagePath="intro" pageLevel=1></PageHeader>
-TODO: Legg til tab komponent
 
 # Om designsystemet
 


### PR DESCRIPTION
Fjernet link til Jira og skrevet tydeligere hvordan man bør gå fram for å melde feil og bidra til endringer.
Har også endret menyvalget fra "Utvikling" til "Les dette først":
![image](https://github.com/user-attachments/assets/2d7957e5-9b7b-4e55-86a7-d802e7db6534)

Fjernet også denne teksten:
 _TODO: Legg til tab komponent_ 
fra en rekke sider, siden vi ble enige om å droppe faner.

