### PR TITLE
fix(nve-alert): fikse kommentar

### DIFF
--- a/src/components/nve-alert/nve-alert.component.ts
+++ b/src/components/nve-alert/nve-alert.component.ts
@@ -13,7 +13,9 @@ export default class NveAlert extends SlAlert {
   constructor() {
     super();
   }
-  /** Tykk tekst, vises helt til venstre */
+  /**
+   * Tykk tekst, vises helt til venstre¨
+   *  */
   @property({ reflect: true }) label: string = '';
   /** Tynnere beskrivelse tekst */
   @property({ reflect: true }) text: string = '';


### PR DESCRIPTION
 for å publisere riktig versjon 2.0.1 siden 2.0.0 vil ikke bli publisert. Det er en del caching som gjør at vi ikke kan ha versjon 2.0.0.