### PR TITLE
fix: Kan nå bygge med node 22

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -7,7 +7,7 @@ import { parse } from 'comment-parser';
 import { pascalCase } from 'pascal-case';
 import commandLineArgs from 'command-line-args';
 import fs from 'fs';
-import externalCEM from '@shoelace-style/shoelace/dist/custom-elements.json' assert { type: 'json' };
+import externalCEM from '@shoelace-style/shoelace/dist/custom-elements.json' with { type: 'json' };
 
 const packageData = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 const { name, description, version, author, homepage, license } = packageData;


### PR DESCRIPTION
Kunne ikke bygge med node 22, siden assert-imports ikke lenger er støttet (skal bruke `with` istedenfor)