### PR TITLE
feat(mange komponenter)!: fjern titel property i nve-alert, nve-stepper, nve-message-card, nve-link-card

### DIFF
--- a/doc-site/.vitepress/theme/components/ComponentOverview.vue
+++ b/doc-site/.vitepress/theme/components/ComponentOverview.vue
@@ -13,7 +13,7 @@
     komponentene ved å bruke komponentnavnet som tag i GitHub.
   </p>
   <nve-message-card
-    title="Merk saker og PR'er i Github med komponentnavn for å se dem her"
+    label="Merk saker og PR'er i Github med komponentnavn for å se dem her"
     size="simple"
   ></nve-message-card>
 

--- a/doc-site/.vitepress/theme/components/apidoc/ComponentDescription.vue
+++ b/doc-site/.vitepress/theme/components/apidoc/ComponentDescription.vue
@@ -22,7 +22,7 @@
       <nve-message-card
         :v-if="parent?.name?.startsWith('sl-')"
         size="compact"
-        title="Sjekk også Shoelace-dokumentasjonen"
+        label="Sjekk også Shoelace-dokumentasjonen"
       >
         Denne komponenten bygger på en Shoelace-komponent. Sjekk også dokumentasjonen i Shoelace for å få full oversikt
         over hvordan komponenten funker.</nve-message-card

--- a/doc-site/components/nve-alert.md
+++ b/doc-site/components/nve-alert.md
@@ -106,9 +106,9 @@ Bruk `saturation="emphasized"` for å få litt mørkere bakgrunnsfarge.
 
 </CodeExamplePreview>
 
-### Tittel og tekst
+### Overskrift og tekst
 
-Du kan bruke `label` for å lage en slags overskrift. Resten av teksten kan enten ligge i `text` eller inni elementet.
+Du kan bruke `label` for å lage en overskrift. Resten av teksten kan enten ligge i `text` eller inni elementet.
 
 <CodeExamplePreview arrangeComponentsVertically>
 

--- a/doc-site/components/nve-alert.md
+++ b/doc-site/components/nve-alert.md
@@ -10,7 +10,7 @@ layout: component
 
 </CodeExamplePreview>
 
-<nve-message-card title="Tips">
+<nve-message-card label="Tips">
 Bruk `open` for å vise en alert. Hvis ikke `open` er satt, vises den ikke.
 </nve-message-card>
 
@@ -108,18 +108,18 @@ Bruk `saturation="emphasized"` for å få litt mørkere bakgrunnsfarge.
 
 ### Tittel og tekst
 
-Du kan bruke `title` for å lage en slags overskrift. Resten av teksten kan enten ligge i `text` eller inni elementet.
+Du kan bruke `label` for å lage en slags overskrift. Resten av teksten kan enten ligge i `text` eller inni elementet.
 
 <CodeExamplePreview arrangeComponentsVertically>
 
 ```html
-<nve-alert text="og tekst" title="Tittel" open></nve-alert>
+<nve-alert text="og tekst" label="Tittel" open></nve-alert>
 
-<nve-alert title="Kun tittel" open></nve-alert>
+<nve-alert label="Kun tittel" open></nve-alert>
 
 <nve-alert text="kun tekst" open></nve-alert>
 
-<nve-alert title="Tittel" text="og tekst som ikke vises" open>
+<nve-alert label="Tittel" text="og tekst som ikke vises" open>
   Dersom en alert har både text-egenskap og tekst i selve elementet så skjuler vi teksten i egenskapen
 </nve-alert>
 ```

--- a/doc-site/components/nve-darkmode-switch.md
+++ b/doc-site/components/nve-darkmode-switch.md
@@ -2,7 +2,7 @@
 layout: component
 ---
 
-<nve-message-card title="Virker ikke på denne siden"  variant="warning">
+<nve-message-card label="Virker ikke på denne siden"  variant="warning">
 Merk at denne design-system-siden bruker en annen måte å sette darkmode på (siden den har NVE og Varsom-theme), så demo virker ikke her
 </nve-message-card>
 <CodeExamplePreview>

--- a/doc-site/components/nve-dropdown.md
+++ b/doc-site/components/nve-dropdown.md
@@ -2,7 +2,7 @@
 layout: component
 ---
 
-<nve-message-card title="Tips">
+<nve-message-card label="Tips">
 <span>For nedtrekksliste/"rullgardin"/dropdown-list, bruk <a href="/components/nve-select.html">nve-select</a></span>
 </nve-message-card>
 

--- a/doc-site/components/nve-icon.md
+++ b/doc-site/components/nve-icon.md
@@ -54,7 +54,7 @@ Man kan bruke `src`. Med definert `src` vil `nve-icon` bruke `<img>-taggen` bak 
 
 `name` og `library` brukes ikke når `src` er definert. Man kan fortsatt bruke `--icon-size`, men bruk av `font-size` css property skal ikke fungere.
 
-<nve-message-card variant="warning" title="Obs!">
+<nve-message-card variant="warning" label="Obs!">
 Selv om vi støtter bruk av ikoner direkte fra egen repo, det anbefales sterkt å bruke Material Symboler der
 hvor det er mulig. 
 </nve-message-card>

--- a/doc-site/components/nve-link-card.md
+++ b/doc-site/components/nve-link-card.md
@@ -5,7 +5,7 @@ layout: component
 <CodeExamplePreview>
 
 ```html
-<nve-link-card title="Kommuneplan" href="/components/Komponentoversikt"></nve-link-card>
+<nve-link-card label="Kommuneplan" href="/components/Komponentoversikt"></nve-link-card>
 ```
 
 </CodeExamplePreview>
@@ -17,7 +17,7 @@ layout: component
 ```html
 
 <nve-link-card
-  title="Intern lenke"
+  label="Intern lenke"
   additionalText="Klikk for å gå til intern linke"
   variant="contrast"
   href="/components/Komponentoversikt"
@@ -25,7 +25,7 @@ layout: component
 > </nve-link-card>
 
 <nve-link-card
-  title="Last ned fil"
+  label="Last ned fil"
   additionalText="Klikk for å laste ned en fil"
   variant="contrast"
   size="medium"
@@ -34,7 +34,7 @@ layout: component
 </nve-link-card>
 
 <nve-link-card
-  title="Egendefinert nedlasting"
+  label="Egendefinert nedlasting"
   additionalText="Klikk for å laste ned en tilpasset fil"
   variant="contrast"
   size="medium"
@@ -54,7 +54,7 @@ layout: component
 </script>
 
   <nve-link-card
-    title="Ekstern lenke"
+    label="Ekstern lenke"
     additionalText="Klikk for å åpne en ekstern side"
     variant="contrast"
     href="https://www.nve.no/"
@@ -63,7 +63,7 @@ layout: component
   </nve-link-card>
 
   <nve-link-card
-    title="Send e-post"
+    label="Send e-post"
     additionalText="Klikk for å sende en e-post"
     href="someone@example.com"
     variant="contrast"
@@ -78,9 +78,9 @@ layout: component
 <CodeExamplePreview>
 
 ```html
-<nve-link-card title="Kommuneplan" additionalText="Additional text."></nve-link-card>
-<nve-link-card title="Kommuneplan" additionalText="Additional text." variant="contrast"></nve-link-card>
-<nve-link-card title="Kommuneplan" additionalText="Additional text." variant="secondary"></nve-link-card>
+<nve-link-card label="Kommuneplan" additionalText="Additional text."></nve-link-card>
+<nve-link-card label="Kommuneplan" additionalText="Additional text." variant="contrast"></nve-link-card>
+<nve-link-card label="Kommuneplan" additionalText="Additional text." variant="secondary"></nve-link-card>
 ```
 
 </CodeExamplePreview>
@@ -90,9 +90,9 @@ layout: component
 <CodeExamplePreview>
 
 ```html
