### PR TITLE
chore: Lås style-dictionary til 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,122 +1,141 @@
 # [1.7.0](https://github.com/NVE/Designsystem/compare/v1.6.6...v1.7.0) (2025-06-04)
 
+
 ### Features
 
-- Oppdaterade eslint til v9 og la til Husky for auto lint vid commit ([#521](https://github.com/NVE/Designsystem/issues/521)) ([325893d](https://github.com/NVE/Designsystem/commit/325893dbf4a1c3566e787cd68ac12341f565eb1f))
+* Oppdaterade eslint til v9 og la til Husky for auto lint vid commit ([#521](https://github.com/NVE/Designsystem/issues/521)) ([325893d](https://github.com/NVE/Designsystem/commit/325893dbf4a1c3566e787cd68ac12341f565eb1f))
 
 ## [1.6.6](https://github.com/NVE/Designsystem/compare/v1.6.5...v1.6.6) (2025-05-21)
 
+
 ### Bug Fixes
 
-- En del småendringer og bugfikser på nve-alert ([#519](https://github.com/NVE/Designsystem/issues/519)) ([c8df7e7](https://github.com/NVE/Designsystem/commit/c8df7e7c5fb7e5d7917259d50255c3041fc67eb9))
-- Kan nå bygge med node 22 ([#514](https://github.com/NVE/Designsystem/issues/514)) ([a793de5](https://github.com/NVE/Designsystem/commit/a793de50369312297e51352956c6f31c6b8e3883))
+* En del småendringer og bugfikser på nve-alert ([#519](https://github.com/NVE/Designsystem/issues/519)) ([c8df7e7](https://github.com/NVE/Designsystem/commit/c8df7e7c5fb7e5d7917259d50255c3041fc67eb9))
+* Kan nå bygge med node 22 ([#514](https://github.com/NVE/Designsystem/issues/514)) ([a793de5](https://github.com/NVE/Designsystem/commit/a793de50369312297e51352956c6f31c6b8e3883))
 
 ## [1.6.5](https://github.com/NVE/Designsystem/compare/v1.6.4...v1.6.5) (2025-05-21)
 
+
 ### Bug Fixes
 
-- **stepper:** 511 stepper skjuling av description for et steg fungerer ikke ([#512](https://github.com/NVE/Designsystem/issues/512)) ([0586dc8](https://github.com/NVE/Designsystem/commit/0586dc820a71faa612783ac7db5d34e9f858854e))
+* **stepper:** 511 stepper skjuling av description for et steg fungerer ikke ([#512](https://github.com/NVE/Designsystem/issues/512)) ([0586dc8](https://github.com/NVE/Designsystem/commit/0586dc820a71faa612783ac7db5d34e9f858854e))
 
 ## [1.6.4](https://github.com/NVE/Designsystem/compare/v1.6.3...v1.6.4) (2025-04-28)
 
+
 ### Bug Fixes
 
-- **nve-message-card:** endret tekststørrelse slik de matcher designskisser ([#500](https://github.com/NVE/Designsystem/issues/500)) ([68b2eb9](https://github.com/NVE/Designsystem/commit/68b2eb919c1ad29fada6e21fc0e5e494a17eb6ca))
-- **vite:** Bump vite from 5.4.16 to 5.4.18 in /doc-site ([#498](https://github.com/NVE/Designsystem/issues/498)) ([e6e1ca2](https://github.com/NVE/Designsystem/commit/e6e1ca232c90ab32aa542e99e6de36cbf26aa0be))
-- **vite:** Bump vite from 6.2.4 to 6.2.5 ([#493](https://github.com/NVE/Designsystem/issues/493)) ([853b959](https://github.com/NVE/Designsystem/commit/853b959e3adfd2c662792ff41a6c33f8fc50735a))
+* **nve-message-card:** endret tekststørrelse slik de matcher designskisser ([#500](https://github.com/NVE/Designsystem/issues/500)) ([68b2eb9](https://github.com/NVE/Designsystem/commit/68b2eb919c1ad29fada6e21fc0e5e494a17eb6ca))
+* **vite:** Bump vite from 5.4.16 to 5.4.18 in /doc-site ([#498](https://github.com/NVE/Designsystem/issues/498)) ([e6e1ca2](https://github.com/NVE/Designsystem/commit/e6e1ca232c90ab32aa542e99e6de36cbf26aa0be))
+* **vite:** Bump vite from 6.2.4 to 6.2.5 ([#493](https://github.com/NVE/Designsystem/issues/493)) ([853b959](https://github.com/NVE/Designsystem/commit/853b959e3adfd2c662792ff41a6c33f8fc50735a))
 
 ## [1.6.3](https://github.com/NVE/Designsystem/compare/v1.6.2...v1.6.3) (2025-04-10)
 
+
 ### Bug Fixes
 
-- Bump vite to 6.2.4 ([#489](https://github.com/NVE/Designsystem/issues/489)) ([cf579f4](https://github.com/NVE/Designsystem/commit/cf579f4ba626f19e220c8c0d0cd382e0f142b59c))
-- Oppgradert esbuild og vite ([#486](https://github.com/NVE/Designsystem/issues/486)) ([4a5bda2](https://github.com/NVE/Designsystem/commit/4a5bda2578f069f08c263fdcb7b09fa51990c2de))
+* Bump vite to 6.2.4 ([#489](https://github.com/NVE/Designsystem/issues/489)) ([cf579f4](https://github.com/NVE/Designsystem/commit/cf579f4ba626f19e220c8c0d0cd382e0f142b59c))
+* Oppgradert esbuild og vite ([#486](https://github.com/NVE/Designsystem/issues/486)) ([4a5bda2](https://github.com/NVE/Designsystem/commit/4a5bda2578f069f08c263fdcb7b09fa51990c2de))
 
 ## [1.6.2](https://github.com/NVE/Designsystem/compare/v1.6.1...v1.6.2) (2025-03-24)
 
+
 ### Bug Fixes
 
-- **nve-step:** sette nve-icon størrelsen til 24px ([#484](https://github.com/NVE/Designsystem/issues/484)) ([63e7445](https://github.com/NVE/Designsystem/commit/63e744585f3a675595a44a76ba30128ab02acb0d))
+* **nve-step:** sette nve-icon størrelsen til 24px ([#484](https://github.com/NVE/Designsystem/issues/484)) ([63e7445](https://github.com/NVE/Designsystem/commit/63e744585f3a675595a44a76ba30128ab02acb0d))
 
 ## [1.6.1](https://github.com/NVE/Designsystem/compare/v1.6.0...v1.6.1) (2025-03-12)
 
+
 ### Bug Fixes
 
-- **472:** rettet farge feil på nve-option, nve-ikon i mørk modus ([#473](https://github.com/NVE/Designsystem/issues/473)) ([088e607](https://github.com/NVE/Designsystem/commit/088e60783bc2d8fa9fd9b91c19edd36740694342)), closes [#472](https://github.com/NVE/Designsystem/issues/472)
+* **472:** rettet farge feil på nve-option, nve-ikon i mørk modus ([#473](https://github.com/NVE/Designsystem/issues/473)) ([088e607](https://github.com/NVE/Designsystem/commit/088e60783bc2d8fa9fd9b91c19edd36740694342)), closes [#472](https://github.com/NVE/Designsystem/issues/472)
 
 # [1.6.0](https://github.com/NVE/Designsystem/compare/v1.5.2...v1.6.0) (2025-03-12)
 
+
 ### Features
 
-- Laget en tabell som viser fargene i DS ([b483220](https://github.com/NVE/Designsystem/commit/b4832201036fb9d7c18a525b8488422c0effa238))
+* Laget en tabell som viser fargene i DS ([b483220](https://github.com/NVE/Designsystem/commit/b4832201036fb9d7c18a525b8488422c0effa238))
 
 ## [1.5.2](https://github.com/NVE/Designsystem/compare/v1.5.1...v1.5.2) (2025-03-07)
 
+
 ### Bug Fixes
 
-- **tokens:** sørge for at large-desktop tar breakpoint på min-width 1400px ([#463](https://github.com/NVE/Designsystem/issues/463)) ([349072a](https://github.com/NVE/Designsystem/commit/349072aee10e5895dd1b544a9b86395d6d2ccf77))
+* **tokens:** sørge for at large-desktop tar breakpoint på min-width 1400px ([#463](https://github.com/NVE/Designsystem/issues/463)) ([349072a](https://github.com/NVE/Designsystem/commit/349072aee10e5895dd1b544a9b86395d6d2ccf77))
 
 ## [1.5.1](https://github.com/NVE/Designsystem/compare/v1.5.0...v1.5.1) (2025-03-06)
 
+
 ### Bug Fixes
 
-- **nve-input:** rettet hover-effekt over label i nve-input med skrivebeskyttelse ([#459](https://github.com/NVE/Designsystem/issues/459)) ([8831fff](https://github.com/NVE/Designsystem/commit/8831fff543afb6d81248b3f6d90ca3a22d240a26))
+* **nve-input:** rettet hover-effekt over label i nve-input med skrivebeskyttelse ([#459](https://github.com/NVE/Designsystem/issues/459)) ([8831fff](https://github.com/NVE/Designsystem/commit/8831fff543afb6d81248b3f6d90ca3a22d240a26))
 
 # [1.5.0](https://github.com/NVE/Designsystem/compare/v1.4.7...v1.5.0) (2025-03-05)
 
+
 ### Features
 
-- **nve-icon:** støtte offline ikoner med src egenskap ([#456](https://github.com/NVE/Designsystem/issues/456)) ([c951e29](https://github.com/NVE/Designsystem/commit/c951e29ec9a65612dc2fafc09c1bcd0c9a0518de)), closes [#2](https://github.com/NVE/Designsystem/issues/2)
+* **nve-icon:** støtte offline ikoner med src egenskap ([#456](https://github.com/NVE/Designsystem/issues/456)) ([c951e29](https://github.com/NVE/Designsystem/commit/c951e29ec9a65612dc2fafc09c1bcd0c9a0518de)), closes [#2](https://github.com/NVE/Designsystem/issues/2)
 
 ## [1.4.7](https://github.com/NVE/Designsystem/compare/v1.4.6...v1.4.7) (2025-03-05)
 
+
 ### Bug Fixes
 
-- **nve-button:** outline knapp skal også ha transition på ramme når m… ([#457](https://github.com/NVE/Designsystem/issues/457)) ([91ae096](https://github.com/NVE/Designsystem/commit/91ae096d5fbabd8125b4cf842e1db5859f583144))
+* **nve-button:** outline knapp skal også ha transition på ramme når m… ([#457](https://github.com/NVE/Designsystem/issues/457)) ([91ae096](https://github.com/NVE/Designsystem/commit/91ae096d5fbabd8125b4cf842e1db5859f583144))
 
 ## [1.4.6](https://github.com/NVE/Designsystem/compare/v1.4.5...v1.4.6) (2025-03-05)
 
+
 ### Bug Fixes
 
-- **nve-link-card:** css outline og tab accessibility ([#453](https://github.com/NVE/Designsystem/issues/453)) ([2c38339](https://github.com/NVE/Designsystem/commit/2c383391f9b5e1e456718122e189ebc157763089))
+* **nve-link-card:** css outline og tab accessibility ([#453](https://github.com/NVE/Designsystem/issues/453)) ([2c38339](https://github.com/NVE/Designsystem/commit/2c383391f9b5e1e456718122e189ebc157763089))
 
 ## [1.4.5](https://github.com/NVE/Designsystem/compare/v1.4.4...v1.4.5) (2025-03-05)
 
+
 ### Bug Fixes
 
-- **nve-drawer:** forbedringer til design ([#430](https://github.com/NVE/Designsystem/issues/430)) ([bc08e7f](https://github.com/NVE/Designsystem/commit/bc08e7f2d58235c51d7369fa5d343db6a4d40bc1))
+* **nve-drawer:** forbedringer til design ([#430](https://github.com/NVE/Designsystem/issues/430)) ([bc08e7f](https://github.com/NVE/Designsystem/commit/bc08e7f2d58235c51d7369fa5d343db6a4d40bc1))
 
 ## [1.4.4](https://github.com/NVE/Designsystem/compare/v1.4.3...v1.4.4) (2025-03-03)
 
+
 ### Bug Fixes
 
-- rette .css stier i global.css ([#443](https://github.com/NVE/Designsystem/issues/443)) ([51ff529](https://github.com/NVE/Designsystem/commit/51ff5291fde80ea33c3326f6a0ecacbb41f8a2f0))
+* rette .css stier i global.css ([#443](https://github.com/NVE/Designsystem/issues/443)) ([51ff529](https://github.com/NVE/Designsystem/commit/51ff5291fde80ea33c3326f6a0ecacbb41f8a2f0))
 
 ## [1.4.3](https://github.com/NVE/Designsystem/compare/v1.4.2...v1.4.3) (2025-03-03)
 
+
 ### Bug Fixes
 
-- publish pipeline release-bot ([#442](https://github.com/NVE/Designsystem/issues/442)) ([3d45425](https://github.com/NVE/Designsystem/commit/3d45425d8a24354a01bc6176f345ee2a4eaae970)), closes [#1](https://github.com/NVE/Designsystem/issues/1) [#2](https://github.com/NVE/Designsystem/issues/2) [#3](https://github.com/NVE/Designsystem/issues/3)
+* publish pipeline release-bot ([#442](https://github.com/NVE/Designsystem/issues/442)) ([3d45425](https://github.com/NVE/Designsystem/commit/3d45425d8a24354a01bc6176f345ee2a4eaae970)), closes [#1](https://github.com/NVE/Designsystem/issues/1) [#2](https://github.com/NVE/Designsystem/issues/2) [#3](https://github.com/NVE/Designsystem/issues/3)
 
 ## [1.4.2](https://github.com/NVE/Designsystem/compare/v1.4.1...v1.4.2) (2025-03-03)
 
+
 ### Bug Fixes
 
-- publish branch releaser bot ([#441](https://github.com/NVE/Designsystem/issues/441)) ([129c29c](https://github.com/NVE/Designsystem/commit/129c29cb92e8f6041054c772a8ffb0d9ea747775)), closes [#1](https://github.com/NVE/Designsystem/issues/1) [#2](https://github.com/NVE/Designsystem/issues/2)
+* publish branch releaser bot ([#441](https://github.com/NVE/Designsystem/issues/441)) ([129c29c](https://github.com/NVE/Designsystem/commit/129c29cb92e8f6041054c772a8ffb0d9ea747775)), closes [#1](https://github.com/NVE/Designsystem/issues/1) [#2](https://github.com/NVE/Designsystem/issues/2)
 
 ## [1.4.1](https://github.com/NVE/Designsystem/compare/v1.4.0...v1.4.1) (2025-03-03)
 
+
 ### Bug Fixes
 
-- bruke release bot ([#438](https://github.com/NVE/Designsystem/issues/438)) ([405a525](https://github.com/NVE/Designsystem/commit/405a525c34eba2fb4604c95935dda00aebdd84de))
-- publish pipeline release-bot [#1](https://github.com/NVE/Designsystem/issues/1) ([#440](https://github.com/NVE/Designsystem/issues/440)) ([0941eac](https://github.com/NVE/Designsystem/commit/0941eaca4e1ca4551fbd4dfc757bc752fdc6ba6b))
-- støtte css-filer import via cdn ([#439](https://github.com/NVE/Designsystem/issues/439)) ([293cf4c](https://github.com/NVE/Designsystem/commit/293cf4c9348a13b3733dc49ef33d07211ea1722f))
+* bruke release bot ([#438](https://github.com/NVE/Designsystem/issues/438)) ([405a525](https://github.com/NVE/Designsystem/commit/405a525c34eba2fb4604c95935dda00aebdd84de))
+* publish pipeline release-bot [#1](https://github.com/NVE/Designsystem/issues/1) ([#440](https://github.com/NVE/Designsystem/issues/440)) ([0941eac](https://github.com/NVE/Designsystem/commit/0941eaca4e1ca4551fbd4dfc757bc752fdc6ba6b))
+* støtte css-filer import via cdn ([#439](https://github.com/NVE/Designsystem/issues/439)) ([293cf4c](https://github.com/NVE/Designsystem/commit/293cf4c9348a13b3733dc49ef33d07211ea1722f))
 
 # [1.4.0](https://github.com/NVE/Designsystem/compare/v1.3.1...v1.4.0) (2025-02-28)
 
+
 ### Features
 
-- endre engelsk tekst til norsk ([#434](https://github.com/NVE/Designsystem/issues/434)) ([a5e3209](https://github.com/NVE/Designsystem/commit/a5e32099146603e1c37b143a2ebe3fb6243b8320))
+* endre engelsk tekst til norsk ([#434](https://github.com/NVE/Designsystem/issues/434)) ([a5e3209](https://github.com/NVE/Designsystem/commit/a5e32099146603e1c37b143a2ebe3fb6243b8320))
 
 # [1.3.1](https://github.com/NVE/Designsystem/compare/v1.0.0...v1.1.0) (2025-02-17)
 

--- a/README.md
+++ b/README.md
@@ -34,35 +34,36 @@ Ikke push endringer direkte i `main`. Lag en pull request.
 
 ### Conventional Commits
 
-Vi har innført **Conventional Commits**-standarden i vårt prosjekt for å automatisere oppdatering av versjonsnummer og generering av versjonslogg. Når du lager en pull request (PR) som skal flettes inn i `main`-branchen, må tittelen på PR-en følge denne standarden for at den skal bli godkjent.
-Tittelen på PR-en blir generert på bakgrunn av første commit i branchen som PR'en er basert på.
+Vi har innført **Conventional Commits**-standarden i vårt prosjekt for å automatisere oppdatering av versjonsnummer og generering av changelog-filer. Når du lager en pull request (PR) som skal merges til `main`-branchen, må tittelen på PR-en følge denne standarden for at den skal bli godkjent.
 
 #### Standardformatet er som følger
 
 `<type>(<scope>): <beskrivelse>`
 
-- **type**: Hvilken type endring det er. Disse er tillatt:
+- **type**: Definerer hvilken type endring det er. Eksempler:
 
-  - `feat`: Ny funksjonalitet
+  - `feat`: Legger til ny funksjonalitet
   - `fix`: Fikser en feil
   - `chore`: Oppgaver som ikke endrer kode (f.eks. oppdatering av verktøy)
   - `docs`: Endringer i dokumentasjon
 
-- **scope**: Beskriver hvor i prosjektet endringen er gjort. Valgfri.
+- **scope** (valgfritt): Beskriver hvor i prosjektet endringen er gjort. Eksempler:
 
-- **beskrivelse**: En kortfattet, imperativ beskrivelse av hva endringen gjør. Den skal være på én linje og beskrive hva koden gjør etter endringen.
+  - `auth`: Endringer relatert til autentisering
+  - `ui`: Endringer i brukergrensesnittet
+
+- **beskrivelse**: En kortfattet, imperativ beskrivelse av hva endringen gjør. Den skal være på én linje og beskrive hva koden gjør etter endringen. For eksempel: "Legg til validering for e-postadresse."
 
 #### Eksempler på commit-meldinger
 
-- fix(nve-icon): Standardstørrelse satt til 24px
-- feat(nve-step): Nytt attributt, hideStep for å skjule et steg
-- docs: Nye installasjonsinstruksjoner i README
+- feat(auth): legg til støtte for 2-faktor autentisering fix(ui): rettet layout-feil på forsiden
+- docs: oppdatert README med nye installasjonsinstruksjoner
 
 For mer informasjon om standarden, kan du lese mer på [Conventional Commits.](https://www.conventionalcommits.org/en/v1.0.0/)
 
 #### PR-sjekk før merging til main
 
-Tittelen blir automatisk validert som en del av en PR-sjekk.
+Tittelen på PR-en må oppfylle **Conventional Commits**-standarden. Dette blir automatisk validert som en del av en PR-sjekk.
 
 #### Verktøy for å følge standarden
 
@@ -76,50 +77,44 @@ npx cz
 
 2. VS Code-utvidelse: Hvis du bruker Visual Studio Code, kan du installere utvidelsen [VS Code Conventional Commits](https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits) for å sikre at commit-meldinger følger standarden. Etter at du har installert tillegget, kan du klikke på den runde sirkelen til høyre for Source Control for att gjøre en commit.
 
-## Versjonslogg
+## Changelog
 
-`CHANGELOG.md` genereres automatisk basert på commit-meldingene som går inn main-branchen og blir synlige i [versjonsloggen](https://github.com/NVE/Designsystem/releases) på GitHub.
+Changelog-filene genereres automatisk basert på commit-meldingene dine og blir synlige i [release-notatene](https://github.com/NVE/Designsystem/releases) på GitHub.
 
 ### Betingelser for Semantic Release
 
-Merk at `semantic-release` stiller visse betingelser før oppdatering av versjonsloggen. For at en endring skal registreres i versjonsloggen, må følgende krav være oppfylt:
+Merk at `semantic-release` stiller visse betingelser før oppdatering av changeloggen. For at en endring skal registreres i changelogen, må følgende krav være oppfylt:
 
 - Commit-typen må være en av følgende:
-
   - `BREAKING CHANGE`: Introduserer en endring som bryter bakoverkompatibiliteten
-  - `feat`: Ny funksjonalitet
-  - `fix`: Fikser en feil
-  - `chore`: Oppgaver som ikke endrer kode (f.eks. oppdatering av verktøy)
-  - `docs`: Endringer i dokumentasjon
-
+  - `feat`: Legger til en ny funksjonalitet
+  - `fix`: Retter en feil
+  - `perf`: Forbedrer ytelsen
 - Endringen må ha skjedd i en av følgende mappespesifikasjoner:
   - `src/**`
   - `build/**`
   - `public/css/**`
 
 ## Automatiske oppdateringer med Dependabot
-
 Vi bruker **Dependabot** for å automatisk opprette pull requests når det finnes oppdateringer av avhengigheter eller sikkerhetsfikser i vår `package.json`.  
 Konfigurasjonen for Dependabot ligger i: .github/dependabot.yml
 
 Når Dependabot oppretter en pull request, genereres det automatisk et **forhåndsvisningsmiljø** av nettsiden via **Azure Static Web Apps**. Dette lar deg enkelt sjekke hvordan endringene påvirker dokumentasjonsappen.
 
 ### Slik finner du lenken til forhåndsvisningen:
-
 1. Gå inn i den aktuelle pull requesten.
 2. Klikk på fanen **Checks**.
 3. Velg jobben **"Bygg og installasjon av dok-app i skyen"**.
 4. Gå til steget **"Installer dokumentasjons-nettsted"**.
-5. Se etter linjen som inneholder: Visit your site at: https://...
+5. Se etter linjen som inneholder:  Visit your site at: https://...
 6. Klikk på lenken for å åpne den midlertidige versjonen av nettstedet.
 
 Merk: Lenken vises **ikke automatisk som en kommentar** i PR-en.  
 Dette skyldes at Dependabot, av sikkerhetsgrunner, ikke har tillatelse til å poste kommentarer via GitHub Actions. Derfor kan du se følgende feilmelding i loggene:
-
 ```
 Unexpectedly failed to add GitHub comment.
 ```
-
+   
 ## Oppretting av en ny komponent og mappestruktur
 
 <em>Alle komponenters navn skal starte med `nve-`. Bruk det samme navnet som komponenten får i html. Kun små bokstaver og bindestrek er tillatt i navnet.</em>


### PR DESCRIPTION
Dependabot maser om å oppgradere `style-dictionary` til siste versjon (se #538), men dette kommer i konflikt med siste versjon av `style-dictionary-utils`, som ikke er kompatibel med versjon 5 av `style-dictionary`. 
Velger derfor å låse den til den versjonen vi bruker idag.
Denne endringen vil føre til at vi slipper mer mas fra Dependabot om `style-dictionary`.