### PR TITLE
fix(nve-checkbox): fikse deaktivert styling

### DIFF
--- a/src/components/nve-checkbox/nve-checkbox.styles.ts
+++ b/src/components/nve-checkbox/nve-checkbox.styles.ts
@@ -17,15 +17,6 @@ export default css`
     transition: all var(--transition-time) ease-in;
   }
 
-  :host([disabled])::part(control) {
-    border-color: var(--neutrals-border-disabled);
-  }
-
-  :host([disabled])::part(form-control-help-text),
-  :host([disabled])::part(label) {
-    color: var(--interactive-primary-background-disabled);
-  }
-
   :host::part(control control--checked),
   :host::part(control control--indeterminate) {
     background: var(--neutrals-foreground-primary) !important;


### PR DESCRIPTION
Shoelace legger på checkbox--disabled-klassen, som gjør at hele elementet får opacity: 0.5. Jeg har ikke endret på det. har bare fjernet styling som forstyret shoelace sin styling. Jeg tror vi burde sette av en dag til å rydde opp i disabled-styling på alle komponenter – spesielt de som arver fra Shoelace. Det virker som vi ikke er helt konsekvente med hvordan vi håndterer deaktivert-styling. Jeg lager en issue på det.