### PR TITLE
fix(stepper): 511 stepper skjuling av description for et steg fungerer ikke

### DIFF
--- a/doc-site/components/nve-stepper.md
+++ b/doc-site/components/nve-stepper.md
@@ -169,6 +169,7 @@ Dette eksempelet viser at `description` er en valgfri egenskap. Steg 2 har ingen
 ```
 
 </CodeExamplePreview>
+
 ### Mobil-versjon
 
 Stepperen vises automatisk i en egen mobil-versjon på små skjermer.

--- a/doc-site/components/nve-stepper.md
+++ b/doc-site/components/nve-stepper.md
@@ -78,8 +78,21 @@ Se Vue eksempel [her](#stepper-uten-standardknapper) hvordan du bruker metoderna
 <CodeExamplePreview>
 
 ```html
+<nve-label>horizontal</nve-label>
 <nve-stepper
   hideStateText
+  steps='
+  [
+  {"title":"Steg 1","description":"","state":1,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 2","description":"","state":0,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 3","description":"","state":0,"isSelected":false,"readyForEntrance":true}]'
+>
+</nve-stepper>
+
+<nve-label>vertical</nve-label>
+<nve-stepper
+  hideStateText
+  orientation="vertical"
   steps='
   [
   {"title":"Steg 1","description":"","state":1,"isSelected":false,"readyForEntrance":true},
@@ -91,6 +104,71 @@ Se Vue eksempel [her](#stepper-uten-standardknapper) hvordan du bruker metoderna
 
 </CodeExamplePreview>
 
+### Kompakt stepper uten beskrivelser
+
+Bruk `hideDescriptions` for å skjule alle beskrivelser og få en mer kompakt visning. Dette er nyttig når du har begrenset plass eller når beskrivelsene ikke er nødvendige for brukeren.
+
+Selv om du setter `hideDescriptions=true`, kan du fortsatt definere beskrivelser i step-objektene. Disse vil bli skjult i grensesnittet men kan brukes i andre sammenhenger eller vises senere om nødvendig.
+
+<CodeExamplePreview>
+
+```html
+<nve-label>Kompakt horizontal</nve-label>
+<nve-stepper
+  hideDescriptions
+  steps='
+  [
+  {"title":"Steg 1","description":"Denne beskrivelsen vises ikke","state":1,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 2","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 3","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true}]'
+>
+</nve-stepper>
+
+<nve-label>Kompakt vertical</nve-label>
+<nve-stepper
+  hideDescriptions
+  orientation="vertical"
+  steps='
+  [
+  {"title":"Steg 1","description":"Denne beskrivelsen vises ikke","state":1,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 2","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 3","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true}]'
+>
+</nve-stepper>
+```
+
+</CodeExamplePreview>
+
+### Skjul description for steg 2
+
+Dette eksempelet viser at `description` er en valgfri egenskap. Steg 2 har ingen beskrivelse, mens steg 1 og 3 har beskrivelser.
+
+<CodeExamplePreview>
+
+```html
+<nve-label>horizontal</nve-label>
+<nve-stepper
+  steps='
+  [
+  {"title":"Steg 1","description":"Beskrivelse steg 1","state":1,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 2","state":0,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 3","description":"Beskrivelse steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
+>
+</nve-stepper>
+
+<nve-label>vertical</nve-label>
+<nve-stepper
+  orientation="vertical"
+  steps='
+    [
+  {"title":"Steg 1","description":"Beskrivelse steg 1","state":1,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 2","state":0,"isSelected":false,"readyForEntrance":true},
+  {"title":"Steg 3","description":"Beskrivelse steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
+>
+</nve-stepper>
+```
+
+</CodeExamplePreview>
 ### Mobil-versjon
 
 Stepperen vises automatisk i en egen mobil-versjon på små skjermer.

--- a/src/components/nve-stepper/nve-step/nve-step.component.ts
+++ b/src/components/nve-stepper/nve-step/nve-step.component.ts
@@ -248,7 +248,7 @@ export default class NveStep extends LitElement {
             ${this.hideStateText ? '' : this.getStateText(this.state)}
           </div>
           <div>       
-          ${this.hideDescriptions ? '' : this.renderDescription()}
+            ${this.hideDescriptions ? '' : this.renderDescription()}
           </div>
         </div>
       </div>
@@ -268,9 +268,9 @@ export default class NveStep extends LitElement {
         <div class="${this.isLast ? "" : "text-container"}">
           <div class="step-title ${this.getTitleClass(this.state)}">${this.title}</div>
           <div class="step-state ${this.getStateColorClass(this.state)}">
-          ${this.hideStateText ? '' : this.getStateText(this.state)}
+            ${this.hideStateText ? '' : this.getStateText(this.state)}
           </div>       
-          ${this.hideDescriptions ? '' : this.renderDescription()}
+            ${this.hideDescriptions ? '' : this.renderDescription()}
         </div>
     `;
   }

--- a/src/components/nve-stepper/nve-step/nve-step.styles.ts
+++ b/src/components/nve-stepper/nve-step/nve-step.styles.ts
@@ -78,6 +78,11 @@ export default css`
     padding-top: 0.625rem; /*10px; */
   }
 
+  .empty-description {
+    min-height: 1rem; /* Set a minimum height for empty descriptions */
+    padding-top: 0.625rem; /* Match the padding of regular descriptions */
+  }
+
   .step-description-max-width-vertical {
     max-width: 430px;
     padding-bottom: var(--spacing-large, 1.5rem);

--- a/src/components/nve-stepper/nve-stepper.component.ts
+++ b/src/components/nve-stepper/nve-stepper.component.ts
@@ -19,9 +19,6 @@ export interface INveStepper {
   /** Tvinger en re-render av komponenten */
   reRender?(): void;
 
-  /** Skjuler beskrivelser for alle trinn */
-  hideDescriptions?: boolean;
-
   /** Hvilken retning Steps skal gå. */
   orientation?: 'horizontal' | 'vertical';
 
@@ -42,6 +39,9 @@ export interface INveStepper {
 
   /** Angir om stateText skal skjules for alle trinn */
   hideStateText?: boolean;
+
+  /** Skjuler beskrivelser for alle trinn */
+  hideDescriptions?: boolean;
 }
 
 /** Funksjon for å sjekke om enheten er en mobil enhet */

--- a/src/components/nve-stepper/nve-stepper.component.ts
+++ b/src/components/nve-stepper/nve-stepper.component.ts
@@ -19,6 +19,9 @@ export interface INveStepper {
   /** Tvinger en re-render av komponenten */
   reRender?(): void;
 
+  /** Skjuler beskrivelser for alle trinn */
+  hideDescriptions?: boolean;
+
   /** Hvilken retning Steps skal gå. */
   orientation?: 'horizontal' | 'vertical';
 
@@ -82,6 +85,10 @@ export default class NveStepper extends LitElement {
    /** Angir om stateText skal skjules for alle trinn */
   @property({ type: Boolean })
   hideStateText: boolean = false;
+
+  /** Skjuler beskrivelser for alle trinn */
+  @property({ type: Boolean })
+  hideDescriptions: boolean = false;
 
   private selectedStepIndex: { value: number } = { value: 0 };
 
@@ -273,6 +280,7 @@ export default class NveStepper extends LitElement {
                 .readyForEntrance=${step.readyForEntrance}
                 .orientation=${this.orientation}
                 .hideStateText=${this.hideStateText}
+                .hideDescriptions=${this.hideDescriptions}
               >
               </nve-step>
             `


### PR DESCRIPTION
Denne PRen forbedrer nve-stepper med ny funksjonalitet, fikser en "feil" og oppdaterer dokumentasjon.

### Forbedring:

* **Ny `hideDescriptions` property**:
  - Lagt til `hideDescriptions` i `StepProps` og `NveStep` for å tillate å skjule beskrivelser og en mer kompakt visning. [[1]](diffhunk://#diff-0aecb4bb76df86fc16ecce8403ea132e66a93eda9b58841ceedc254ce2601380L23-R23) [[2]](diffhunk://#diff-0aecb4bb76df86fc16ecce8403ea132e66a93eda9b58841ceedc254ce2601380R74-R77)
  - Oppdatert `NveStepper` med `hideDescriptions`. [[1]](diffhunk://#diff-fb644bfa12b5c8bbb1058ae4879db2555acb97b2efddd8f64c8e35a1d4953b3bR22-R24) [[2]](diffhunk://#diff-fb644bfa12b5c8bbb1058ae4879db2555acb97b2efddd8f64c8e35a1d4953b3bR89-R92) [[3]](diffhunk://#diff-fb644bfa12b5c8bbb1058ae4879db2555acb97b2efddd8f64c8e35a1d4953b3bR283)

* **Endret rendering funksjon**:
  - Endret `renderDescription` til å returnere en tom div med minimum høyde når beskrivelsene er skjult eller ugyldige for mer enhetlig spacing.
  - Justert logikk for visning av beskrivelse basert på `hideDescriptions` property. [[1]](diffhunk://#diff-0aecb4bb76df86fc16ecce8403ea132e66a93eda9b58841ceedc254ce2601380L235-R251) [[2]](diffhunk://#diff-0aecb4bb76df86fc16ecce8403ea132e66a93eda9b58841ceedc254ce2601380L257-R273)

* **CSS**:
  - Lagt til en ny `.empty-description` klasse for å style tomme beskrivelse/placeholders så det blir mer konsistent padding og høyde.

### Dokumentasjon:

* **Eksempler på ny feature**:
  - Lagt til eksempel som demonstrerer bruken av `hideDescriptions` for mer kompakt stepper, og valgfri beskrivelseselement. [[1]](diffhunk://#diff-dbcee1d6da68e9d32e6f4b7d348765c171762acfa32933022dae69c8659e4da2R81) [[2]](diffhunk://#diff-dbcee1d6da68e9d32e6f4b7d348765c171762acfa32933022dae69c8659e4da2R91-R171) 
