### PR TITLE
fix: sentrere tekst i NVE-tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.44.0",
         "@shoelace-style/shoelace": "^2.20.1",
         "fontfaceobserver": "^2.3.0",
         "lit": "^3.3.0"

--- a/src/components/nve-tag/nve-tag.styles.ts
+++ b/src/components/nve-tag/nve-tag.styles.ts
@@ -107,9 +107,13 @@ export default css`
 
   :host::part(text) {
     font: var(--label-x-small);
+    display: flex;
+    align-items: center;
   }
   :host::part(extra) {
     font: var(--label-x-small-light);
+    display: flex;
+    align-items: center;
   }
   ::slotted(nve-icon) {
     font-size: var(--font-size-small);


### PR DESCRIPTION
La til styling i :host::part(text) og :host::part(extra) for å få sentrert teksen i nve-tag.

#557 
