### PR TITLE
doc: Vise hvem som har ansvar for en oppgave knytta til en komponent

### DIFF
--- a/doc-site/.vitepress/theme/components/ComponentIssues.vue
+++ b/doc-site/.vitepress/theme/components/ComponentIssues.vue
@@ -6,9 +6,14 @@
       <a class="header-anchor" href="#issues" aria-label='Permalink to "Issues"'>&ZeroWidthSpace;</a>
     </h2>
   </div>
-  <ul v-if="issues?.length > 0">
+  <ul v-if="issues?.length">
     <li v-for="issue of issues">
-      <a :href="issue.url" target="_blank">{{ issue.title }} <span v-if="issue.isPullRequest"> (PR) </span></a>
+      <a :href="issue.url" target="_blank">{{ issue.title }} <span v-if="issue.isPullRequest"> (PR) </span> </a>
+      <span v-if="issue.assigneeLogins.length">
+        <nve-badge v-for="user in issue.assigneeLogins" :key="user" variant="neutral" size="small">{{
+          user
+        }}</nve-badge>
+      </span>
     </li>
   </ul>
   <p v-else v-if="showHeader">

--- a/doc-site/.vitepress/theme/github.services.ts
+++ b/doc-site/.vitepress/theme/github.services.ts
@@ -3,15 +3,22 @@
  * For å koble en sak eller PR i Github til en komponent, merk den med komponent-navnet, f.eks. `nve-checkbox`
  */
 import { request } from '@octokit/request';
-import { componentNames } from './customElementsManifest.store';
 
 /**
  * En sak eller PR i Github
  */
 export interface Issue {
+  /** Sammendrag / tittel */
   title: string;
+
+  /** Link til saken */
   url: string;
+
+  /** true hvis denne er en PR */
   isPullRequest: boolean;
+
+  /** En liste av brukernavn til ansvarlige. Tom liste = ingen som har ansvar for saken */
+  assigneeLogins: string[];
 }
 
 /**
@@ -33,15 +40,16 @@ export const fetchIssues = async (): Promise<Map<string, Issue[]>> => {
       });
       response.data.forEach((issue: any) => {
         issue.labels.forEach((label: any) => {
-          // Sjekker om denne saken er merka med et komponentnavn. 
-          // Vi sjekker ikke mot komponentregisteret, 
-          // for vi vil også ha med navn på komponenter som ikke er laget ennå 
+          // Sjekker om denne saken er merka med et komponentnavn.
+          // Vi sjekker ikke mot komponentregisteret,
+          // for vi vil også ha med navn på komponenter som ikke er laget ennå
           if (label.name?.startsWith('nve-')) {
             const issuesForThisComponent = issuesPerComponent.get(label.name) || [];
             issuesForThisComponent.push({
               title: issue.title,
               url: issue.html_url,
               isPullRequest: issue.pull_request,
+              assigneeLogins: issue.assignees.map((assignee: any) => assignee.login),
             });
             issuesPerComponent.set(label.name, issuesForThisComponent);
           }


### PR DESCRIPTION
Nå viser vi brukernavnet til evt. ansvarlig(e) for en oppgave i komponentoversikten og på sida for en komponent:

![image](https://github.com/user-attachments/assets/bb9a37dc-49d6-4efa-b9ea-4a28e33e396a)


fixes #436 