### PR TITLE
fix(tokens): sørge for at large desktop tar breakpoint på min-width 1…

### DIFF
--- a/doc-site/.vitepress/theme/styles/nve_theme.css
+++ b/doc-site/.vitepress/theme/styles/nve_theme.css
@@ -955,7 +955,7 @@
   --supplemental-emphasized-blue-background: var(--blue-300);
   --supplemental-emphasized-blue-foreground: var(--grey-999); }
 
-@media (max-width:1400px) { 
+@media (min-width: 1400px) {
 :root.nve, :root.nve_darkmode {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;
@@ -1007,7 +1007,7 @@
   --font-size-3xlarge: var(--dimension-12x);
 }
 }
-@media (max-width:1200px) { 
+@media (max-width: 1200px) {
 :root.nve, :root.nve_darkmode {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;
@@ -1059,7 +1059,7 @@
   --font-size-3xlarge: var(--dimension-11x);
 }
 }
-@media (max-width:600px) { 
+@media (max-width: 600px) {
 :root.nve, :root.nve_darkmode {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;

--- a/doc-site/.vitepress/theme/styles/varsom_theme.css
+++ b/doc-site/.vitepress/theme/styles/varsom_theme.css
@@ -15,7 +15,7 @@
   --brand-050: #fbc792;
   --grey-100: #f7f7f8;
   --grey-150: #c8eaf9;
-  --grey-200: #c9cbcf;
+  --grey-200: #7ec4e2;
   --grey-300: #b7babf;
   --grey-400: #9fa3a9;
   --grey-500: #878c94;
@@ -537,7 +537,7 @@
   --brand-050: #fbc792;
   --grey-100: #f7f7f8;
   --grey-150: #c8eaf9;
-  --grey-200: #c9cbcf;
+  --grey-200: #7ec4e2;
   --grey-300: #b7babf;
   --grey-400: #9fa3a9;
   --grey-500: #878c94;
@@ -955,7 +955,7 @@
   --supplemental-emphasized-blue-background: var(--blue-300);
   --supplemental-emphasized-blue-foreground: var(--grey-999); }
 
-@media (max-width:1400px) { 
+@media (min-width: 1400px) {
 :root.varsom, :root.varsom_darkmode {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;
@@ -1007,7 +1007,7 @@
   --font-size-3xlarge: var(--dimension-12x);
 }
 }
-@media (max-width:1200px) { 
+@media (max-width: 1200px) {
 :root.varsom, :root.varsom_darkmode {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;
@@ -1059,7 +1059,7 @@
   --font-size-3xlarge: var(--dimension-11x);
 }
 }
-@media (max-width:600px) { 
+@media (max-width: 600px) {
 :root.varsom, :root.varsom_darkmode {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;

--- a/public/css/nve.css
+++ b/public/css/nve.css
@@ -526,7 +526,7 @@
   --fixed-sizing-x-large: var(--dimension-12x);
   --fixed-sizing-2x-large: var(--dimension-14x);
   --fixed-sizing-3x-large: var(--dimension-16x); }
-@media (max-width:1400px) { 
+@media (min-width: 1400px) {
 :root {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;
@@ -578,7 +578,7 @@
   --font-size-3xlarge: var(--dimension-12x);
 }
 }
-@media (max-width:1200px) { 
+@media (max-width: 1200px) {
 :root {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;
@@ -630,7 +630,7 @@
   --font-size-3xlarge: var(--dimension-11x);
 }
 }
-@media (max-width:600px) { 
+@media (max-width: 600px) {
 :root {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;

--- a/public/css/varsom.css
+++ b/public/css/varsom.css
@@ -21,7 +21,7 @@
   --brand-050: #fbc792;
   --grey-100: #f7f7f8;
   --grey-150: #c8eaf9;
-  --grey-200: #c9cbcf;
+  --grey-200: #7ec4e2;
   --grey-300: #b7babf;
   --grey-400: #9fa3a9;
   --grey-500: #878c94;
@@ -526,7 +526,7 @@
   --fixed-sizing-x-large: var(--dimension-12x);
   --fixed-sizing-2x-large: var(--dimension-14x);
   --fixed-sizing-3x-large: var(--dimension-16x); }
-@media (max-width:1400px) { 
+@media (min-width: 1400px) {
 :root {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;
@@ -578,7 +578,7 @@
   --font-size-3xlarge: var(--dimension-12x);
 }
 }
-@media (max-width:1200px) { 
+@media (max-width: 1200px) {
 :root {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;
@@ -630,7 +630,7 @@
   --font-size-3xlarge: var(--dimension-11x);
 }
 }
-@media (max-width:600px) { 
+@media (max-width: 600px) {
 :root {
   --spacing-none: 0;
   --content-margin-top-bottom-mobile: 24px;

--- a/public/css/varsom_dark.css
+++ b/public/css/varsom_dark.css
@@ -21,7 +21,7 @@
   --brand-050: #fbc792;
   --grey-100: #f7f7f8;
   --grey-150: #c8eaf9;
-  --grey-200: #c9cbcf;
+  --grey-200: #7ec4e2;
   --grey-300: #b7babf;
   --grey-400: #9fa3a9;
   --grey-500: #878c94;

--- a/transformTokens/transform.js
+++ b/transformTokens/transform.js
@@ -32,13 +32,13 @@ myStyleDictionary.registerFormat({
 myStyleDictionary.registerFormat({
   name: 'css/device',
   format: ({ dictionary, options }) => {
-    const { outputReferences } = options;
-    return options.maxWidth
-      ? `${'@media (max-width:' + options.maxWidth + 'px) { \n'}` +
+    const { outputReferences, minWidth, maxWidth } = options;
+    return minWidth || maxWidth
+      ? `@media (${maxWidth ? 'max-width' : 'min-width'}: ${maxWidth || minWidth}px) {\n` +
           `:root {\n` +
           formattedVariables({ format: 'css', dictionary, outputReferences }) +
-          '\n}' +
-          '\n}\n'
+          '\n}\n' +
+          '}\n'
       : formattedVariables({ format: 'css', dictionary, outputReferences });
   },
 });
@@ -62,7 +62,7 @@ const filterDevicesTokens = (token) => {
   );
 };
 
-const transformDeviceTokens = async (device, maxWidth) => {
+const transformDeviceTokens = async (device, minWidth, maxWidth) => {
   const deviceTokens = await myStyleDictionary.extend({
     source: [
       'tokens/$metadata.json',
@@ -82,6 +82,7 @@ const transformDeviceTokens = async (device, maxWidth) => {
             format: 'css/device',
             options: {
               outputReferences: true,
+              minWidth: minWidth,
               maxWidth: maxWidth,
             },
           },
@@ -94,13 +95,13 @@ const transformDeviceTokens = async (device, maxWidth) => {
 
 const devices = [
   { name: 'desktop' },
-  { name: 'desktop-large', maxWidth: 1400 },
+  { name: 'desktop-large', minWidth: 1400 },
   { name: 'desktop-small', maxWidth: 1200 },
   { name: 'mobile', maxWidth: 600 },
 ];
 
 // transform alle tilgjengelige gjenstander
-devices.forEach(async ({ name, maxWidth }) => await transformDeviceTokens(name, maxWidth));
+devices.forEach(async ({ name, minWidth, maxWidth }) => await transformDeviceTokens(name, minWidth, maxWidth));
 
 const nveTokensLight = await myStyleDictionary.extend({
   source: ['tokens/brand/nve.json', 'tokens/*json', 'tokens/public/theme/light.json'],


### PR DESCRIPTION
Det er en liten feil i breakpoints i .css-filene. 'desktop-large' burde være for alt som er større enn 1400px, mens 'desktop' burde være for alt som er mellom 1200px og 1400px. I dag er det omvendt. Denne PR-en fikser problemet. Brukere skal ikke merke noen forskjell, fordi både desktop og desktop-large bruker de samme verdiene, men i fremtiden, dersom vi bestemmer oss for å sette nye breakpoints, kan dette påvirke arbeidet negativt. Det er viktig å fikse dette fordi vi informerte brukerne om hvordan breakpoints settes på Teams, og det ser ut som løsningen gjør tingene litt annerledes...
#mybad