-<nve-link-card title="Kommuneplan" additionalText="Additional text." variant="contrast" size="small"></nve-link-card>
-<nve-link-card title="Kommuneplan" additionalText="Additional text." variant="contrast" size="medium"></nve-link-card>
-<nve-link-card title="Kommuneplan" additionalText="Additional text." variant="contrast" size="large"></nve-link-card>
+<nve-link-card label="Kommuneplan" additionalText="Additional text." variant="contrast" size="small"></nve-link-card>
+<nve-link-card label="Kommuneplan" additionalText="Additional text." variant="contrast" size="medium"></nve-link-card>
+<nve-link-card label="Kommuneplan" additionalText="Additional text." variant="contrast" size="large"></nve-link-card>
 ```
 
 </CodeExamplePreview>
@@ -105,7 +105,7 @@ Vi har ingen begrensning på lengden på tittelen eller teksten, men det er opp 
 
 ```html
 <nve-link-card
-  title="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+  label="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
   additionalText="Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?"
 ></nve-link-card>
 ```

--- a/doc-site/components/nve-message-card.md
+++ b/doc-site/components/nve-message-card.md
@@ -5,8 +5,8 @@ layout: component
 <CodeExamplePreview>
 
 ```html
-<nve-message-card title="Dette er et kort">Bruk meg med glede</nve-message-card>
-<nve-message-card title="NVE avdelinger">
+<nve-message-card label="Dette er et kort">Bruk meg med glede</nve-message-card>
+<nve-message-card label="NVE avdelinger">
   <ul>
     <li>RME</li>
     <li>EK</li>
@@ -30,12 +30,12 @@ Bruk `variant` for å velge farge. `primary` er standard.
 <CodeExamplePreview>
 
 ```html
-<nve-message-card title="Tittel">Primary</nve-message-card>
+<nve-message-card label="Tittel">Primary</nve-message-card>
 <!-- Box-shadow stil på den nøytrale varianten på grunn av lik farger med bakgrunnen i kodeforhåndsvisningen -->
-<nve-message-card style="box-shadow:var(--dropdown)" variant="neutral" title="Tittel">Neutral</nve-message-card>
-<nve-message-card variant="warning" title="Tittel">Warning</nve-message-card>
-<nve-message-card variant="danger" title="Tittel">Danger</nve-message-card>
-<nve-message-card variant="success" title="Tittel">Success</nve-message-card>
+<nve-message-card style="box-shadow:var(--dropdown)" variant="neutral" label="Tittel">Neutral</nve-message-card>
+<nve-message-card variant="warning" label="Tittel">Warning</nve-message-card>
+<nve-message-card variant="danger" label="Tittel">Danger</nve-message-card>
+<nve-message-card variant="success" label="Tittel">Success</nve-message-card>
 ```
 
 </CodeExamplePreview>
@@ -48,9 +48,9 @@ Forskjellen mellom `compact` og `simple` er at `simple` viser kun tittel og ikon
 <CodeExamplePreview>
 
 ```html
-<nve-message-card title="Default">Størrelsen på kortet</nve-message-card>
-<nve-message-card size="compact" title="Compact">Størrelsen på kortet</nve-message-card>
-<nve-message-card size="simple" title="Simple">Størrelsen på kortet</nve-message-card>
+<nve-message-card label="Default">Størrelsen på kortet</nve-message-card>
+<nve-message-card size="compact" label="Compact">Størrelsen på kortet</nve-message-card>
+<nve-message-card size="simple" label="Simple">Størrelsen på kortet</nve-message-card>
 ```
 
 </CodeExamplePreview>
@@ -62,11 +62,11 @@ Bruk `saturation="emphasized"` for å vise sterkere bakgrunnsfarge.
 <CodeExamplePreview>
 
 ```html
-<nve-message-card saturation="emphasized" title="Tittel">Primary</nve-message-card>
-<nve-message-card saturation="emphasized" variant="neutral" title="Tittel">Neutral</nve-message-card>
-<nve-message-card saturation="emphasized" variant="warning" title="Tittel">Warning</nve-message-card>
-<nve-message-card saturation="emphasized" variant="danger" title="Tittel">Danger</nve-message-card>
-<nve-message-card saturation="emphasized" variant="success" title="Tittel">Success</nve-message-card>
+<nve-message-card saturation="emphasized" label="Tittel">Primary</nve-message-card>
+<nve-message-card saturation="emphasized" variant="neutral" label="Tittel">Neutral</nve-message-card>
+<nve-message-card saturation="emphasized" variant="warning" label="Tittel">Warning</nve-message-card>
+<nve-message-card saturation="emphasized" variant="danger" label="Tittel">Danger</nve-message-card>
+<nve-message-card saturation="emphasized" variant="success" label="Tittel">Success</nve-message-card>
 ```
 
 </CodeExamplePreview>
@@ -79,7 +79,7 @@ Bruk `closable` for å vise lukk-knappen i tittel.
 
 ```html
 <div class="closable-example-container">
-  <nve-message-card closable class="message-card-closable" title="Tittel "> </nve-message-card>
+  <nve-message-card closable class="message-card-closable" label="Tittel "> </nve-message-card>
 </div>
 
 <script>
@@ -99,7 +99,7 @@ Bruk `closable` for å vise lukk-knappen i tittel.
     newMessageCard.setAttribute('closable', '');
     newMessageCard.classList.add('message-card-closable');
     newMessageCard.setAttribute('variant', 'primary');
-    newMessageCard.setAttribute('title', 'Tittel');
+    newMessageCard.setAttribute('label', 'Tittel');
 
     newMessageCard.addEventListener('nve-hide', () => {
       handleHideEvent();
@@ -125,7 +125,7 @@ Du kan bruke `footer`spor til å vise f.eks. en knapp.
 <CodeExamplePreview>
 
 ```html
-<nve-message-card variant="warning" title="Ingen støtte">
+<nve-message-card variant="warning" label="Ingen støtte">
   Vi støtter ikke denne funksjonen.
   <slot name="footer">
     <nve-button variant="neutral">Les mer</nve-button>
@@ -142,7 +142,7 @@ Slot `subheader` brukes til å vise en ekstra tekst over tittelen.
 <CodeExamplePreview>
 
 ```html
-<nve-message-card title="Tittel">
+<nve-message-card label="Tittel">
   <div slot="subheader">Varsel | 21.08.2024</slot>
 </nve-message-card
 >
@@ -157,7 +157,7 @@ Som default ikon vises ved tittelen. Ikon kan slås av ved ønske.
 <CodeExamplePreview>
 
 ```html
-<nve-message-card showIcon="false" title="Ingen ikon"> Ikon skal ikke vises </nve-message-card>
+<nve-message-card showIcon="false" label="Ingen ikon"> Ikon skal ikke vises </nve-message-card>
 ```
 
 </CodeExamplePreview>
@@ -169,10 +169,10 @@ Ikon er tilpasset varianten i utgangspunktet, men du kan velge ditt eget ikon ve
 <CodeExamplePreview>
 
 ```html
-<nve-message-card iconTitle="pets" title="Hunden sier voff voff">
+<nve-message-card iconTitle="pets" label="Hunden sier voff voff">
   Du kan velge et ikon i headeren selv
 </nve-message-card>
