### PR TITLE
fix(npm-link): dist mappe overskrevet

### DIFF
--- a/scripts/npmLink.js
+++ b/scripts/npmLink.js
@@ -51,7 +51,7 @@ const runBuild = async () => {
   isBuilding = true;
   buildCancelled = false;
 
-  currentBuildProcess = spawn('npx', ['vite', 'build', '--outDir', 'dist'], {
+  currentBuildProcess = spawn('npx', ['vite', 'build', '--outDir', 'dist', '--emptyOutDir=false'], {
     stdio: ['inherit', 'pipe', 'pipe'],
     shell: true,
   });


### PR DESCRIPTION
Dist mappen ble overskrevet, dette resulterte i at viktige filer for npm-link ble overskrevet.