### PR TITLE
feat(mange-elementer): fjern titel property i nve-alert, nve-stepper,…

### DIFF
--- a/src/components/nve-alert/nve-alert.component.ts
+++ b/src/components/nve-alert/nve-alert.component.ts
@@ -13,7 +13,9 @@ export default class NveAlert extends SlAlert {
   constructor() {
     super();
   }
-  /** Tykk tekst, vises helt til venstre */
+  /**
+   * Tykk tekst, vises helt til venstre
+   */
   @property({ reflect: true }) label: string = '';
   /** Tynnere beskrivelse tekst */
   @property({ reflect: true }) text: string = '';


### PR DESCRIPTION
BREAKING CHANGES. PR som skal innføre oppgradering av hoved pakke versjon
PR-en løser [problemet 525](https://github.com/NVE/Designsystem/issues/525).

Jeg valgte ikke å fikse selve nve-alert. Det er en del problemer med visning av komponenten, men det skal fikses i en separat PR. 
Jeg bestemte å endre title til label i stepper props. Usikker om det er så viktig, men tenkte bare å bruke samme navn siden selve property i nve-step skal nå hete label, ikke title. Alle komponentne skal virke som før, med en forksjell for å ikke bruke title. Brukere kan bruke title selv om de har lyst til det i deres prosjekter.

Nå skal vi ikke ha tooltips når man hover over nevnte komponenter. Bruk av title som property navn burde bli forbudt, tenker jeg.
![image](https://github.com/user-attachments/assets/c389bec1-e748-44e7-b72f-1bf4cbea99b1)
![image](https://github.com/user-attachments/assets/d911c053-ec30-488b-97f9-e5c1211a9f9e)
 