### PR TITLE
docs(typography): oppgradert typografi dokumentasjon

### DIFF
--- a/doc-site/.vitepress/theme/components/TypographyTable.vue
+++ b/doc-site/.vitepress/theme/components/TypographyTable.vue
@@ -1,8 +1,9 @@
+<!-- Viser en font verdi tabell for et valgt innhold (se TableContent type), og for en valgt skjermbredde -->
 <template>
   <div v-if="cssTokenState.stateInitialized" ref="componentRoot" class="typography-table">
     <nve-radio-group
       size="large"
-      label="Skjerm størrelse:"
+      label="Skjermbredde:"
       orientation="horizontal"
       value="default"
       @sl-input="setResolution($event.target.value)"

--- a/doc-site/.vitepress/theme/components/TypographyTable.vue
+++ b/doc-site/.vitepress/theme/components/TypographyTable.vue
@@ -1,0 +1,203 @@
+<template>
+  <div v-if="cssTokenState.stateInitialized" ref="componentRoot" class="typography-table">
+    <nve-radio-group
+      size="large"
+      label="Skjerm størrelse:"
+      orientation="horizontal"
+      value="default"
+      @sl-input="setResolution($event.target.value)"
+    >
+      <nve-radio value="600">mindre enn 600 px</nve-radio>
+      <nve-radio value="1200">mindre enn 1200 px </nve-radio>
+      <nve-radio value="default"> Standard </nve-radio>
+      <nve-radio value="1400">større enn 1400 px </nve-radio>
+    </nve-radio-group>
+
+    <ul v-if="tableContentType === 'default'" class="font-list font-list--border-top">
+      <li
+        v-for="(value, key) in currentResolutionValues"
+        :key="key"
+        :style="{ 'font-size': `var(${key})`, 'line-height': '100%' }"
+      >
+        {{ key }} {{ value }}
+      </li>
+    </ul>
+    <template v-else>
+      <div class="font-list__container">
+        <table>
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>font-weight</th>
+              <th>font-size</th>
+              <th>line-height</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(value, key) in tableContent" :key="key">
+              <td>{{ key }}</td>
+              <td>{{ value.weight }}</td>
+              <td>{{ value.size }}</td>
+              <td>{{ value.lineHeight }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <ul class="font-list">
+          <li v-for="(value, key) in tableContent" :key="key" :style="{ font: `var(${key})` }">
+            {{ key }} {{ value.size }}
+          </li>
+        </ul>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { cssTokenState } from '../cssTokenState';
+import { FontValues, TableContent } from '../types/FontValues';
+
+const props = defineProps<{
+  tableContentType: TableContent;
+}>();
+
+const componentRoot = ref<HTMLElement | null>(null);
+const tableContent = ref<Record<string, FontValues>>({});
+const screenSizeRadio = ref<string>('default');
+const currentResolutionValues = ref<Record<string, string>>(
+  Object.fromEntries(Object.entries(cssTokenState.fontTokensDefault).reverse())
+);
+
+const setResolution = (resolution: 'default' | '1400' | '1200' | '600') => {
+  screenSizeRadio.value = resolution;
+  let fontTokensObject: { [key: string]: string } = {};
+  switch (resolution) {
+    case '1400':
+      fontTokensObject = cssTokenState.fontTokens1400;
+      break;
+    case '1200':
+      fontTokensObject = cssTokenState.fontTokens1200;
+      break;
+    case '600':
+      fontTokensObject = cssTokenState.fontTokens600;
+      break;
+    default:
+      fontTokensObject = cssTokenState.fontTokensDefault;
+  }
+  const reversedFontTokensObject = Object.fromEntries(Object.entries(fontTokensObject).reverse()); //TODO: this doesnt work so well
+  currentResolutionValues.value = reversedFontTokensObject;
+  if (props.tableContentType !== 'default') {
+    cssTokenState.updateFontValuesPerTableContent(props.tableContentType, fontTokensObject);
+  }
+};
+
+watch(
+  () => currentResolutionValues.value,
+  (newValue) => {
+    Object.entries(newValue).map((entry) => {
+      const [key, value] = entry;
+      componentRoot.value?.style.setProperty(key, value);
+    });
+  },
+  { immediate: true }
+);
+
+watch(
+  () => [
+    cssTokenState.headers,
+    cssTokenState.subHeaders,
+    cssTokenState.ingress,
+    cssTokenState.body,
+    cssTokenState.bodyCompact,
+    cssTokenState.detailText,
+    cssTokenState.label,
+  ],
+  () => {
+    switch (props.tableContentType) {
+      case 'default':
+        tableContent.value = cssTokenState.headers;
+        break;
+      case 'headers':
+        tableContent.value = cssTokenState.headers;
+        break;
+      case 'subheaders':
+        tableContent.value = cssTokenState.subHeaders;
+        break;
+      case 'ingress':
+        tableContent.value = cssTokenState.ingress;
+        break;
+      case 'body':
+        tableContent.value = cssTokenState.body;
+        break;
+      case 'body-compact':
+        tableContent.value = cssTokenState.bodyCompact;
+        break;
+      case 'detail-text':
+        tableContent.value = cssTokenState.detailText;
+        break;
+      case 'label':
+        tableContent.value = cssTokenState.label;
+        break;
+    }
+
+    Object.entries(tableContent.value).map((entry) => {
+      const [key, value] = entry;
+      const a = `${value.weight} ${value.size} / ${value.lineHeight} 'Source Sans Pro'`;
+      componentRoot.value?.style.setProperty(key, a);
+    });
+  },
+  { immediate: true }
+);
+</script>
+
+<style scoped>
+.typography-table {
+  display: flex;
+  flex-direction: column;
+}
+
+table {
+  --vp-c-divider: var(--grey-200);
+  border: solid 1px var(--grey-200);
+}
+
+.vp-doc tr:nth-child(2n) {
+  background-color: unset;
+}
+
+nve-radio-group {
+  border: solid 1px var(--grey-200);
+  border-bottom: none;
+  border-radius: 3px 3px 0px 0px;
+  padding: 10px;
+}
+
+.font-list {
+  border-bottom: solid 1px var(--grey-200);
+  border-left: solid 1px var(--grey-200);
+  border-right: solid 1px var(--grey-200);
+  border-radius: 0px 0px 3px 3px;
+  min-width: 20rem;
+  max-width: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  list-style: none !important;
+  background: #f6f6f7;
+}
+
+.font-list--border-top {
+  border-top: solid 1px var(--grey-200);
+}
+
+.font-list__container table,
+ul {
+  margin: 0;
+}
+
+.font-list__container table {
+  display: table;
+}
+</style>

--- a/doc-site/.vitepress/theme/cssTokenState.ts
+++ b/doc-site/.vitepress/theme/cssTokenState.ts
@@ -1,0 +1,233 @@
+import { reactive, ref } from 'vue';
+import { FontValues, FontVariables, TableContent } from './types/FontValues';
+
+/** Om css tilstand er initialisert */
+const stateInitialized = ref(false);
+
+/** Objekt med font-token-navn som nøkkel og token-verdi som verdi for standard skjermstørrelsen */
+const fontTokensDefault = ref<Record<string, string>>({});
+/** Objekt med font-token-navn som nøkkel og token-verdi som verdi for skjermstørrelsen over 1400px */
+const fontTokens1400 = ref<Record<string, string>>({});
+/** Objekt med font-token-navn som nøkkel og token-verdi som verdi for skjermstørrelsen mindre enn 1200px */
+const fontTokens1200 = ref<Record<string, string>>({});
+/** Objekt med font-token-navn som nøkkel og token-verdi som verdi for skjermstørrelsen mindre enn 600px */
+const fontTokens600 = ref<Record<string, string>>({});
+
+/** Objekt med line-height-token-navn som nøkkel og token-verdi som verdi */
+const lineHeightsObject = ref<Record<string, string>>({});
+/** Objekt med font-weight-token-navn som nøkkel og token-verdi som verdi */
+const fontWeightsObject = ref<Record<string, string>>({});
+
+/** Objekt med header-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde faktiske verdier som verdi. */
+const headers = ref<Record<string, FontValues>>({});
+/** Objekt med subheader-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde faktiske verdier som verdi. */
+const subHeaders = ref<Record<string, FontValues>>({});
+/** Objekt med ingress-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde faktiske verdier som verdi. */
+const ingress = ref<Record<string, FontValues>>({});
+/** Objekt med body-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde faktiske verdier som verdi. */
+const body = ref<Record<string, FontValues>>({});
+/** Objekt med body-compact-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde faktiske verdier som verdi. */
+const bodyCompact = ref<Record<string, FontValues>>({});
+/** Objekt med detailtext-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde faktiske verdier som verdi. */
+const detailText = ref<Record<string, FontValues>>({});
+/** Objekt med label-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde faktiske verdier som verdi. */
+const label = ref<Record<string, FontValues>>({});
+
+/** Objekt med header-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde token-navn som verdi. */
+const headersVariables: (FontVariables | null)[] = [];
+/** Objekt med subheader-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde token-navn som verdi. */
+const subheadersVariables: (FontVariables | null)[] = [];
+/** Objekt med ingress-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde token-navn som verdi. */
+const ingressVariables: (FontVariables | null)[] = [];
+/** Objekt med body-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde token-navn som verdi. */
+const bodyVariables: (FontVariables | null)[] = [];
+/** Objekt med body-compact-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde token-navn som verdi. */
+const bodyCompactVariables: (FontVariables | null)[] = [];
+/** Objekt med detailtext-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde token-navn som verdi. */
+const detailTextVariables: (FontVariables | null)[] = [];
+/** Objekt med label-font-token-navn som nøkkel og font-vekt, font-størrelsen og linje høyde token-navn som verdi. */
+const labelVariables: (FontVariables | null)[] = [];
+
+/**
+ * Initialiserer font variabeler og verdier fra en css fil
+ * @param cssFileContent
+ */
+const initGlobalState = (cssFileContent: string) => {
+  const cssContentDefault: string[] = cssFileContent.match(/:root\.nve\s*\{([\s\S]*?)\}/) || [];
+  const cssContent1400px: string[] = cssFileContent.match(/@media\s*\(min-width:\s*1400px\)\s*\{([\s\S]*?)\}/) || [];
+  const cssContent1200px: string[] = cssFileContent.match(/@media\s*\(max-width:\s*1200px\)\s*\{([\s\S]*?)\}/) || [];
+  const cssContent600px: string[] = cssFileContent.match(/@media\s*\(max-width:\s*600px\)\s*\{([\s\S]*?)\}/) || [];
+
+  const dimensionsReg: string[] = cssFileContent.match(/(--dimension-[\d-]+x):\s*([^;]+);/g) || [];
+
+  const cssFontTokens1400px: string[] = cssContent1400px[1].match(/--font-size-[a-z0-9-]+:\s*[^;]+;/g) || [];
+  const cssFontTokens1200px: string[] = cssContent1200px[1].match(/--font-size-[a-z0-9-]+:\s*[^;]+;/g) || [];
+  const cssFontTokens600px: string[] = cssContent600px[1].match(/--font-size-[a-z0-9-]+:\s*[^;]+;/g) || [];
+  const cssFontTokensDefault: string[] = cssContentDefault[1].match(/--font-size-[a-z0-9-]+:\s*[^;]+;/g) || [];
+  const fontWeights: string[] = cssFileContent.match(/--font-weight-[a-z0-9-]+:\s*[^;]+;/g) || [];
+
+  const lineHeights: string[] = cssFileContent.match(/--line-heights-[\d\w]+:\s*[^;]+;/g) || [];
+
+  const cssHeaderFonts: string[] = cssFileContent.match(/--header-[a-z0-9-]+:\s*[^;]+;/g) || [];
+  const cssSubHeaderFonts: string[] = cssFileContent.match(/--subheading-[a-z0-9-]+:\s*[^;]+;/g) || [];
+  const ingressFonts: string[] = cssFileContent.match(/--ingress-[a-z0-9-]+:\s*[^;]+;/g) || [];
+  const bodyFonts: string[] = cssFileContent.match(/--body-(?!.*(?:-underline|-compact))[^;]+;\s*/g) || [];
+  const bodyCompactFonts: string[] = cssFileContent.match(/--body-compact(?!.*(?:-underline))[^;]+;\s*/g) || [];
+  const detailTextFonts: string[] = cssFileContent.match(/--detailtext-[a-z0-9-]+:\s*[^;]+;/g) || [];
+  const labelFonts: string[] = cssFileContent.match(/--label-[a-z0-9-]+:\s*[^;]+;/g) || [];
+
+  // returnerer {--dimension-1x: "0.25rem"}
+  const dimensions = Object.fromEntries(
+    dimensionsReg.map((entry) => {
+      const [key, value] = entry
+        .replace(';', '')
+        .split(':')
+        .map((str) => str.trim());
+      return [key, value];
+    })
+  );
+
+  fontTokensDefault.value = getFontSizeDimension(cssFontTokensDefault);
+  fontTokens1400.value = getFontSizeDimension(cssFontTokens1400px);
+  fontTokens1200.value = getFontSizeDimension(cssFontTokens1200px);
+  fontTokens600.value = getFontSizeDimension(cssFontTokens600px);
+
+  lineHeightsObject.value = Object.fromEntries(
+    lineHeights.map((entry) => {
+      const [key, value] = entry
+        .replace(';', '')
+        .split(':')
+        .map((str) => str.trim());
+      return [key, value];
+    })
+  );
+
+  fontWeightsObject.value = Object.fromEntries(
+    fontWeights.map((entry) => {
+      const [key, value] = entry
+        .replace(';', '')
+        .split(':')
+        .map((str) => str.trim());
+      return [key, value];
+    })
+  );
+
+  headersVariables.push(...getFontVariables(cssHeaderFonts));
+  subheadersVariables.push(...getFontVariables(cssSubHeaderFonts));
+  ingressVariables.push(...getFontVariables(ingressFonts));
+  bodyVariables.push(...getFontVariables(bodyFonts));
+  bodyCompactVariables.push(...getFontVariables(bodyCompactFonts));
+  detailTextVariables.push(...getFontVariables(detailTextFonts));
+  labelVariables.push(...getFontVariables(labelFonts));
+
+  headers.value = getFontValues(headersVariables, fontTokensDefault.value);
+  subHeaders.value = getFontValues(subheadersVariables, fontTokensDefault.value);
+  ingress.value = getFontValues(ingressVariables, fontTokensDefault.value);
+  body.value = getFontValues(bodyVariables, fontTokensDefault.value);
+  bodyCompact.value = getFontValues(bodyCompactVariables, fontTokensDefault.value);
+  detailText.value = getFontValues(detailTextVariables, fontTokensDefault.value);
+  label.value = getFontValues(labelVariables, fontTokensDefault.value);
+
+  stateInitialized.value = true;
+
+  // returnerer {--font-size-2xsmall: '0.875rem}
+  function getFontSizeDimension(fontTokens: string[]): Record<string, string> {
+    return Object.fromEntries(
+      fontTokens.map((entry) => {
+        const [key, value] = entry
+          .replace(';', '')
+          .split(':')
+          .map((str) => str.trim());
+        return [key, dimensions[value.replace(/^var\((.*)\)$/, '$1')]];
+      })
+    );
+  }
+
+  //returnerer --header-large: {size: --font-size}
+  function getFontVariables(cssContent: string[]): (FontVariables | null)[] {
+    return cssContent.map((entry) => {
+      const keyMatch = entry.match(/(--[\w-]+):/);
+      const weightMatch = entry.match(/var\((--font-weight-[\w-]+)\)/);
+      const sizeMatch = entry.match(/var\((--font-size-[\w-]+)\)/);
+      const lineHeightMatch = entry.match(/var\((--line-heights-[\w-]+)\)/);
+      if (!weightMatch || !sizeMatch || !lineHeightMatch || !keyMatch) {
+        return null;
+      }
+      return { [keyMatch[1]]: { weight: weightMatch[1], size: sizeMatch[1], lineHeight: lineHeightMatch[1] } };
+    });
+  }
+};
+
+/**
+ * Gjør om font-token verdier til faktiske verdier
+ * @param fonts
+ * @param currentResolutionValues
+ * @returns riktige font verdier for valgt skjermstørrelse
+ */
+const getFontValues = (
+  fonts: (FontVariables | null)[],
+  currentResolutionValues: Record<string, string>
+): Record<string, FontValues> => {
+  const fontValues: Record<string, FontValues> = {};
+  fonts.forEach((font) => {
+    if (font) {
+      const [key, value] = Object.entries(font)[0];
+      if (value.weight && value.size && value.lineHeight) {
+        fontValues[key] = {
+          weight: fontWeightsObject.value[value.weight],
+          size: currentResolutionValues[value.size],
+          lineHeight: lineHeightsObject.value[value.lineHeight],
+        };
+      }
+    }
+  });
+  return fontValues;
+};
+
+/**
+ * Oppdaterer font verdier per spesifikk TableContent for valgte skjerm størrelser
+ * @param tableContent
+ * @param newResolutionValues
+ */
+const updateFontValuesPerTableContent = (tableContent: TableContent, newResolutionValues: Record<string, string>) => {
+  switch (tableContent) {
+    case 'headers':
+      headers.value = getFontValues(headersVariables, newResolutionValues);
+      break;
+    case 'subheaders':
+      subHeaders.value = getFontValues(subheadersVariables, newResolutionValues);
+      break;
+    case 'ingress':
+      ingress.value = getFontValues(ingressVariables, newResolutionValues);
+      break;
+    case 'body':
+      body.value = getFontValues(bodyVariables, newResolutionValues);
+      break;
+    case 'body-compact':
+      bodyCompact.value = getFontValues(bodyCompactVariables, newResolutionValues);
+      break;
+    case 'detail-text':
+      detailText.value = getFontValues(detailTextVariables, newResolutionValues);
+      break;
+    case 'label':
+      label.value = getFontValues(labelVariables, newResolutionValues);
+      break;
+  }
+};
+
+export const cssTokenState = reactive({
+  fontTokensDefault,
+  fontTokens1400,
+  fontTokens1200,
+  fontTokens600,
+  headers,
+  subHeaders,
+  ingress,
+  body,
+  bodyCompact,
+  detailText,
+  label,
+  initGlobalState,
+  stateInitialized,
+  updateFontValuesPerTableContent,
+});

--- a/doc-site/.vitepress/theme/cssTokenState.ts
+++ b/doc-site/.vitepress/theme/cssTokenState.ts
@@ -1,3 +1,4 @@
+// Mapper typografi css-variabler fra .css fil til lesbare objekter.
 import { reactive, ref } from 'vue';
 import { FontValues, FontVariables, TableContent } from './types/FontValues';
 

--- a/doc-site/.vitepress/theme/index.ts
+++ b/doc-site/.vitepress/theme/index.ts
@@ -16,6 +16,8 @@ import PageHeader from './components/PageHeader.vue';
 import ComponentOverview from './components/ComponentOverview.vue';
 import ThemeSelect from './components/ThemeSelect.vue';
 import ColorList from './components/ColorList.vue';
+import TypographyTable from './components/TypographyTable.vue';
+import { cssTokenState } from './cssTokenState';
 import { useCurrentTheme, Theme } from './composables/useCurrentTheme';
 
 export default {
@@ -57,7 +59,16 @@ export default {
       // siden VitePress bygges via SSR, vi må sikre at våre web komponenter lastes ned i nettleseren bare
       // derfor importerer vi alle komponenter når miljø ikke er SSR
       const components = import.meta.glob('../../../src/components/*/*.component.ts');
+      const styles = import.meta.glob('./styles/nve_theme.css', { as: 'raw' });
 
+      // Read the content of the nve_theme.css file
+      (async () => {
+        const importPromises = Object.values(styles).map((importFunc) =>
+          typeof importFunc === 'function' ? importFunc() : Promise.resolve(null)
+        );
+        const cssFileResult = await Promise.all(importPromises);
+        cssTokenState.initGlobalState(cssFileResult.join('\n'));
+      })();
       //vi batcher imports for å redusere antall nettverksforespørsler og for å ikke restarte applikasjonen flere ganger
       (async () => {
         const importPromises = Object.values(components).map((importFunc) =>
@@ -66,7 +77,6 @@ export default {
         await Promise.all(importPromises);
       })();
     }
-
     app.component('component', ComponentLayout);
     app.component('CodeExamplePreview', CodeExamplePreview);
     app.component('SandboxPreview', SandboxPreview);
@@ -76,6 +86,7 @@ export default {
     app.component('ComponentOverview', ComponentOverview);
     app.component('ThemeSelect', ThemeSelect);
     app.component('ColorList', ColorList);
+    app.component('TypographyTable', TypographyTable);
     registerIconLibrary('system', {
       resolver: (name) => {
         return `data:image/svg+xml,${encodeURIComponent(icons[name])}`;

--- a/doc-site/.vitepress/theme/index.ts
+++ b/doc-site/.vitepress/theme/index.ts
@@ -59,9 +59,9 @@ export default {
       // siden VitePress bygges via SSR, vi må sikre at våre web komponenter lastes ned i nettleseren bare
       // derfor importerer vi alle komponenter når miljø ikke er SSR
       const components = import.meta.glob('../../../src/components/*/*.component.ts');
-      const styles = import.meta.glob('./styles/nve_theme.css', { as: 'raw' });
 
-      // Read the content of the nve_theme.css file
+      // Lese inn nve_theme.css for å hente ut css variabler
+      const styles = import.meta.glob('./styles/nve_theme.css', { as: 'raw' });
       (async () => {
         const importPromises = Object.values(styles).map((importFunc) =>
           typeof importFunc === 'function' ? importFunc() : Promise.resolve(null)

--- a/doc-site/.vitepress/theme/types/FontValues.ts
+++ b/doc-site/.vitepress/theme/types/FontValues.ts
@@ -1,0 +1,23 @@
+export type FontValues = {
+  weight: string | undefined;
+  size: string;
+  lineHeight: string;
+};
+
+export type TableContent =
+  | 'default'
+  | 'headers'
+  | 'subheaders'
+  | 'ingress'
+  | 'body'
+  | 'body-compact'
+  | 'detail-text'
+  | 'label';
+
+export interface FontVariables {
+  [x: string]: {
+    weight: string | null;
+    size: string | null;
+    lineHeight: string | null;
+  };
+}

--- a/doc-site/.vitepress/theme/types/FontValues.ts
+++ b/doc-site/.vitepress/theme/types/FontValues.ts
@@ -1,9 +1,11 @@
+// Brukes for å mappe css token til en faktisk verdi
 export type FontValues = {
   weight: string | undefined;
   size: string;
   lineHeight: string;
 };
 
+// Definerer hvilken typografi innhold skal vises i TypographyTable.vue
 export type TableContent =
   | 'default'
   | 'headers'
@@ -14,10 +16,7 @@ export type TableContent =
   | 'detail-text'
   | 'label';
 
+//font-token nøkkel - FontValues verdi par
 export interface FontVariables {
-  [x: string]: {
-    weight: string | null;
-    size: string | null;
-    lineHeight: string | null;
-  };
+  [x: string]: FontValues;
 }

--- a/doc-site/introduction/designelementer/typography.md
+++ b/doc-site/introduction/designelementer/typography.md
@@ -41,7 +41,7 @@ Under kan du teste hvordan fontene endres på ulike skjermbredder.
 
 <TypographyTable tableContentType="default"></TypographyTable>
 
-Basert på fontstørrelsevariablene har vi laget fontvariabler for bestemte formål: Overskrift, ingress, brødtekst, samt et par andre spesielle formål. Disse fontvariablene er grupperte CSS-`font` -egenskaper som kombinerer `font-weight`, `font-size`, `line-height` og `font-family` til en enkelt enhet. Ved å bruke disse variablene, sikrer vi at riktig linjehøyde og fontstørrelse benyttes, i tråd med universell utforming, designprinsipper og beste praksis.
+Basert på fontstørrelsevariablene har vi laget fontvariabler for bestemte formål: Overskrift, ingress, brødtekst, samt et par andre spesielle formål. Disse fontvariablene er grupperte CSS-`font` -egenskaper som kombinerer `font-weight`, `font-size`, `line-height` og `font-family` til en enkelt enhet. Ved å bruke disse variablene, sikrer vi at riktig linjehøyde og fontstørrelse benyttes, i tråd med prinsipper for universell utforming og beste praksis.
 
 I Figma-skisser blir disse font-egenskapene typisk brukt på ulike tekststiler og komponenter. For eksempel, header-stiler blir definert ved å bruke --heading- variabler, noe som sikrer en sammenhengende og standardisert tilnærming til typografi på tvers av design-systemet.
 

--- a/doc-site/introduction/designelementer/typography.md
+++ b/doc-site/introduction/designelementer/typography.md
@@ -4,11 +4,11 @@ outline: [2, 3]
 
 <PageHeader title="Typografi" imagePath="typografi" pageLevel=1></PageHeader>
 
-<img src="../../assets/images/typo.png" width="auto">
-
 Typografi er et av de sterkeste virkemidlene vi har for å lage visuelle hierarkier. For å sikre et konsekvent visuelt uttrykk på alle våre tjenester definerer designsystemet satte stiler på font-størrelse, font-vekt og linjeavstand. Vi bruker skrifttypen Source Sans i all kommunikasjon.
 
 #### Source Sans
+
+<img src="../../assets/images/typo.png" width="auto">
 
 Source Sans Pro/3 er en «open-source» sans serif skrifttype, laget for å gi god lesbarhet på digitale produkter. I designsystemet bruker vi kun vektene Regular og Semibold, med tilhørende italics-versjoner.
 

--- a/doc-site/introduction/designelementer/typography.md
+++ b/doc-site/introduction/designelementer/typography.md
@@ -1,3 +1,7 @@
+---
+outline: [2, 3]
+---
+
 <PageHeader title="Typografi" imagePath="typografi" pageLevel=1></PageHeader>
 
 ## Typografi
@@ -24,4 +28,52 @@ Fonten heter Source Sans 3 i Google Fonts. Der kan du finne informasjon om hvord
 
 <hr>
 
-TODO: Legge til oversikt over alle typografiske elementer vi har i tokens. Referanse: https://aksel.nav.no/grunnleggende/styling/typografi
+## Typografi variabler
+
+Vi tilbyr 7 fontstørrelsevariabler som er beregnet basert på dimensjonsvariabler, som igjen skaleres basert på skjermstørrelsen (TODO: device tokens-seksjonen).
+
+Vi bruker 4 brytningspunkter:
+
+<ul>
+<li><b>Desktop-large</b>: For store skjermer, som store monitorer. Brytningspunkt: 1400px.</li>
+<li><b>Desktop</b>: For vanlige stasjonære og bærbare datamaskiner.</li>
+<li><b>Desktop-small</b>: For mindre skjermer, som små bærbare PC-er. Brytningspunkt: 1200px.</li>
+<li><b>Mobile</b>: For smarttelefoner og andre små enheter. Brytningspunkt: 600px.</li>
+</ul>
+
+Under kan du teste hvordan fontene endres på forskjellige skjermstørrelser.
+
+<TypographyTable tableContentType="default"></TypographyTable>
+
+Videre, basert på fontstørrelsevariablene som tilpasser seg skjermstørrelsen, har vi også definert fontvariabler for å opprettholde konsistens på tvers av ulike komponenter. Disse fontvariablene er grupperte CSS-`font` -egenskaper som kombinerer `font-weight`, `font-size`, `line-height` og `font-family` til en enkelt enhet. Ved å bruke disse spesifikke variablene, sikrer vi at riktig linjehøyde og fontstørrelse benyttes, i tråd med universell utforming designprinsipper og beste praksis.
+
+I Figma-skisser blir disse font-egenskapene typisk brukt på ulike tekststiler og komponenter. For eksempel, header-stiler blir definert ved å bruke --heading- variabler, noe som sikrer en sammenhengende og standardisert tilnærming til typografi på tvers av design-systemet.
+
+### Header
+
+Header typografi variabler skal vanligvis brukes på html header-tagene som `<h1>`, `<h2>` osv.
+<TypographyTable tableContentType="headers"></TypographyTable>
+
+### Subheader
+
+<TypographyTable tableContentType="subheaders"></TypographyTable>
+
+### Ingress
+
+<TypographyTable tableContentType="ingress"></TypographyTable>
+
+### Body
+
+<TypographyTable tableContentType="body"></TypographyTable>
+
+### Body compact
+
+<TypographyTable tableContentType="body-compact"></TypographyTable>
+
+### Detail text
+
+<TypographyTable tableContentType="detail-text"></TypographyTable>
+
+### Label
+
+<TypographyTable tableContentType="label"></TypographyTable>

--- a/doc-site/introduction/designelementer/typography.md
+++ b/doc-site/introduction/designelementer/typography.md
@@ -4,8 +4,6 @@ outline: [2, 3]
 
 <PageHeader title="Typografi" imagePath="typografi" pageLevel=1></PageHeader>
 
-## Typografi
-
 <img src="../../assets/images/typo.png" width="auto">
 
 Typografi er et av de sterkeste virkemidlene vi har for å lage visuelle hierarkier. For å sikre et konsekvent visuelt uttrykk på alle våre tjenester definerer designsystemet satte stiler på font-størrelse, font-vekt og linjeavstand. Vi bruker skrifttypen Source Sans i all kommunikasjon.
@@ -26,26 +24,24 @@ Fonten heter Source Sans Pro i Figma, og er tilgjenglig uten at du trenger å la
 
 Fonten heter Source Sans 3 i Google Fonts. Der kan du finne informasjon om hvordan fonten skal legges inn i kode på digitale produkter, og laste ned font-filer du kan installere på din maskin [her.](https://fonts.google.com/specimen/Source+Sans+3)
 
-<hr>
+## Typografi-variabler
 
-## Typografi variabler
+Vi tilbyr 7 fontstørrelsevariabler som er beregnet basert på dimensjonsvariabler, som igjen skaleres basert på skjermbredde (TODO: device tokens-seksjonen).
 
-Vi tilbyr 7 fontstørrelsevariabler som er beregnet basert på dimensjonsvariabler, som igjen skaleres basert på skjermstørrelsen (TODO: device tokens-seksjonen).
-
-Vi bruker 4 brytningspunkter:
+Vi bruker 4 brekkpunkter:
 
 <ul>
-<li><b>Desktop-large</b>: For store skjermer, som store monitorer. Brytningspunkt: 1400px.</li>
+<li><b>Desktop-large</b>: For store skjermer. Brekkpunkt: 1400px.</li>
 <li><b>Desktop</b>: For vanlige stasjonære og bærbare datamaskiner.</li>
-<li><b>Desktop-small</b>: For mindre skjermer, som små bærbare PC-er. Brytningspunkt: 1200px.</li>
-<li><b>Mobile</b>: For smarttelefoner og andre små enheter. Brytningspunkt: 600px.</li>
+<li><b>Desktop-small</b>: For mindre skjermer, som små bærbare PC-er. Brekkpunkt: 1200px.</li>
+<li><b>Mobile</b>: For smarttelefoner og andre små enheter. Brekkpunkt: 600px.</li>
 </ul>
 
-Under kan du teste hvordan fontene endres på forskjellige skjermstørrelser.
+Under kan du teste hvordan fontene endres på ulike skjermbredder.
 
 <TypographyTable tableContentType="default"></TypographyTable>
 
-Videre, basert på fontstørrelsevariablene som tilpasser seg skjermstørrelsen, har vi også definert fontvariabler for å opprettholde konsistens på tvers av ulike komponenter. Disse fontvariablene er grupperte CSS-`font` -egenskaper som kombinerer `font-weight`, `font-size`, `line-height` og `font-family` til en enkelt enhet. Ved å bruke disse spesifikke variablene, sikrer vi at riktig linjehøyde og fontstørrelse benyttes, i tråd med universell utforming designprinsipper og beste praksis.
+Basert på fontstørrelsevariablene har vi laget fontvariabler for bestemte formål: Overskrift, ingress, brødtekst, samt et par andre spesielle formål. Disse fontvariablene er grupperte CSS-`font` -egenskaper som kombinerer `font-weight`, `font-size`, `line-height` og `font-family` til en enkelt enhet. Ved å bruke disse variablene, sikrer vi at riktig linjehøyde og fontstørrelse benyttes, i tråd med universell utforming, designprinsipper og beste praksis.
 
 I Figma-skisser blir disse font-egenskapene typisk brukt på ulike tekststiler og komponenter. For eksempel, header-stiler blir definert ved å bruke --heading- variabler, noe som sikrer en sammenhengende og standardisert tilnærming til typografi på tvers av design-systemet.
 


### PR DESCRIPTION
Oppdaterte typografi siden som nå viser våre font tokene + font 'grupper' (som headers, subheaders osv). 
Alt verdier hentes direkte fra css filer, de er ikke hardkodet (bortsett fra font-family i TypographyTabel komponent).
Man kan vise hvordan typografi tokene endrer seg basert på skjermstørrelesen. 
Var usikker om jeg skal skrive noe under forskjellige font grupper. Har bare skrevet noe under headers.
Gjerne si fra om dere syns innholdet burde skrives om eller noe. 