### PR TITLE
fix: endret til å bruke filen dependabot.yml og lagt til chore som conventional commit type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 5
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
+    commit-message:
+      prefix: 'chore(security)'
+      include: 'scope'
+    labels:
+      - 'security'
+      - 'dependencies'
+    reviewers:
+      - 'gruble'
+      - 'amish1188'
+      - 'NVEJoel'
+      - 'tomapedersen'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 5
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    commit-message:
+      prefix: 'chore(deps)'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+    reviewers:
+      - 'gruble'
+      - 'amish1188'
+      - 'NVEJoel'
+      - 'tomapedersen'

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -22,3 +22,4 @@ jobs:
             fix 
             feat
             docs
+            chore

--- a/README.md
+++ b/README.md
@@ -45,11 +45,7 @@ Vi har innført **Conventional Commits**-standarden i vårt prosjekt for å auto
   - `feat`: Legger til ny funksjonalitet
   - `fix`: Fikser en feil
   - `chore`: Oppgaver som ikke endrer kode (f.eks. oppdatering av verktøy)
-  - `refactor`: En kodeendring som verken fikser en feil eller legger til en funksjon
   - `docs`: Endringer i dokumentasjon
-  - `style`: Endringer som ikke påvirker logikken i koden (f.eks. formattering)
-  - `build`: Endringer som påvirker byggesystemet eller eksterne avhengigheter
-  - `ci`: Endringer i våre CI-konfigurasjonsfiler og skript
 
 - **scope** (valgfritt): Beskriver hvor i prosjektet endringen er gjort. Eksempler:
 


### PR DESCRIPTION
- Endret slik at vi har en konfigurasjonsfil for dependabot i stedet hvor vi legger til riktig prefiks (chore) for dependabot automatisk PR.
- Konfigurasjonen tillater to forskjellige prefiksmeldinger (chore(security eller chore(deps) ) avhengig av hvilken type PR det er.
- Rettet readme- og pr-title-check slik at det bare er 4 forskjellige typer du kan gjøre.
- 
Closes #487  