### PR TITLE
fix(nve-icon): rettet standardstørrelse fra 16px til 24px

### DIFF
--- a/doc-site/components/nve-icon.md
+++ b/doc-site/components/nve-icon.md
@@ -16,21 +16,21 @@ Her er [oversikt over ikoner i Material Symbols](https://fonts.google.com/icons)
 
 ### Størrelse
 
-For å endre størrelsen, bruk `--icon-size` css custom property;
+For å endre størrelsen, bruk `--icon-size` css custom property.
 
 Man kan fortsatt bruke bare `font-size` css property (se siste eksempel), men man må huske å endre `line-height` også så at den stemmer med valgte `font-size`.
 
-16px er standard.
+24px er standard.
 <CodeExamplePreview>
 
 ```html
-<nve-icon name="Rocket"></nve-icon>
-
 <nve-icon name="Rocket" style="--icon-size: 20px;"></nve-icon>
 
-<nve-icon name="Rocket" style="--icon-size: 24px;"></nve-icon>
+<nve-icon name="Rocket"></nve-icon>
 
-<nve-icon name="Rocket" style="font-size: 24px; line-height: 24px;"></nve-icon>
+<nve-icon name="Rocket" style="--icon-size: 28px;"></nve-icon>
+
+<nve-icon name="Rocket" style="font-size: 28px; line-height: 28px;"></nve-icon>
 ```
 
 </CodeExamplePreview>

--- a/src/components/nve-icon/nve-icon.styles.ts
+++ b/src/components/nve-icon/nve-icon.styles.ts
@@ -13,7 +13,7 @@ export default css`
     user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
-    --icon-size: 16px;
+    --icon-size: 24px;
     font-size: var(--icon-size);
     line-height: var(--icon-size);
   }


### PR DESCRIPTION
Endret standardstørrelse på ikoner fra 16px til 24px. 

fixes #478 
