### PR TITLE
feat: hideStep på nve-step som gjør at man kan skjule et steg

### DIFF
--- a/doc-site/components/nve-stepper.md
+++ b/doc-site/components/nve-stepper.md
@@ -6,7 +6,7 @@ layout: component
 
 ### Standard med og uten knapper
 
-Bruk `hideStepButtons` for å skjule knappene i desktop-versjon. Hvis du skjuler knappene, må du implementere dine egne knapper og du bruker metodene `nextStep` og `prevStep` for å håndtere logikken.
+Bruk `hideStepButtons` for å skjule knappene i desktop-versjon. Hvis du skjuler knappene, må du implementere dine egne knapper og du bruker metodene `nextStep` og `prevStep` for å håndtere logikken. Du kan også bruke `hideStep` på individuelle steg i `steps`-arrayet for å skjule spesifikke steg - navigasjon vil automatisk hoppe over de skjulte stegene.
 
 I siste trinn erstattes neste knapp med en klarknapp, som standard er teksten "Sende", men du kan endre teksten gjennom egenskapen `endButtonText`. Du må bruke metoden `finishSteps` for du spesifiserer hva som skal skje på den siste knappen.
 
@@ -200,6 +200,25 @@ Bruk `hideMobileStepButtons` for å skjule knappene i mobil-versjon.
   {"title":"Steg 1", "state":2,"isSelected":true,"readyForEntrance":true},
   {"title":"Steg 2", "state":2,"isSelected":false,"readyForEntrance":true},
   {"title":"Steg 3", "state":2,"isSelected":false,"readyForEntrance":true}]'
