### PR TITLE
fix(nve-label): posisjoneringen av tooltip var feil

### DIFF
--- a/src/components/nve-label/nve-label.styles.ts
+++ b/src/components/nve-label/nve-label.styles.ts
@@ -11,6 +11,7 @@ export const styles = css`
     display: flex;
     align-items: center;
     gap: var(--spacing-xx-small);
+    position: relative;
   }
 
   /* skriftstørrelser */


### PR DESCRIPTION
Vi har hatt problemer med at tooltippen ikke kommer frem der den skal i flere tilfeller. (laaangt unna)


Dette gjelder nve-label og nve-tooltip.

Denne PR fikser nve-label men ikke nve-tooltip da nve-tooltip ikke er wrappet i et element. 

