### PR TITLE
fix: Fikset en selector som var feil på nve-carousel. 

### DIFF
--- a/src/components/nve-carousel/nve-carousel.styles.ts
+++ b/src/components/nve-carousel/nve-carousel.styles.ts
@@ -5,7 +5,7 @@ export default css`
     gap: 0rem 10px;
   }
 
-  :host([pagination-counter])::part(scroll-container)::after {
+  :host([pagination-counter]) #scroll-container::after {
     content: attr(data-active-item) ' / ' attr(data-num-items);
     display: block;
     position: absolute;
@@ -14,8 +14,8 @@ export default css`
     padding: var(--spacing-xx-small) var(--spacing-x-small);
     border-radius: var(--border-radius-small);
     color: var(--pagination-counter-color, inherit);
-    background-color: var(--pagination-counter-bg-color, inherit);  }
-
+    background-color: var(--pagination-counter-bg-color, inherit);
+  }
 
   :host::part(scroll-container) {
     aspect-ratio: auto;


### PR DESCRIPTION
Knekker i nyere Chromium-baserte browsere
::part::after er ikke en gyldig selector ihht spesifikasjonen