+>
+</nve-stepper>
+```
+
+</CodeExamplePreview>
+
+### Skjule bestemte steg
+
+Bruk `hideStep`-propertyen på individuelle steg for å skjule dem fra visningen. Stepper-komponenten vil automatisk hoppe over skjulte steg ved navigasjon.
+
+<CodeExamplePreview>
+
+```html
+<nve-stepper
+  steps='
+  [
+  {"title":"Steg 1","description":"Dette steget er synlig","state":1,"isSelected":true,"readyForEntrance":true},
+  {"title":"Steg 2","description":"Dette steget er skjult","state":0,"isSelected":false,"readyForEntrance":true,"hideStep":true},
+  {"title":"Steg 3","description":"Dette steget er synlig","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 ```
@@ -771,6 +790,178 @@ const handlePrevStep = () => {
     stepper.value.prevStep();
   }
 };
+</script>
+
+```
+
+</SandboxPreview>
+
+### Skjul bestemte steg i Vue
+
+Du kan kontrollere visningen av bestemte steg ved å bruke `hideStep`-propertyen. Dette eksempelet viser hvordan du kan dynamisk vise eller skjule steg i en Vue-applikasjon:
+
+```vue
+<template>
+  <div>
+    <nve-button @click="toggleStepVisibility">{{ showAllSteps ? 'Skjul steg 2' : 'Vis alle steg' }}</nve-button>
+    <nve-stepper ref="stepper" :steps="steps"></nve-stepper>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+
+import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+import 'nve-designsystem/components/nve-button/nve-button.component';
+
+import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+import { INveStepper } from 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+
+const showAllSteps = ref(true);
+const stepper = ref<HTMLElement | null>(null);
+
+const steps = ref<StepProps[]>([
+  {
+    title: 'Steg 1',
+    description: 'Første steg',
+    state: StepState.Active,
+    isSelected: true,
+    readyForEntrance: true,
+  },
+  {
+    title: 'Steg 2',
+    description: 'Andre steg',
+    state: StepState.NotStarted,
+    isSelected: false,
+    readyForEntrance: true,
+    hideStep: false, // Steg er synlig som standard
+  },
+  {
+    title: 'Steg 3',
+    description: 'Tredje steg',
+    state: StepState.NotStarted,
+    isSelected: false,
+    readyForEntrance: true,
+  },
+]);
+
+const toggleStepVisibility = () => {
+  showAllSteps.value = !showAllSteps.value;
+
+  // For å sikre at endringer i hideStep blir oppdaget av Lit-komponenten,
+  // må vi lage en helt ny kopi av steps-arrayet
+  steps.value = steps.value.map((step, index) => {
+    if (index === 1) {
+      return {
+        ...step,
+        hideStep: !showAllSteps.value,
+        title: step.title + '.', // Denne endringen fungerer allerede
+      };
+    }
+    return step;
+  });
+
+  // Gi beskjed til stepper at den skal oppdatere seg
+  if (stepper.value) {
+    (stepper.value as unknown as INveStepper).reRender();
+  }
+};
+
+onMounted(() => {
+  // Initialiser stepper
+  if (stepper.value) {
+    const nveStepper = stepper.value as unknown as INveStepper;
+  }
+});
+</script>
+```
+
+Når du endrer `hideStep`-egenskapen på et steg, bør du kalle `reRender()`-metoden for å sikre at stepper-komponenten oppdaterer visningen. Stepper-komponenten vil automatisk håndtere navigasjon og hoppe over skjulte steg.
+
+<SandboxPreview>
+
+```
+<template>
+  <div>
+    <nve-button @click="toggleStepVisibility">{{ showAllSteps ? 'Skjul steg 2' : 'Vis alle steg' }}</nve-button>
+    <nve-stepper ref="stepper" :steps="steps"></nve-stepper>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+
+import 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+import 'nve-designsystem/components/nve-button/nve-button.component';
+
+import { StepProps } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js';
+import { INveStepper } from 'nve-designsystem/components/nve-stepper/nve-stepper.component';
+
+const showAllSteps = ref(true);
+const stepper = ref<HTMLElement | null>(null);
+
+const steps = ref<StepProps[]>([
+  {
+    title: 'Steg 1',
+    description: 'Første steg',
+    state: StepState.Active,
+    isSelected: true,
+    readyForEntrance: true,
+  },
+  {
+    title: 'Steg 2',
+    description: 'Andre steg',
+    state: StepState.NotStarted,
+    isSelected: false,
+    readyForEntrance: true,
+    hideStep: false, // Steg er synlig som standard
+  },
+  {
+    title: 'Steg 3',
+    description: 'Tredje steg',
+    state: StepState.NotStarted,
+    isSelected: false,
+    readyForEntrance: true,
+  },
+]);
+
+const toggleStepVisibility = () => {
+  showAllSteps.value = !showAllSteps.value;
+
+  // For å sikre at hideStep-endringer oppdages må vi gjøre en mer
+  // omfattende endring av steps-arrayet enn bare å endre enkeltegenskaper
+  const hideSecondStep = !showAllSteps.value;
+
+  // Lag et helt nytt array med oppdaterte verdier
+  // Dette sikrer at Lit oppfatter endringen som en faktisk endring av data
+  const updatedSteps: StepProps[] = [
+    { ...steps.value[0] }, // Første steg - uendret
+    {
+      ...steps.value[1],
+      hideStep: hideSecondStep,
+      title: steps.value[1].title + '.' // Denne endringen fungerer allerede
+    }, // Andre steg - oppdatert
+    { ...steps.value[2] } // Tredje steg - uendret
+  ];
+
+  // Sett det nye arrayet som steps.value
+  steps.value = updatedSteps;
+
+  // Fortell Lit-komponenten at den må oppdatere seg
+  if (stepper.value) {
+    (stepper.value as unknown as INveStepper).reRender();
+  }
+};
+
+onMounted(() => {
+  // Initialiser stepper
+  if (stepper.value) {
+    const nveStepper = stepper.value as unknown as INveStepper;
+  }
+});
+
 </script>
 
 ```

--- a/src/components/nve-stepper/nve-step/nve-step.component.ts
+++ b/src/components/nve-stepper/nve-step/nve-step.component.ts
@@ -20,7 +20,8 @@ export interface StepProps {
   readyForEntrance: boolean;
   orientation?: string;
   hideStateText?: boolean;
-  hideDescriptions?: boolean;
+  hideDescription?: boolean;
+  hideStep?: boolean;
 }
 
 /** Komponent for et enkelt steg i en stepper */
@@ -73,7 +74,11 @@ export default class NveStep extends LitElement {
 
   /** Angir om beskrivelser skal skjules */
   @property({ type: Boolean })
-  hideDescriptions: boolean = false;
+  hideDescription: boolean = false;
+
+  /** Angir omhele steget skal skjules */
+  @property({ type: Boolean })
+  hideStep?: boolean = false;
 
   /** Brukes for å justere høyden for den vertikale skilleveggen blir så høy som nær Step har en description. */
   @query('.step-description')
@@ -204,7 +209,7 @@ export default class NveStep extends LitElement {
   private renderDescription(): TemplateResult | string {
     if (!this.isDescriptionValid(this.description)) {
       // Return an empty div with min-height to maintain spacing when no description
-      return html`<div class="step-description empty-description ${this.orientation === 'vertical' ? 'step-description-max-width-vertical' : 'step-description-max-width-horizontal'}"></div>`;
+      return html`<div class="step-description step-description-empty ${this.orientation === 'vertical' ? 'step-description-max-width-vertical' : 'step-description-max-width-horizontal'}"></div>`;
     }
     return html`<div class="step-description ${this.orientation === 'vertical' ? 'step-description-max-width-vertical' : 'step-description-max-width-horizontal'}">${this.description}</div>`;
   }
@@ -232,7 +237,8 @@ export default class NveStep extends LitElement {
   }
 
   private renderVerticalStep(): TemplateResult {
-    return html`
+    return this.hideStep === true ? html`` : 
+    html`
       <div class="vertical-container">
         <div class="step-figure-vertical">
           <div
@@ -248,7 +254,7 @@ export default class NveStep extends LitElement {
             ${this.hideStateText ? '' : this.getStateText(this.state)}
           </div>
           <div>       
-            ${this.hideDescriptions ? '' : this.renderDescription()}
+            ${this.hideDescription ? '' : this.renderDescription()}
           </div>
         </div>
       </div>
@@ -256,7 +262,7 @@ export default class NveStep extends LitElement {
   }
 
   render(): TemplateResult {
-    return this.isOrientationVertical() ? this.renderVerticalStep() : html`
+    return this.isOrientationVertical() ? this.renderVerticalStep() : this.hideStep === true ? html`` : html`
         <div class="step-figure">
           <span
             class=" ${this.getIconClass(this.state)}"
@@ -270,7 +276,7 @@ export default class NveStep extends LitElement {
           <div class="step-state ${this.getStateColorClass(this.state)}">
             ${this.hideStateText ? '' : this.getStateText(this.state)}
           </div>       
-            ${this.hideDescriptions ? '' : this.renderDescription()}
+            ${this.hideDescription ? '' : this.renderDescription()}
         </div>
     `;
   }

--- a/src/components/nve-stepper/nve-step/nve-step.styles.ts
+++ b/src/components/nve-stepper/nve-step/nve-step.styles.ts
@@ -78,7 +78,7 @@ export default css`
     padding-top: 0.625rem; /*10px; */
   }
 
-  .empty-description {
+  .step-description-empty {
     min-height: 1rem; /* Set a minimum height for empty descriptions */
     padding-top: 0.625rem; /* Match the padding of regular descriptions */
   }


### PR DESCRIPTION
Denne PRen legger til en property `hideStep` i `nve-step` komponenten som gjør at man kan skjule et steg.

Endringer:
- **`nve-stepper.component.ts`**:  tar hensyn til hideStep i beregning av hvilket steg som er neste, forrige, osv. Videresender hideStep fra steps-kolleksjonen til `nve-step`
- **`nve-step.component.ts`**: Her er det lagt til en property `hideStep`. I render-metoden (horisontal og vertikal) er sjekkes det som `hideStep` er satt og hvis den er det så rendres ikke elementet. Oppdaterte `hideDescrtiptions` til `hideDescription` for `nve-step` (den heter `hideDescriptions`på `nve-stepper`). og
- **`nve-step`**: Endret navn på css-klassen `empty-description` til `step-description-empty`.