### PR TITLE
fix(form): flytte obligatorisk tekst etter overskrift

### DIFF
--- a/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit';
+import { html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import '../nve-label/nve-label.component';
 import styles from './nve-checkbox-group.styles';
@@ -7,9 +7,9 @@ import deepCompare from '../../utils/deepCompare';
 
 /**
  * Bruk denne for å håndtere flere avkrysningsbokser (nve-checkbox) som hører sammen.
- * selectedValues inneholder `value` til hver av avkrysningsboksene som er valgt i gruppa. 
- * Gruppa oppdaterer seg automatisk når man klikker på en avkrysningsboks. 
- * Støtter både constraint validation (kun `required`) og tilpasset validering. 
+ * selectedValues inneholder `value` til hver av avkrysningsboksene som er valgt i gruppa.
+ * Gruppa oppdaterer seg automatisk når man klikker på en avkrysningsboks.
+ * Støtter både constraint validation (kun `required`) og tilpasset validering.
  * Tilpasset validering prioriteres foran `required`.
  * @slot default - legg avkrysningsboksene inni denne.
  * */
@@ -35,7 +35,7 @@ export default class NveCheckboxGroup extends LitElement {
   @property() requiredLabel = '*Obligatorisk';
   /** Returnerer en tabell av value-attributet til alle sjekkbokser som er valgt. Man kan lagre både primitiver og objekter i selectedValues. */
   @property({ type: Array }) selectedValues?: string[];
-   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   @query('slot') slot: any;
   /** Bestemmer om feilmelding skal vises når validering feiler  */
   @state() protected showErrorMessage = false;
@@ -190,16 +190,16 @@ export default class NveCheckboxGroup extends LitElement {
         aria-errormessage="error-message"
       >
         ${this.label
-        ? html`<div class="checkbox-group__label">
+          ? html`<div class="checkbox-group__label">
               <nve-label id="label" value=${this.label} size="small" tooltip=${this.tooltip!}></nve-label>
             </div>`
-        : null}
+          : nothing}
         <slot class="checkbox-group__checkboxes"></slot>
         ${this.showErrorMessage
-        ? html`<span role="alert" id="error-message" class="checkbox-group__error-message"
-              >${this.errorMessage || null}</span
+          ? html`<span role="alert" id="error-message" class="checkbox-group__error-message"
+              >${this.errorMessage || nothing}</span
             >`
-        : null}
+          : nothing}
       </fieldset>
     `;
   }

--- a/src/components/nve-checkbox-group/nve-checkbox-group.styles.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.styles.ts
@@ -49,4 +49,8 @@ export default css`
     font: var(--body-xsmall);
     color: var(--feedback-background-emphasized-error);
   }
+
+  nve-label {
+    width: unset;
+  }
 `;

--- a/src/components/nve-input/nve-input.styles.ts
+++ b/src/components/nve-input/nve-input.styles.ts
@@ -88,11 +88,11 @@ export default css`
     border-color: var(--feedback-background-emphasized-error);
   }
 
-  /* Formaterer "*Obligatorisk" over input-felt og til høyre riktig når required er satt */
+  /* Formaterer "*Obligatorisk" over input-felt når required er satt */
   .form-control--has-label .form-control__label {
     display: flex;
-    width: 100%;
-    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-xx-small);
     margin-inline-start: unset;
   }
 `;

--- a/src/components/nve-textarea/nve-textarea.component.ts
+++ b/src/components/nve-textarea/nve-textarea.component.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import styles from './nve-textarea.styles';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -121,6 +121,10 @@ export default class NveTextarea extends LitElement implements INveComponent {
   }
   private resizeObserver: ResizeObserver | null = null;
   firstUpdated() {
+    if (this.requiredLabel) {
+      this.style.setProperty('--textarea-required-content', `"${this.requiredLabel}"`);
+    }
+
     // Sjekker om data-valid når komponenten først lastes
     if (this.required) {
       const isValid = this.input.checkValidity();
@@ -224,20 +228,11 @@ export default class NveTextarea extends LitElement implements INveComponent {
   render() {
     return html`
       <div part="form-control" class=${classMap({ 'form-control': true, 'form-control--has-label': this.label })}>
-        <div part="textarea-label" class="textarea__label">
-          ${this.label
-            ? html`
-                <nve-label
-                  aria-hidden=${this.label ? 'false' : 'true'}
-                  value=${this.label}
-                  tooltip=${ifDefined(this.tooltip)}
-                ></nve-label>
-              `
-            : null}
-          ${this.required && this.label
-            ? html`<span class="textarea__required-label">${this.requiredLabel}</span>`
-            : null}
-        </div>
+        ${this.label
+          ? html`<div class="textarea__label">
+              <nve-label id="label" value=${this.label} size="small" tooltip=${ifDefined(this.tooltip)}></nve-label>
+            </div>`
+          : nothing}
         <div part="base" class="textarea__base">
           <textarea
             part="textarea"
@@ -271,7 +266,7 @@ export default class NveTextarea extends LitElement implements INveComponent {
                 ${this.disabled ? html`<nve-icon name="lock"></nve-icon>` : null}
                 ${this.showErrorMessage ? html`<nve-icon class="textarea__icon--error" name="error"></nve-icon>` : null}
               </div>`
-            : null}
+            : nothing}
         </div>
         <div part="help-text-container" class="textarea__help-text__container">
           <!-- Ikke vis hjelpe tekst mens feil -->
@@ -279,10 +274,10 @@ export default class NveTextarea extends LitElement implements INveComponent {
             ? html`<span class="textarea__help-text" aria-hidden=${this.helpText ? 'false' : 'true'}
                 >${this.helpText}</span
               >`
-            : null}
+            : nothing}
           ${this.showErrorMessage
             ? html`<span class="textarea__help-text textarea__help-text--error">${this.errorMessage}</span>`
-            : null}
+            : nothing}
         </div>
       </div>
     `;

--- a/src/components/nve-textarea/nve-textarea.styles.ts
+++ b/src/components/nve-textarea/nve-textarea.styles.ts
@@ -3,6 +3,7 @@ import { css } from 'lit';
 export default css`
   :host {
     display: flex;
+    --textarea-required-content: '*Obligatorisk';
   }
 
   .form-control {
@@ -71,8 +72,10 @@ export default css`
     align-items: center;
   }
 
-  .textarea__required-label {
+  :host([required]) nve-label::after {
+    content: var(--textarea-required-content);
     font: var(--label-x-small-light);
+    margin-left: auto;
     color: var(--feedback-background-emphasized-error);
   }
 
@@ -100,5 +103,9 @@ export default css`
     left: -24px;
     top: 10px;
     color: var(--feedback-background-emphasized-error);
+  }
+
+  nve-label {
+    width: unset;
   }
 `;


### PR DESCRIPTION
Da flytter jeg alle "obligatorisk" tekstene rett etter overskriften i nve-input, nve-checkbox-group, nve-radio-group, nve-textarea.