### PR TITLE
fix: Feil farge på nve-divider, og feil på nve-menu i darkmode

### DIFF
--- a/doc-site/components/nve-menu-item.md
+++ b/doc-site/components/nve-menu-item.md
@@ -91,7 +91,7 @@ Bruk `value` for å gi menyvalget en unik ID. Du kan lese av `value` til aktuelt
   <nve-menu-item value="opt-1">Option 1</nve-menu-item>
   <nve-menu-item value="opt-2">Option 2</nve-menu-item>
   <nve-menu-item value="opt-3">Option 3</nve-menu-item>
-  <sl-divider></sl-divider>
+  <nve-divider></nve-divider>
   <nve-menu-item type="checkbox" value="opt-4">Checkbox 4</nve-menu-item>
   <nve-menu-item type="checkbox" value="opt-5">Checkbox 5</nve-menu-item>
   <nve-menu-item type="checkbox" value="opt-6">Checkbox 6</nve-menu-item>

--- a/src/components/nve-divider/nve-divider.component.ts
+++ b/src/components/nve-divider/nve-divider.component.ts
@@ -14,7 +14,7 @@ export default class NveDivider extends SlDivider {
     SlDivider.styles,
     css`
       :host {
-        --color: var(--neutrals-border-default);
+        --color: var(--neutrals-border-subtle);
         --width: var(--border-width-default, 1px);
         --spacing: var(--spacing-xx-small, 0.25rem);
       }

--- a/src/components/nve-menu/nve-menu.styles.ts
+++ b/src/components/nve-menu/nve-menu.styles.ts
@@ -5,6 +5,7 @@ export default css`
     margin-top: var(--spacing-xx-small);
     border: none;
     box-shadow: var(--soft);
+    background: var(--neutrals-background-primary);
   }
   ::slotted(nve-label) {
     padding: var(--spacing-small);


### PR DESCRIPTION
Det var en liten feil på nve-menu som gjorde at bakgrunnen til sl-menu lakk igjennom. Kun synlig i darkmode.