-<nve-message-card variant="warning" title="Katten liker ikke voff voff"> Vær forsiktig </nve-message-card>
+<nve-message-card variant="warning" label="Katten liker ikke voff voff"> Vær forsiktig </nve-message-card>
 ```
 
 </CodeExamplePreview>

--- a/doc-site/components/nve-stepper.md
+++ b/doc-site/components/nve-stepper.md
@@ -22,9 +22,9 @@ Se Vue eksempel [her](#stepper-uten-standardknapper) hvordan du bruker metoderna
   endButtonText="Klar"
   steps='
   [
-  {"title":"Steg 1","description":"Beskrivelse av steg 1","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","description":"Beskrivelse av steg 2","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"Beskrivelse av steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"Beskrivelse av steg 1","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","description":"Beskrivelse av steg 2","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"Beskrivelse av steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 
@@ -34,9 +34,9 @@ Se Vue eksempel [her](#stepper-uten-standardknapper) hvordan du bruker metoderna
   hideStepButtons
   steps='
   [
-  {"title":"Steg 1","description":"Beskrivelse av steg 1","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","description":"Beskrivelse av steg 2","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"Beskrivelse av steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"Beskrivelse av steg 1","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","description":"Beskrivelse av steg 2","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"Beskrivelse av steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 ```
@@ -52,9 +52,9 @@ Se Vue eksempel [her](#stepper-uten-standardknapper) hvordan du bruker metoderna
 <nve-stepper
   steps='
   [
-  {"title":"Steg 1","description":"Beskrivelse av steg 1","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","description":"Beskrivelse av steg 2","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"Beskrivelse av steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"Beskrivelse av steg 1","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","description":"Beskrivelse av steg 2","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"Beskrivelse av steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 
@@ -64,9 +64,9 @@ Se Vue eksempel [her](#stepper-uten-standardknapper) hvordan du bruker metoderna
   orientation="vertical"
   steps='
   [
-  {"title":"Steg 1","description":"Beskrivelse av steg 1","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","description":"Beskrivelse av steg 2","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"Beskrivelse av steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"Beskrivelse av steg 1","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","description":"Beskrivelse av steg 2","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"Beskrivelse av steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 ```
@@ -83,9 +83,9 @@ Se Vue eksempel [her](#stepper-uten-standardknapper) hvordan du bruker metoderna
   hideStateText
   steps='
   [
-  {"title":"Steg 1","description":"","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","description":"","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","description":"","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 
@@ -95,9 +95,9 @@ Se Vue eksempel [her](#stepper-uten-standardknapper) hvordan du bruker metoderna
   orientation="vertical"
   steps='
   [
-  {"title":"Steg 1","description":"","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","description":"","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","description":"","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 ```
@@ -118,9 +118,9 @@ Selv om du setter `hideDescriptions=true`, kan du fortsatt definere beskrivelser
   hideDescriptions
   steps='
   [
-  {"title":"Steg 1","description":"Denne beskrivelsen vises ikke","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"Denne beskrivelsen vises ikke","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 
@@ -130,9 +130,9 @@ Selv om du setter `hideDescriptions=true`, kan du fortsatt definere beskrivelser
   orientation="vertical"
   steps='
   [
-  {"title":"Steg 1","description":"Denne beskrivelsen vises ikke","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"Denne beskrivelsen vises ikke","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"Denne beskrivelsen vises ikke","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 ```
@@ -150,9 +150,9 @@ Dette eksempelet viser at `description` er en valgfri egenskap. Steg 2 har ingen
 <nve-stepper
   steps='
   [
-  {"title":"Steg 1","description":"Beskrivelse steg 1","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"Beskrivelse steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"Beskrivelse steg 1","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"Beskrivelse steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 
@@ -161,9 +161,9 @@ Dette eksempelet viser at `description` er en valgfri egenskap. Steg 2 har ingen
   orientation="vertical"
   steps='
     [
-  {"title":"Steg 1","description":"Beskrivelse steg 1","state":1,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 2","state":0,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3","description":"Beskrivelse steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1","description":"Beskrivelse steg 1","state":1,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 2","state":0,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3","description":"Beskrivelse steg 3","state":0,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 ```
@@ -185,9 +185,9 @@ Bruk `hideMobileStepButtons` for å skjule knappene i mobil-versjon.
   displayMobileVersion
   steps='
   [
-  {"title":"Steg 1", "state":2,"isSelected":true,"readyForEntrance":true},
-  {"title":"Steg 2", "state":2,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3", "state":2,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1", "state":2,"isSelected":true,"readyForEntrance":true},
+  {"label":"Steg 2", "state":2,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3", "state":2,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 
@@ -197,9 +197,9 @@ Bruk `hideMobileStepButtons` for å skjule knappene i mobil-versjon.
   hideMobileStepButtons
   steps='
   [
-  {"title":"Steg 1", "state":2,"isSelected":true,"readyForEntrance":true},
-  {"title":"Steg 2", "state":2,"isSelected":false,"readyForEntrance":true},
-  {"title":"Steg 3", "state":2,"isSelected":false,"readyForEntrance":true}]'
+  {"label":"Steg 1", "state":2,"isSelected":true,"readyForEntrance":true},
+  {"label":"Steg 2", "state":2,"isSelected":false,"readyForEntrance":true},
+  {"label":"Steg 3", "state":2,"isSelected":false,"readyForEntrance":true}]'
 >
 </nve-stepper>
 ```
@@ -218,7 +218,7 @@ Eksemplet viser hvordan du bruker nve-stepper med standardinnstillinger.
 
 For å legge til valideringslogikk før du går til neste trinn, kan du skrive over komponentens nextStep-funksjon. Dette gjør det mulig å kontrollere om gjeldende trinn er gyldig før du går videre. Nedenfor finner du et eksempel på hvordan du kan skrive over nextStep-funksjonen og inkludere egen valideringslogikk.
 
-<nve-message-card title="Tips">
+<nve-message-card label="Tips">
 Merk at du bør lage en kopi av den originale funksjonen slik at du kan bruke den dersom valideringen lykkes</nve-message-card>
 <div style="height: 20px;"></div>
 
@@ -254,28 +254,28 @@ import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-
 
 const steps: StepProps[] = [
   {
-    title: 'Kategorisering',
+    label: 'Kategorisering',
     description: 'Lorem Ipsum',
     state: StepState.Started,
     isSelected: true,
     readyForEntrance: true,
   },
   {
-    title: 'Beskrivelse',
+    label: 'Beskrivelse',
     description: 'Lorem Ipsum',
     state: StepState.NotStarted,
     isSelected: false,
     readyForEntrance: true,
   },
   {
-    title: 'Kontakt info',
+    label: 'Kontakt info',
     description: 'Lorem Ipsum',
     state: StepState.NotStarted,
     isSelected: false,
     readyForEntrance: true,
   },
   {
-    title: 'Oppsumering',
+    label: 'Oppsumering',
     description: 'Lorem Ipsum',
     state: StepState.NotStarted,
     isSelected: false,
@@ -364,28 +364,28 @@ import { StepProps } from "nve-designsystem/components/nve-stepper/nve-step/nve-
 import { StepState } from "nve-designsystem/components/nve-stepper/nve-step/nve-step.component.js";
 const steps: StepProps[] = [
   {
-    title: 'Kategorisering',
+    label: 'Kategorisering',
     description: 'Lorem Ipsum',
     state: StepState.Started,
     isSelected: true,
     readyForEntrance: true,
   },
   {
-    title: 'Beskrivelse',
+    label: 'Beskrivelse',
     description: 'Lorem Ipsum',
     state: StepState.NotStarted,
     isSelected: false,
     readyForEntrance: true,
   },
   {
-    title: 'Kontakt info',
+    label: 'Kontakt info',
     description: 'Lorem Ipsum',
     state: StepState.NotStarted,
     isSelected: false,
     readyForEntrance: true,
   },
   {
-    title: 'Oppsumering',
+    label: 'Oppsumering',
     description: 'Lorem Ipsum',
     state: StepState.NotStarted,
     isSelected: false,
@@ -471,7 +471,7 @@ Du kan skrive over prevStep-funksjonen.
 
 For å legge til valideringslogikk før du går til neste trinn, kan du skrive over komponentens nextStep-funksjon. Dette gjør det mulig å kontrollere om gjeldende trinn er gyldig før du går videre. Nedenfor finner du et eksempel på hvordan du kan skrive over nextStep-funksjonen og inkludere egen valideringslogikk.
 
-<nve-message-card title="Tips">
+<nve-message-card label="Tips">
 Merk at du bør lage en kopi av den originale funksjonen slik at du kan bruke den dersom valideringen lykkes</nve-message-card>
 <div style="height: 20px;"></div>
 
@@ -529,28 +529,28 @@ import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-
 
 const steps: StepProps[] = [
   {
-    title: 'Kategorisering',
+    label: 'Kategorisering',
     description: 'Lorem Ipsum',
     state: StepState.Started,
     isSelected: true,
     readyForEntrance: true,
   },
   {
-    title: 'Beskrivelse',
+    label: 'Beskrivelse',
     description: '',
     state: StepState.NotStarted,
     isSelected: false,
     readyForEntrance: true,
   },
   {
-    title: 'Kontakt info',
+    label: 'Kontakt info',
     description: '',
     state: StepState.NotStarted,
     isSelected: false,
     readyForEntrance: true,
   },
   {
-    title: 'Oppsumering',
+    label: 'Oppsumering',
     description: 'Lorem Ipsum',
     state: StepState.NotStarted,
     isSelected: false,
@@ -672,28 +672,28 @@ import { StepState } from 'nve-designsystem/components/nve-stepper/nve-step/nve-
 
 const steps: StepProps[] = [
   {
-    title: 'Kategorisering',
+    label: 'Kategorisering',
     description: 'Lorem Ipsum',
     state: StepState.Started,
     isSelected: true,
     readyForEntrance: true,
   },
   {
-    title: 'Beskrivelse',
+    label: 'Beskrivelse',
     description: '',
     state: StepState.NotStarted,
     isSelected: false,
     readyForEntrance: true,
   },
   {
-    title: 'Kontakt info',
+    label: 'Kontakt info',
     description: '',
     state: StepState.NotStarted,
     isSelected: false,
     readyForEntrance: true,
   },
   {
-    title: 'Oppsumering',
+    label: 'Oppsumering',
     description: 'Lorem Ipsum',
     state: StepState.NotStarted,
     isSelected: false,

--- a/doc-site/introduction/forDesigner/contribution.md
+++ b/doc-site/introduction/forDesigner/contribution.md
@@ -92,7 +92,7 @@ Designsystemet er en felles dugnad fra og for alle prosjekter i NVE. Derfor er v
 4. **Løs oppgaven i Figma eller i kode**  
    Løs oppgaven du har fått tildelt i Figma eller i kode avhengig av oppgave. Sørg for at du forholder deg til retningslinjene satt i profilmanualen og i designsystemet, og sørg for at løsningen din oppfyller kravene til universell utforming.
 
-<nve-message-card title="Krav">
+<nve-message-card label="Krav">
   <ul>
     <li class="list-item">Gi komponenten et navn som er fornuftig. Det skal være lett å finne for folk som ikke vet om det. Navnet skal være beskrivende for hva det er eller hva det gjør.</li>
     <li class="list-item">Gjør komponenten enkel å bruke for andre ved å sørge for at den fungerer bra i andre sammenhenger enn den du designet den for: Ulike størrelser, med ulik mengde innhold osv.</li>

--- a/doc-site/introduction/forDesigner/getStarted.md
+++ b/doc-site/introduction/forDesigner/getStarted.md
@@ -35,7 +35,7 @@ Device - Kan du bytte mellom forskjellige skjermstørrelser. Da vil innholdet ju
 
 <img src="../../assets/images/get-started-2.png" width="auto">
 
-<nve-message-card title="Tips">For at dette skal funke utmerket må du huske å bruke variablene som er fastsatt og ikke løse designverdier. Da vil ikke alt av innholdet endres i forhold til hva slags variabler/tokens du bruker.</nve-message-card>
+<nve-message-card label="Tips">For at dette skal funke utmerket må du huske å bruke variablene som er fastsatt og ikke løse designverdier. Da vil ikke alt av innholdet endres i forhold til hva slags variabler/tokens du bruker.</nve-message-card>
 
 ## Bestanddeler
 

--- a/doc-site/introduction/forDevelopers/development.md
+++ b/doc-site/introduction/forDevelopers/development.md
@@ -14,7 +14,7 @@ Designsystemet utvikles på dugnad og etter behov. Vi vil gjerne ha bidrag fra d
 
 Finner du feil i dokumentasjon eller komponenter, sjekk aktuell komponent i [komponentoversikten](https://designsystem.nve.no/components/Komponentoversikt.html) om feilen allerede er registrert. Om ikke, [registrer en sak i Github](https://github.com/NVE/Designsystem/issues). Gi gjerne saken til deg selv om du ønsker å fikse problemet med en gang, men det kan være lurt å melde fra om dette også på [FUX-forum i Teams](https://teams.microsoft.com/l/channel/19%3A3vNPKWAB1NfvK_GxsEsNWj04elWJ8WrylwsoZF9KaOY1%40thread.tacv2/FUX%20Forum?groupId=ec755ca5-8bfc-4a59-b502-d9721ef8eda4&tenantId=bc8d840d-60c9-410b-b4fb-11b86806780c&ngc=true&allowXTenantAccess=true), så folk får vite at noen er på saken. Der kan man også stille spørsmål om man lurer på noe.
 
-<nve-message-card title="Les readme">Les Readme før du endrer noe i Designsystemet. Der finner du tips og en del kjøreregler for utvikling av designsystemet.
+<nve-message-card label="Les readme">Les Readme før du endrer noe i Designsystemet. Der finner du tips og en del kjøreregler for utvikling av designsystemet.
 <slot name="Footer">
 <a href="https://github.com/NVE/Designsystem" target="_blank">Link til readme</a>
 </slot>

--- a/doc-site/introduction/forDevelopers/validation.md
+++ b/doc-site/introduction/forDevelopers/validation.md
@@ -2,7 +2,7 @@
 
 # Validering av input
 
-<nve-message-card title="Tips">
+<nve-message-card label="Tips">
   Komponentene du skal validere må ligge inni en &lt;form&gt;, fordi validering utføres når submit-eventet fyres av.
 </nve-message-card>
 

--- a/src/components/nve-alert/nve-alert.component.ts
+++ b/src/components/nve-alert/nve-alert.component.ts
@@ -14,7 +14,7 @@ export default class NveAlert extends SlAlert {
     super();
   }
   /** Tykk tekst, vises helt til venstre */
-  @property({ reflect: true }) title: string = '';
+  @property({ reflect: true }) label: string = '';
   /** Tynnere beskrivelse tekst */
   @property({ reflect: true }) text: string = '';
   /** Bestemmer sterkere bakgrunnsfarge */
@@ -29,8 +29,8 @@ export default class NveAlert extends SlAlert {
 
   updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
-    if (changedProperties.has('title')) {
-      this.style.setProperty('--nve-alert-title', `"${this.title}"`);
+    if (changedProperties.has('label')) {
+      this.style.setProperty('--nve-alert-label', `"${this.label}"`);
     }
     if (changedProperties.has('text')) {
       const hasContentInSlot =

--- a/src/components/nve-alert/nve-alert.styles.ts
+++ b/src/components/nve-alert/nve-alert.styles.ts
@@ -53,7 +53,7 @@ export default css`
   }
 
   .alert__message::before {
-    content: var(--nve-alert-title);
+    content: var(--nve-alert-label);
     font: var(--label-large);
     white-space: nowrap;
   }

--- a/src/components/nve-link-card/nve-link-card.component.ts
+++ b/src/components/nve-link-card/nve-link-card.component.ts
@@ -9,9 +9,9 @@ import styles from './nve-link-card.styles';
 @customElement('nve-link-card')
 export default class NveLinkCard extends LitElement implements INveComponent {
   /** Tittel som vises øverst på kortet */
-  @property({ reflect: true }) title: string = "";
+  @property({ reflect: true }) label: string = '';
 
-   /** Tilleggsbeskrivelse som vises under tittelen */
+  /** Tilleggsbeskrivelse som vises under tittelen */
   @property({ reflect: true }) additionalText?: string;
 
   /** Størrelse på kortet, kan være 'small', 'medium' eller 'large' */
@@ -34,11 +34,10 @@ export default class NveLinkCard extends LitElement implements INveComponent {
   /** Tilpasset klikk-handler som kan brukes til å overstyre standard atferd (f.eks. i Vue med vue-router) */
   @property() customClickHandler?: (event: MouseEvent) => void;
 
-
   static styles = [styles];
 
   /**
-   * Standard nedlastingsfunksjon som brukes hvis downloadHandler ikke er overstyrt. 
+   * Standard nedlastingsfunksjon som brukes hvis downloadHandler ikke er overstyrt.
    * Bruker lenken (href) til å laste ned en fil.
    */
   private async defaultDownloadHandler() {
@@ -107,9 +106,9 @@ export default class NveLinkCard extends LitElement implements INveComponent {
     }
   }
 
-/**
- * Denne er lagt til slik man klikke på cardet ved bruk av tastaturet.
- */
+  /**
+   * Denne er lagt til slik man klikke på cardet ved bruk av tastaturet.
+   */
   private handleKeyDown(event: KeyboardEvent) {
     if (event.key === 'Enter') {
       this.handleClick(event);
@@ -121,20 +120,33 @@ export default class NveLinkCard extends LitElement implements INveComponent {
    */
   private getIconName() {
     switch (this.clickAction) {
-      case 'internal': return 'arrow_forward';
-      case 'download': return 'download';
-      case 'external': return 'open_in_new';
-      case 'mail': return 'mail';
-      default: return 'arrow_forward';
+      case 'internal':
+        return 'arrow_forward';
+      case 'download':
+        return 'download';
+      case 'external':
+        return 'open_in_new';
+      case 'mail':
+        return 'mail';
+      default:
+        return 'arrow_forward';
     }
   }
 
   render() {
     return html`
-    <a part="link-card" class="link-card link-card--${this.size} link-card--${this.variant}" tabindex="0" @click="${this.handleClick}" @keydown="${this.handleKeyDown}">
+      <a
+        part="link-card"
+        class="link-card link-card--${this.size} link-card--${this.variant}"
+        tabindex="0"
+        @click="${this.handleClick}"
+        @keydown="${this.handleKeyDown}"
+      >
         <div class="link-card__content">
-          <div part="title" class="link-card__title">${this.title}</div>
-          ${this.additionalText ? html`<div part="additional-text" class="link-card__additional-text">${this.additionalText}</div>` : nothing }
+          <div part="label" class="link-card__label">${this.label}</div>
+          ${this.additionalText
+            ? html`<div part="additional-text" class="link-card__additional-text">${this.additionalText}</div>`
+            : nothing}
         </div>
         <div>
           <nve-icon slot="suffix" name="${this.getIconName()}" style="font-size: 1.5rem;"></nve-icon>

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -13,15 +13,15 @@ export default css`
   }
 
   .link-card:focus {
-    outline: var(--interactive-primary-foreground-border-focus, #008FFB) solid 2px;
+    outline: var(--interactive-primary-foreground-border-focus, #008ffb) solid 2px;
   }
 
-  .link-card:hover .link-card__title {
+  .link-card:hover .link-card__label {
     text-decoration: underline;
   }
 
   .link-card:active {
-    outline: var(--interactive-primary-foreground-border-focus, #008FFB) solid 2px;
+    outline: var(--interactive-primary-foreground-border-focus, #008ffb) solid 2px;
   }
 
   .link-card--small {
@@ -37,20 +37,20 @@ export default css`
     min-height: 70px;
   }
 
-  .link-card__title {
+  .link-card__label {
     font-size: 1rem;
-    color: var(--neutrals-foreground-primary, #0D0D0E);
-    font-family: "Source Sans Pro";
+    color: var(--neutrals-foreground-primary, #0d0d0e);
+    font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;
     line-height: 150%;
   }
 
-  .link-card__title--small {
+  .link-card__label--small {
     font-size: 0.875rem;
   }
 
-  .link-card__title--large {
+  .link-card__label--large {
     font-size: 1.125rem;
   }
 
@@ -61,8 +61,8 @@ export default css`
   }
 
   .link-card__additional-text {
-    color: var(--neutrals-foreground-primary, #0D0D0E);
-    font-family: "Source Sans Pro";
+    color: var(--neutrals-foreground-primary, #0d0d0e);
+    font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;
     line-height: 120%;
@@ -71,27 +71,27 @@ export default css`
   }
 
   .link-card--primary {
-    background: var(--neutrals-background-primary, #FFF);
+    background: var(--neutrals-background-primary, #fff);
   }
 
   .link-card--primary:hover {
-    background: var(--neutrals-background-secondary, #E4E5E7);  
+    background: var(--neutrals-background-secondary, #e4e5e7);
   }
 
   .link-card--contrast {
-    background: var(--neutrals-background-primary-contrast, #F7F7F8);  
+    background: var(--neutrals-background-primary-contrast, #f7f7f8);
   }
 
   .link-card--contrast:hover {
-    background: var(--neutrals-background-secondary, #E4E5E7);  
+    background: var(--neutrals-background-secondary, #e4e5e7);
   }
 
   .link-card--secondary {
-    background: var(--neutrals-background-secondary, #E4E5E7);  
+    background: var(--neutrals-background-secondary, #e4e5e7);
   }
 
   .link-card--secondary:hover {
     border-radius: var(--borderRadius-large, 6px);
-    border: 2px solid var(--neutrals-foreground-primary, #0D0D0E);
+    border: 2px solid var(--neutrals-foreground-primary, #0d0d0e);
   }
 `;

--- a/src/components/nve-message-card/nve-message-card.component.ts
+++ b/src/components/nve-message-card/nve-message-card.component.ts
@@ -23,7 +23,7 @@ Brukes som veiledning i skjemaer eller som en informasjon til brukere.
 * @csspart base - hoved komponent kontainer.
 * @csspart header - header seksjonen.
 * @csspart subheader - subheader seksjonen.
-* @csspart title - tittel i header seksjonen.
+* @csspart label - tittel i header seksjonen.
 * @csspart footer - footer seksjonen.
 */
 @customElement('nve-message-card')
@@ -38,7 +38,7 @@ export default class NveMessageCard extends LitElement implements INveComponent 
   /** Viser ikonen ved siden i header seksjonen */
   @property({ reflect: true }) showIcon: 'true' | 'false' = 'true';
   /** Tittel i header seksjonen */
-  @property({ reflect: true }) title: string = '';
+  @property({ reflect: true }) label: string = '';
   /** Beskrivelse tekst under tittelen */
   @property({ reflect: true }) text: string = '';
   /** Man kan velge ikon i headeren, enten kommer en default en */
@@ -108,9 +108,9 @@ export default class NveMessageCard extends LitElement implements INveComponent 
         <div class="message-card__header-container">
           <div part="header" class="message-card__header">
             <slot part="subheader" name="subheader" class="message-card__subheader"></slot>
-            <div part="title" class="message-card__header-title">
+            <div part="label" class="message-card__header-label">
               ${this.showIcon === 'true' ? html`<nve-icon name=${this.determineIcon()}></nve-icon>` : null}
-              ${this.title ? html`<span>${this.title}</span>` : null}
+              ${this.label ? html`<span>${this.label}</span>` : null}
             </div>
           </div>
           ${this.closable

--- a/src/components/nve-message-card/nve-message-card.styles.ts
+++ b/src/components/nve-message-card/nve-message-card.styles.ts
@@ -36,7 +36,7 @@ export default css`
   }
 
   /* tittelen blir kuttet hvis for langt i utgangspunktet */
-  .message-card__header-title {
+  .message-card__header-label {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -77,7 +77,7 @@ export default css`
 
   nve-icon::part(icon) {
     display: unset;
-    font-size: 22px
+    font-size: 22px;
   }
 
   /** Varianter */
@@ -168,13 +168,11 @@ export default css`
     gap: var(--spacing-x-small);
   }
 
-
-
-  :host([size='compact']) .message-card__header-title {
+  :host([size='compact']) .message-card__header-label {
     font: var(--label-medium);
   }
 
-  :host([size='simple']) .message-card__header-title {
+  :host([size='simple']) .message-card__header-label {
     font: var(--label-medium-light);
   }
 

--- a/src/components/nve-stepper/nve-step/nve-step.component.ts
+++ b/src/components/nve-stepper/nve-step/nve-step.component.ts
@@ -13,7 +13,7 @@ export enum StepState {
 
 /** Interface for å definere egenskapene til et steg */
 export interface StepProps {
-  title: string;
+  label: string;
   description?: string;
   state: StepState;
   isSelected: boolean;
@@ -28,8 +28,7 @@ export interface StepProps {
 export default class NveStep extends LitElement {
   /** Tittel på steget */
   @property({ reflect: true })
-  title: string = '';
-
+  label: string = '';
 
   /** Indeks for steget */
   @property({ type: Number })
@@ -62,7 +61,6 @@ export default class NveStep extends LitElement {
   @property({ type: Boolean })
   entranceAllowed: boolean = false;
 
-
   /** Retningen stegene skal gå i: horisontal eller vertikal */
   @property()
   orientation: 'horizontal' | 'vertical' = 'horizontal';
@@ -86,7 +84,6 @@ export default class NveStep extends LitElement {
 
   /** Metode som kjøres hver gang komponentens oppdateres */
   updated(): void {
-
     if (this.isOrientationVertical()) {
       this.updateVerticalDividerHeight();
     }
@@ -100,7 +97,6 @@ export default class NveStep extends LitElement {
     return this.orientation === 'vertical';
   }
 
-
   private iconForState(state: StepState): string {
     let icon = '';
     switch (state) {
@@ -110,7 +106,7 @@ export default class NveStep extends LitElement {
       case StepState.Active:
         icon = 'radio_button_checked';
         break;
-        
+
       case StepState.Started:
         icon = 'trip_origin';
         break;
@@ -144,7 +140,6 @@ export default class NveStep extends LitElement {
     }
   }
 
-
   private getStateColorClass(state: StepState): string {
     switch (state) {
       case StepState.NotStarted:
@@ -160,7 +155,7 @@ export default class NveStep extends LitElement {
     }
   }
 
-  private getTitleClass(state: StepState): string {
+  private getLabelClass(state: StepState): string {
     switch (state) {
       case StepState.NotStarted:
         return 'state-not-started-color';
@@ -188,44 +183,52 @@ export default class NveStep extends LitElement {
     return this.index < this.selectedStepIndex ? 'divider-reached-color' : 'divider-not-reached-color';
   }
 
-
   private renderDivider(): TemplateResult | string {
     const dividerClass = this.isOrientationVertical() ? 'divider-vertical' : 'divider-horizontal';
     return this.isLast
       ? ''
-      : html`
-          <div class="vertical-divider-container">
-          <div
-          class="${dividerClass} ${this.getDividerColorClass()}"
-        ></div>
+      : html` <div class="vertical-divider-container">
+          <div class="${dividerClass} ${this.getDividerColorClass()}"></div>
         </div>`;
   }
 
   private renderDescription(): TemplateResult | string {
     if (!this.isDescriptionValid(this.description)) {
       // Return an empty div with min-height to maintain spacing when no description
-      return html`<div class="step-description empty-description ${this.orientation === 'vertical' ? 'step-description-max-width-vertical' : 'step-description-max-width-horizontal'}"></div>`;
+      return html`<div
+        class="step-description empty-description ${this.orientation === 'vertical'
+          ? 'step-description-max-width-vertical'
+          : 'step-description-max-width-horizontal'}"
+      ></div>`;
     }
-    return html`<div class="step-description ${this.orientation === 'vertical' ? 'step-description-max-width-vertical' : 'step-description-max-width-horizontal'}">${this.description}</div>`;
+    return html`<div
+      class="step-description ${this.orientation === 'vertical'
+        ? 'step-description-max-width-vertical'
+        : 'step-description-max-width-horizontal'}"
+    >
+      ${this.description}
+    </div>`;
   }
 
-  private isDescriptionValid(description: string | undefined): boolean { 
+  private isDescriptionValid(description: string | undefined): boolean {
     // Simplify this expression for clarity
     return !!description && description?.trim().length > 0 === true;
   }
 
   /** Brukes for beregning av riktig høyde før divider. Description elementet har padding, så høyden før divider var for kort, så bruk denne funksjonen for regner ut riktig høyde. */
   private updateVerticalDividerHeight(): void {
-    const TRIP_ORIGIN_ICON_HEIGHT = 24; 
+    const TRIP_ORIGIN_ICON_HEIGHT = 24;
     const DEFAULT_HEIGHT = TRIP_ORIGIN_ICON_HEIGHT + 10; // Default height if no description
-    
+
     let descriptionHeight = DEFAULT_HEIGHT;
-      // Only then try to access the element in the DOM
-      if (this.descriptionElement) {
-        descriptionHeight = this.descriptionElement.offsetHeight + TRIP_ORIGIN_ICON_HEIGHT;
-      }
-    
-    const dividerElement = this.shadowRoot!.querySelector('.vertical-divider-container .divider-vertical') as HTMLElement;
+    // Only then try to access the element in the DOM
+    if (this.descriptionElement) {
+      descriptionHeight = this.descriptionElement.offsetHeight + TRIP_ORIGIN_ICON_HEIGHT;
+    }
+
+    const dividerElement = this.shadowRoot!.querySelector(
+      '.vertical-divider-container .divider-vertical'
+    ) as HTMLElement;
     if (dividerElement) {
       dividerElement.style.height = `${descriptionHeight}px`;
     }
@@ -235,44 +238,40 @@ export default class NveStep extends LitElement {
     return html`
       <div class="vertical-container">
         <div class="step-figure-vertical">
-          <div
-            class=" ${this.getIconClass(this.state)}"
-          >
+          <div class=" ${this.getIconClass(this.state)}">
             <nve-icon slot="suffix" name="${this.iconForState(this.state)}"></nve-icon>
           </div>
           ${this.renderDivider()}
         </div>
         <div class="text-container-vertical">
-          <div class="step-title step-title-vertical ${this.getTitleClass(this.state)}">${this.title}</div>
+          <div class="step-label step-label-vertical ${this.getLabelClass(this.state)}">${this.label}</div>
           <div class="step-state ${this.getStateColorClass(this.state)}">
             ${this.hideStateText ? '' : this.getStateText(this.state)}
           </div>
-          <div>       
-            ${this.hideDescriptions ? '' : this.renderDescription()}
-          </div>
+          <div>${this.hideDescriptions ? '' : this.renderDescription()}</div>
         </div>
       </div>
     `;
   }
 
   render(): TemplateResult {
-    return this.isOrientationVertical() ? this.renderVerticalStep() : html`
-        <div class="step-figure">
-          <span
-            class=" ${this.getIconClass(this.state)}"
-          >
-            <nve-icon  slot="suffix" name="${this.iconForState(this.state)}"></nve-icon>
-          </span>
-          ${this.renderDivider()}
-        </div>
-        <div class="${this.isLast ? "" : "text-container"}">
-          <div class="step-title ${this.getTitleClass(this.state)}">${this.title}</div>
-          <div class="step-state ${this.getStateColorClass(this.state)}">
-            ${this.hideStateText ? '' : this.getStateText(this.state)}
-          </div>       
+    return this.isOrientationVertical()
+      ? this.renderVerticalStep()
+      : html`
+          <div class="step-figure">
+            <span class=" ${this.getIconClass(this.state)}">
+              <nve-icon slot="suffix" name="${this.iconForState(this.state)}"></nve-icon>
+            </span>
+            ${this.renderDivider()}
+          </div>
+          <div class="${this.isLast ? '' : 'text-container'}">
+            <div class="step-label ${this.getLabelClass(this.state)}">${this.label}</div>
+            <div class="step-state ${this.getStateColorClass(this.state)}">
+              ${this.hideStateText ? '' : this.getStateText(this.state)}
+            </div>
             ${this.hideDescriptions ? '' : this.renderDescription()}
-        </div>
-    `;
+          </div>
+        `;
   }
 }
 

--- a/src/components/nve-stepper/nve-step/nve-step.styles.ts
+++ b/src/components/nve-stepper/nve-step/nve-step.styles.ts
@@ -44,7 +44,7 @@ export default css`
     width: 100%;
   }
 
-  .step-title {
+  .step-label {
     color: var(--neutrals-foreground-primary, #0d0d0e);
 
     /* Label/medium */
@@ -168,7 +168,7 @@ export default css`
     flex: 10;
   }
 
-  .step-title-vertical {
+  .step-label-vertical {
     padding-top: 0;
     align-self: flex-start;
   }

--- a/src/components/nve-stepper/nve-stepper-mobile.component.ts
+++ b/src/components/nve-stepper/nve-stepper-mobile.component.ts
@@ -3,18 +3,15 @@ import { customElement, property } from 'lit/decorators.js';
 import styles from './nve-stepper-mobile.styles';
 import { StepProps } from './nve-step/nve-step.component';
 
-
 @customElement('nve-stepper-mobile')
 export default class NveStepperMobile extends LitElement {
   static styles: CSSResultArray = [styles];
-
 
   /** Steps som skal vises, se StepProps interface for data som skal sendes inn. */
   @property({ type: Array })
   steps: StepProps[] = [];
 
-
-   /** Skjuler Neste og Forrige knappene slik at du kan implementere dine egne Neste og Forrige knappene. */
+  /** Skjuler Neste og Forrige knappene slik at du kan implementere dine egne Neste og Forrige knappene. */
   @property({ type: Boolean })
   hideStepButtons: boolean = false;
 
@@ -36,7 +33,6 @@ export default class NveStepperMobile extends LitElement {
 
   selectedStepIndex: { value: number } = { value: 0 };
 
-
   render(): TemplateResult {
     const currentStep = this.steps[this.selectedStepIndex.value];
     const nextStep = this.steps[this.selectedStepIndex.value + 1];
@@ -44,27 +40,18 @@ export default class NveStepperMobile extends LitElement {
 
     return html`
       <div class="mobile-stepper">
-        <div class="progress-circle">
-          ${this.selectedStepIndex.value + 1} of ${this.steps.length}
-        </div>
+        <div class="progress-circle">${this.selectedStepIndex.value + 1} of ${this.steps.length}</div>
         <div class="step-info">
-          <div class="step-title">${currentStep.title}</div>
+          <div class="step-label">${currentStep.label}</div>
           ${!this.hideStepButtons
-            ? html`
-                <div>
-                  ${!isLastStep
-                    ? html`
-                        <div class="step-buttons next-button" @click=${this.handleNextStep}>
-                          Neste: ${nextStep.title}
-                        </div>`
-                    : html`
-                        <div class="step-buttons next-button" @click=${this.handleNextStep}>
-                          Finish
-                        </div>`}
-                  <div class="step-buttons back-button" @click=${this.handlePrevStep}>
-                    Forrige
-                  </div>
-                </div>`
+            ? html` <div>
+                ${!isLastStep
+                  ? html` <div class="step-buttons next-button" @click=${this.handleNextStep}>
+                      Neste: ${nextStep.label}
+                    </div>`
+                  : html` <div class="step-buttons next-button" @click=${this.handleNextStep}>Finish</div>`}
+                <div class="step-buttons back-button" @click=${this.handlePrevStep}>Forrige</div>
+              </div>`
             : ''}
         </div>
       </div>

--- a/src/components/nve-stepper/nve-stepper-mobile.styles.ts
+++ b/src/components/nve-stepper/nve-stepper-mobile.styles.ts
@@ -11,7 +11,7 @@ export default css`
     width: 50px;
     height: 50px;
     border-radius: 50%;
-    border: 3px solid var(--feeedback-foreground-emphasized-success, #00814B);
+    border: 3px solid var(--feeedback-foreground-emphasized-success, #00814b);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -25,38 +25,38 @@ export default css`
     flex-direction: column;
   }
 
-  .step-title {
+  .step-label {
     font-weight: bold;
     font-size: 18px;
   }
 
   .step-description {
-    color: var(--neutrals-foreground-primary, #0D0D0E);
+    color: var(--neutrals-foreground-primary, #0d0d0e);
 
     /* Label/medium */
-    font-family: "Source Sans Pro";
+    font-family: 'Source Sans Pro';
     font-size: 1.125rem; /*18px; */
     font-style: normal;
     font-weight: 600;
-    line-height: 110%; 
+    line-height: 110%;
     padding-top: 0.75rem; /*12px;*/
   }
 
   .next-button {
-    color: var(--neutrals-foreground-primary, #0D0D0E);
+    color: var(--neutrals-foreground-primary, #0d0d0e);
   }
 
   .back-button {
-    color: var(--neutrals-foreground-subtle, #60656C);
-}   
+    color: var(--neutrals-foreground-subtle, #60656c);
+  }
 
-  .step-buttons {    
+  .step-buttons {
     /* Label/small-light */
-    font-family: "Source Sans Pro";
+    font-family: 'Source Sans Pro';
     font-size: 1rem; /*16px; */
     font-style: normal;
     font-weight: 400;
-    line-height: 110%; 
+    line-height: 110%;
     padding-top: 0.625rem; /*10px; */
     cursor: pointer;
   }

--- a/src/components/nve-stepper/nve-stepper.component.ts
+++ b/src/components/nve-stepper/nve-stepper.component.ts
@@ -50,8 +50,8 @@ function isMobileDevice(): boolean {
 }
 /**
  * En stepper-komponent brukes for å bryte ned en kompleks prosess i flere mindre, håndterbare trinn.
- * Hver trinn representerer en del av prosessen og brukeren kan navigere frem og tilbake mellom trinnene. 
- * Dette gir en strukturert og intuitiv måte å fullføre flertrinnsoppgaver på, som for eksempel skjemaer eller registreringsprosesser. 
+ * Hver trinn representerer en del av prosessen og brukeren kan navigere frem og tilbake mellom trinnene.
+ * Dette gir en strukturert og intuitiv måte å fullføre flertrinnsoppgaver på, som for eksempel skjemaer eller registreringsprosesser.
  * Steppers kan være enten horisontale eller vertikale, og kan tilpasses med valideringslogikk og egne knapper.
  */
 @customElement('nve-stepper')
@@ -82,7 +82,7 @@ export default class NveStepper extends LitElement {
   @property({ type: Boolean })
   displayMobileVersion: boolean = false;
 
-   /** Angir om stateText skal skjules for alle trinn */
+  /** Angir om stateText skal skjules for alle trinn */
   @property({ type: Boolean })
   hideStateText: boolean = false;
 
@@ -91,7 +91,6 @@ export default class NveStepper extends LitElement {
   hideDescriptions: boolean = false;
 
   private selectedStepIndex: { value: number } = { value: 0 };
-
 
   /**
    * Ved endring av props, re-render komponenten eksternt med document.querySelector("nve-stepper")?.reRender();
@@ -102,8 +101,6 @@ export default class NveStepper extends LitElement {
   reRender(): void {
     this.requestUpdate();
   }
-
-
 
   /** Metode som kjøres første gang komponenten er lagt til i DOM */
   firstUpdated(): void {
@@ -144,35 +141,33 @@ export default class NveStepper extends LitElement {
   }
 
   /** Metode for å hente den gjeldende indeksen */
-    getCurrentIndex(): number {
-      return this.selectedStepIndex.value;
+  getCurrentIndex(): number {
+    return this.selectedStepIndex.value;
   }
-  
 
   private setStep(index: number): void {
-
     if (this.steps[index].readyForEntrance) {
-        this.selectedStepIndex.value = index;
+      this.selectedStepIndex.value = index;
 
-       // Oppdater status og valg for alle trinn
-        for (let i = 0; i < this.steps.length; i++) {
-            if (i < index) {
-                // Alle trinn under indeks er satt til Done
-                this.steps[i].state = StepState.Done;
-            } else if (i === index) {
-                // Steget ved indeks er satt til Active
-                this.steps[i].state = StepState.Active;
-            } else if (this.steps[i].state !== StepState.NotStarted) {
-                // Alle trinn over indeksen som ikke er NotStarted er satt til Started
-                this.steps[i].state = StepState.Started;
-            }
-
-            this.steps[i].isSelected = i === index;
+      // Oppdater status og valg for alle trinn
+      for (let i = 0; i < this.steps.length; i++) {
+        if (i < index) {
+          // Alle trinn under indeks er satt til Done
+          this.steps[i].state = StepState.Done;
+        } else if (i === index) {
+          // Steget ved indeks er satt til Active
+          this.steps[i].state = StepState.Active;
+        } else if (this.steps[i].state !== StepState.NotStarted) {
+          // Alle trinn over indeksen som ikke er NotStarted er satt til Started
+          this.steps[i].state = StepState.Started;
         }
 
-        this.steps = [...this.steps];
+        this.steps[i].isSelected = i === index;
+      }
+
+      this.steps = [...this.steps];
     }
-}
+  }
 
   private getExtremes(): string | undefined {
     if (this.selectedStepIndex.value === 0) return 'start';
@@ -189,51 +184,42 @@ export default class NveStepper extends LitElement {
     }
   }
 
-
   private handleMobilePrevStep(): void {
     this.prevStep();
   }
 
   private renderBackButton(): TemplateResult | string {
-    return this.hideStepButtons ? '' : html`
-      <nve-button
-        .disabled=${this.getExtremes() === 'start'}
-        size="medium"
-        variant="primary"
-        @click=${this.prevStep}
-      >
-        <nve-icon slot="prefix" name="navigate_before"></nve-icon>
-        Forrige
-      </nve-button>
-    `;
+    return this.hideStepButtons
+      ? ''
+      : html`
+          <nve-button
+            .disabled=${this.getExtremes() === 'start'}
+            size="medium"
+            variant="primary"
+            @click=${this.prevStep}
+          >
+            <nve-icon slot="prefix" name="navigate_before"></nve-icon>
+            Forrige
+          </nve-button>
+        `;
   }
 
   private isOrientationVertical(): boolean {
     return this.orientation === 'vertical';
   }
 
-
   private renderForwardButton(): TemplateResult | string {
     if (this.hideStepButtons) return '';
     if (this.getExtremes() === 'end') {
       return html`
-        <nve-button
-          size="medium"
-          variant="primary"
-          @click=${this.finishSteps}
-        >
+        <nve-button size="medium" variant="primary" @click=${this.finishSteps}>
           <nve-icon slot="suffix" name="done"></nve-icon>
           ${this.endButtonText}
         </nve-button>
       `;
     }
     return html`
-      <nve-button
-        .disabled=${this.getExtremes() === 'end'}
-        size="medium"
-        variant="primary"
-        @click=${this.nextStep}
-      >
+      <nve-button .disabled=${this.getExtremes() === 'end'} size="medium" variant="primary" @click=${this.nextStep}>
         <nve-icon slot="suffix" name="navigate_next"></nve-icon>
         Neste
       </nve-button>
@@ -241,12 +227,9 @@ export default class NveStepper extends LitElement {
   }
 
   private renderVerticalButtons(): TemplateResult | string {
-    return this.hideStepButtons ? '' : html`
-      <div class="vertical-btn-container">
-        ${this.renderBackButton()}
-        ${this.renderForwardButton()}
-      </div>
-    `;
+    return this.hideStepButtons
+      ? ''
+      : html` <div class="vertical-btn-container">${this.renderBackButton()} ${this.renderForwardButton()}</div> `;
   }
 
   /** Hoved render-metode */
@@ -265,12 +248,12 @@ export default class NveStepper extends LitElement {
 
     return html`
       <div class="stepper ${this.orientation}">
-        ${this.isOrientationVertical() ? "" : this.renderBackButton()}
+        ${this.isOrientationVertical() ? '' : this.renderBackButton()}
         <div class="steps-container ${this.orientation}  ${this.hideStepButtons ? '' : 'steps-container-with-buttons'}">
           ${this.steps.map(
             (step, index) => html`
               <nve-step
-                .title=${step.title}
+                .label=${step.label}
                 .description=${step.description}
                 .state=${step.state}
                 .selectedStepIndex=${this.selectedStepIndex.value}
@@ -286,8 +269,8 @@ export default class NveStepper extends LitElement {
             `
           )}
         </div>
-        ${this.isOrientationVertical() ? "" : this.renderForwardButton()}
-        ${this.isOrientationVertical() ? this.renderVerticalButtons() : ""}
+        ${this.isOrientationVertical() ? '' : this.renderForwardButton()}
+        ${this.isOrientationVertical() ? this.renderVerticalButtons() : ''}
       </div>
     `;
   }


### PR DESCRIPTION
BREAKING CHANGES
PR-en løser [problemet 525](https://github.com/NVE/Designsystem/issues/525).

Jeg valgte ikke å fikse selve nve-alert. Det er en del problemer med visning av komponenten, men det skal fikses i en separat PR. 
Jeg bestemte å endre title til label i stepper props. Usikker om det er så viktig, men tenkte bare å bruke samme navn siden selve property i nve-step skal nå hete label, ikke title. Alle komponentne skal virke som før, med en forksjell for å ikke bruke title. Brukere kan bruke title selv om de har lyst til det i deres prosjekter.

Nå skal vi ikke ha tooltips når man hover over nevnte komponenter. Bruk av title som property navn burde bli forbudt, tenker jeg.
![image](https://github.com/user-attachments/assets/c389bec1-e748-44e7-b72f-1bf4cbea99b1)
![image](https://github.com/user-attachments/assets/d911c053-ec30-488b-97f9-e5c1211a9f9e)
 