### PR TITLE
fix(nve-input): rettet hover-effekt over label i nve-input med skrivebeskyttelse

### DIFF
--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -77,13 +77,19 @@ export default css`
     border-color: var(--neutrals-background-secondary);
     background: var(--neutrals-background-secondary);
   }
-  :host([readonly]) :is(:hover, .input--focused) {
-    border-color: transparent;
-    background: var(--neutrals-background-secondary);
-    outline: none;
-  }
+
   :host([readonly]) .input.input--standard:hover:not(.input--disabled) {
     border-color: transparent !important;
+    background: var(--neutrals-background-secondary);
+  }
+
+  :host([readonly]) .input.input--medium.input--standard {
+    border-color: transparent !important;
+    background: var(--neutrals-background-secondary);
+  }
+
+  :host([readonly]) .input--standard.input--focused:not(.input--disabled) {
+    outline: var(--neutrals-background-secondary);
   }
 
   /* Gir rød ramme ved valideringsfeil  */


### PR DESCRIPTION
Rettet hover-effekt over label i nve-input med skrivebeskyttelse

**Før**
![Skjermbilde 2025-03-05 095101](https://github.com/user-attachments/assets/d6f52e0f-c651-4fe3-a813-36fd7e23a068)


**Etter**
![image](https://github.com/user-attachments/assets/9a788918-ef67-4d50-8938-a5d8653191e7)
