### PR TITLE
feat(nve-select): Legg inn checkmark på valgte options i nve-select

### DIFF
--- a/doc-site/components/nve-select.md
+++ b/doc-site/components/nve-select.md
@@ -150,3 +150,25 @@ Bruk `textLabel` i `nve-option` dersom du ønsker at teksten som vises i selve s
 ```
 
 </CodeExamplePreview>
+
+### Markering av valgte elementer
+
+Valgte elementer får et ikon for markering i dropdown. Dette kan slås av med `hide-checkmark` på både vanlig og flervalg-variantene
+
+<CodeExamplePreview>
+
+```html
+<nve-select multiple clearable hide-checkmark value="valg1 valg2" label="Her kan du velge flere">
+  <nve-option value="valg1">Valg 1</nve-option>
+  <nve-option value="valg2">Valg 2</nve-option>
+  <nve-option value="valg3">Valg 3</nve-option>
+</nve-select>
+
+<nve-select value="valg2" hide-checkmark label="Her kan du velge kun én">
+  <nve-option value="valg1">Valg 1</nve-option>
+  <nve-option value="valg2">Valg 2</nve-option>
+  <nve-option value="valg3">Valg 3</nve-option>
+</nve-select>
+```
+
+</CodeExamplePreview>

--- a/src/components/nve-option/nve-option.component.ts
+++ b/src/components/nve-option/nve-option.component.ts
@@ -16,14 +16,25 @@ export default class NveOption extends SlOption {
    */
   @property() textLabel: string | undefined = undefined;
 
-  /* Setter filled attributt på option når parent-select er filled, for å få annen hover-farge*/
+  /**
+   * Setter filled attributt på option når parent-select er filled, for å få annen hover-farge
+   * Setter så hide-checkmark basert på samme logikk
+   */
   firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
     const select = this.closest('nve-select');
-    if (select?.hasAttribute('filled')) {
+    if (!select) {
+      return;
+    }
+    if (select.hasAttribute('filled')) {
       this.toggleAttribute('filled', true);
     } else {
       this.toggleAttribute('filled', false);
+    }
+    if (select.hasAttribute('hide-checkmark')) {
+      this.toggleAttribute('hide-checkmark', true);
+    } else {
+      this.toggleAttribute('hide-checkmark', false);
     }
   }
 

--- a/src/components/nve-option/nve-option.styles.ts
+++ b/src/components/nve-option/nve-option.styles.ts
@@ -16,8 +16,7 @@ export default css`
     color: var(--neutrals-foreground-primary, #0d0d0e);
   }
 
-  /* fjerner checkmark siden den er hvit */
-  :host::part(checked-icon) {
+  :host([hide-checkmark])::part(checked-icon) {
     display: none !important;
   }
 
@@ -39,8 +38,7 @@ export default css`
     background-color: var(--neutrals-background-primary, #fff);
   }
 
-  :host([filled]) .option{
+  :host([filled]) .option {
     color: var(--neutrals-foreground-primary, #0d0d0e);
   }
-
 `;

--- a/src/components/nve-select/nve-select.component.ts
+++ b/src/components/nve-select/nve-select.component.ts
@@ -18,6 +18,12 @@ export default class NveSelect extends SlSelect {
    * Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard.
    */
   @property() requiredLabel = '*Obligatorisk';
+
+  /**
+   * Settes dersom man ikke ønsker å ha checkmark på valgte options i dropdown
+   */
+  @property({ type: Boolean }) hideCheckmark: boolean = false;
+
   /**
    * Brukes til enkel constraint validation til å overskrive default nettleser-melding
    */


### PR DESCRIPTION
Designet i Figma har checkmark på valgte elementer i nve-select. Denne var eksplisitt satt som display: none i vår kode
Jeg tok bort den eksplisitte display: none-koden og erstattet den med en `hide-checkmark" istedenfor. Denne er default `false`