### PR TITLE
feat(nve-switch): legge til primary color og label-position

### DIFF
--- a/doc-site/components/nve-switch.md
+++ b/doc-site/components/nve-switch.md
@@ -12,6 +12,31 @@ layout: component
 
 ## Eksempler
 
+### Varianter
+Bruk variant for å velge farge, default er standard.
+
+
+<CodeExamplePreview>
+
+```html
+<div style="display: flex; flex-direction: row; justify-content: space-evenly ">
+        <div style="display: flex; flex-direction: column; gap: 1rem">
+        På
+        <nve-switch checked>Default</nve-switch>
+        <nve-switch variant="primary" checked>Primary</nve-switch>
+    </div>
+    
+    <div style="display: flex; flex-direction: column; gap: 1rem">
+        Av
+        <nve-switch>Default</nve-switch>
+        <nve-switch variant="primary"  >Primary</nve-switch>
+    </div>
+</div>
+```
+
+</CodeExamplePreview>
+ 
+
 ### Med ikoner
 
 <CodeExamplePreview>
@@ -27,12 +52,13 @@ layout: component
 
 Se også [nve-darkmode-switch](/components/nve-darkmode-switch)
 
-### Label, vises bak bryter
-
+### Label plassering
+For å sette label foran switchen bruk `label-position="start"`. `end` er default. 
 <CodeExamplePreview>
 
 ```html
-<nve-switch> Slå på </nve-switch>
+ 
+<nve-switch label-position="start"> Slå på </nve-switch>
 ```
 
 </CodeExamplePreview>
@@ -47,7 +73,7 @@ Se også [nve-darkmode-switch](/components/nve-darkmode-switch)
 
 </CodeExamplePreview>
 
-### Hent ut verdien
+## Hent ut verdien
 
 Du kan hente ut `checked`-verdien akkurat som med en vanlig html-checkbox, enten via elementet eller på en event
 
@@ -68,31 +94,3 @@ function changehandler(event) {
   const checked = event.target.checked;
 }
 ```
-
-Du kan også bruke attributten `checked` på `nve-switch` for å sette verdien via lytting på change, tilsvarende som for en checkbox
-
-### Egne farger for "på" og "av"
-
-Ved hjelp av variabler så kan du sette egne farger for "på" og "av" på bryteren. Markøren (thumb) har motsatt farge av bakgrunnen dersom det ikke settes spesifikt
-<CodeExamplePreview>
-
-```html
-<div style="--nve-switch-on-color: #FF0000; --nve-switch-off-color: #0000FF;">
-  <nve-switch>Denne har kun satt on/off, så markør er motsatt</nve-switch>
-</div>
-
-<div style="--nve-switch-thumb-on-color: #FF0000; --nve-switch-thumb-off-color: #0000FF;">
-  <nve-switch>Denne setter kun markørfarge, så bakgrunnen affekteres ikke</nve-switch>
-</div>
-
-<div
-  style="--nve-switch-thumb-on-color: var(--feedback-background-emphasized-info); 
-  --nve-switch-thumb-off-color: var(--feedback-background-subtle-error);
-  --nve-switch-off-color: var(--interactive-primary-background-default); 
-  --nve-switch-on-color: var(--interactive-secondary-background-default);"
->
-  <nve-switch>Her setter vi alle fire fargene separat</nve-switch>
-</div>
-```
-
-</CodeExamplePreview>

--- a/doc-site/components/nve-switch.md
+++ b/doc-site/components/nve-switch.md
@@ -19,18 +19,8 @@ Bruk variant for å velge farge, default er standard.
 <CodeExamplePreview>
 
 ```html
-<div style="display: flex; flex-direction: row; justify-content: space-evenly ">
-        <div style="display: flex; flex-direction: column; gap: 1rem">
-        På
         <nve-switch checked>Default</nve-switch>
         <nve-switch variant="primary" checked>Primary</nve-switch>
-    </div>
-    
-    <div style="display: flex; flex-direction: column; gap: 1rem">
-        Av
-        <nve-switch>Default</nve-switch>
-        <nve-switch variant="primary"  >Primary</nve-switch>
-    </div>
 </div>
 ```
 

--- a/doc-site/components/nve-switch.md
+++ b/doc-site/components/nve-switch.md
@@ -52,12 +52,13 @@ Bruk variant for å velge farge, default er standard.
 
 Se også [nve-darkmode-switch](/components/nve-darkmode-switch)
 
-### Label plassering
+### Label
 For å sette label foran switchen bruk `label-position="start"`. `end` er default. 
 <CodeExamplePreview>
 
 ```html
  
+<nve-switch> Slå på </nve-switch>
 <nve-switch label-position="start"> Slå på </nve-switch>
 ```
 
@@ -73,7 +74,7 @@ For å sette label foran switchen bruk `label-position="start"`. `end` er defaul
 
 </CodeExamplePreview>
 
-## Hent ut verdien
+### Hent ut verdien
 
 Du kan hente ut `checked`-verdien akkurat som med en vanlig html-checkbox, enten via elementet eller på en event
 
@@ -94,3 +95,4 @@ function changehandler(event) {
   const checked = event.target.checked;
 }
 ```
+Du kan også bruke attributten `checked` på `nve-switch` for å sette verdien via lytting på change, tilsvarende som for en checkbox

--- a/src/components/nve-switch/nve-switch.component.ts
+++ b/src/components/nve-switch/nve-switch.component.ts
@@ -46,10 +46,10 @@ export default class NveSwitch extends LitElement implements INveComponent {
   @property({ type: Boolean, reflect: true }) checked = false;
 
   /** Bestemmer fargevariant */
-  @property({ reflect: true }) variant: 'primary' | 'default' = 'default';
+  @property() variant: 'primary' | 'default' = 'default';
 
   /** Plassering av label-tekst i forhold til bryteren */
-  @property({ reflect: true, attribute: 'label-position' }) labelPosition: 'start' | 'end' = 'end';
+  @property() labelPosition: 'start' | 'end' = 'end';
 
   static styles: CSSResultArray = [styles];
   private emit(eventname: string): void {

--- a/src/components/nve-switch/nve-switch.component.ts
+++ b/src/components/nve-switch/nve-switch.component.ts
@@ -49,7 +49,7 @@ export default class NveSwitch extends LitElement implements INveComponent {
   @property() variant: 'primary' | 'default' = 'default';
 
   /** Plassering av label-tekst i forhold til bryteren */
-  @property() labelPosition: 'start' | 'end' = 'end';
+  @property({ attribute: 'label-position' }) labelPosition: 'start' | 'end' = 'end';
 
   static styles: CSSResultArray = [styles];
   private emit(eventname: string): void {

--- a/src/components/nve-switch/nve-switch.component.ts
+++ b/src/components/nve-switch/nve-switch.component.ts
@@ -22,11 +22,6 @@ import styles from './nve-switch.styles';
  * @csspart control Element rundt bryteren
  * @csspart thumb Bryter-indikatoren
  * @csspart label Tekst bak bryteren
- *
- * @cssproperty --nve-switch-on-color - Bakgrunnsfarge når switch er PÅ
- * @cssproperty --nve-switch-off-color - Bakgrunnsfarge når switch er AV
- * @cssproperty --nve-switch-thumb-on-color- Farge på bryter når switch er PÅ
- * @cssproperty --nve-switch-thumb-off-color - Farge på bryter når switch er AV
  */
 @customElement('nve-switch')
 export default class NveSwitch extends LitElement implements INveComponent {
@@ -49,6 +44,13 @@ export default class NveSwitch extends LitElement implements INveComponent {
 
   /** Verdien til switchen. */
   @property({ type: Boolean, reflect: true }) checked = false;
+
+  /** Bestemmer fargevariant */
+  @property({ reflect: true }) variant: 'primary' | 'default' = 'default';
+
+  /** Plassering av label-tekst i forhold til bryteren */
+  @property({ reflect: true, attribute: 'label-position' }) labelPosition: 'start' | 'end' = 'end';
+
   static styles: CSSResultArray = [styles];
   private emit(eventname: string): void {
     const event = new CustomEvent(eventname, {
@@ -115,8 +117,10 @@ export default class NveSwitch extends LitElement implements INveComponent {
           switch: true,
           'switch--checked': this.checked,
           'switch--disabled': this.disabled,
-          'switch--focused': this.hasFocus,
-        })}
+          'switch--focused': this.hasFocus, 
+          [`switch--${this.variant}`]: true,
+          [`switch--label-${this.labelPosition}`]: true
+        })} 
       >
         <input
           class="switch__input"
@@ -141,7 +145,7 @@ export default class NveSwitch extends LitElement implements INveComponent {
           <span class="switch__icon switch__onicon"><slot name="onicon"></slot></span>
         </span>
 
-        <div part="label" class="">
+        <div part="label">
           <slot></slot>
         </div>
       </label>

--- a/src/components/nve-switch/nve-switch.styles.ts
+++ b/src/components/nve-switch/nve-switch.styles.ts
@@ -22,9 +22,9 @@ export default css`
     --left: calc(0% + 4px);
     width: 48px;
     --label-color: var(--neutrals-foreground-primary);
-    --on-color: var(--nve-switch-on-color, var(--neutrals-foreground-subtle));
-    --off-color: var(--nve-switch-off-color, var(--neutrals-background-secondary));
-    --thumb-color: var(--nve-switch-thumb-off-color, var(--on-color));
+    --on-color: var(--neutrals-foreground-subtle);
+    --off-color:  var(--neutrals-background-secondary);
+    --thumb-color:  var(--on-color);
     background-color: var(--off-color);
     transition: background-color 0.3s ease-in-out;
   }
@@ -36,7 +36,7 @@ export default css`
   .switch--checked .switch__control {
     /* 100% - bredde på thumb + 4px */
     --left: calc(100% - var(--font-size-xsmall) - 4px);
-    --thumb-color: var(--nve-switch-thumb-on-color, var(--off-color));
+    --thumb-color:  var(--off-color);
     background-color: var(--on-color);
   }
   .switch__thumb {
@@ -94,5 +94,17 @@ export default css`
   }
   .switch.switch--disabled {
     opacity: var(--disabled);
+  } 
+    
+ .switch--label-start {
+    justify-content: flex-end;
+    flex-direction: row-reverse;
+  }
+ 
+  .switch--primary {
+    &.switch--checked .switch__control {
+      --on-color: var(--feedback-background-emphasized-info);
+      --off-color: var(--neutrals-background-secondary);
+    }
   }
 `;

--- a/src/components/nve-switch/nve-switch.styles.ts
+++ b/src/components/nve-switch/nve-switch.styles.ts
@@ -39,6 +39,7 @@ export default css`
     --thumb-color:  var(--off-color);
     background-color: var(--on-color);
   }
+    
   .switch__thumb {
     position: absolute;
     left: var(--left);
@@ -79,12 +80,10 @@ export default css`
     clip: rect(0, 0, 0, 0);
     position: absolute;
   }
-  .switch__label {
-    font: var(--label-medium-light);
-    color: var(--label-color);
-  }
+ 
   .switch.switch--focused:has(:focus-visible) .switch__control {
     outline: 2px solid var(--interactive-links-focus);
+    outline-offset: 1px;
   }
   .switch:not(.switch--disabled):hover {
     --hover-offset: 2px;
@@ -103,7 +102,7 @@ export default css`
  
   .switch--primary {
     &.switch--checked .switch__control {
-      --on-color: var(--feedback-background-emphasized-info);
+      --on-color: var(--interactive-primary-foreground-border-focus);
       --off-color: var(--neutrals-background-secondary);
     }
   }

--- a/src/components/nve-switch/nve-switch.test.ts
+++ b/src/components/nve-switch/nve-switch.test.ts
@@ -12,35 +12,35 @@ describe('nve-switch', () => {
     fixtureCleanup();
   });
 
-  it('has default as default variant', async () => {
+  it('should have default as default variant', async () => {
     const el = await fixture<NveSwitch>(html`<nve-switch></nve-switch>`);
     expect(el.variant).toBe('default');
     const label = el.shadowRoot?.querySelector('label[part="base"]');
     expect(label?.classList.contains('switch--default')).toBe(true);
   });
 
-  it('applies primary variant class', async () => {
+  it('should apply primary variant class', async () => {
     const el = await fixture<NveSwitch>(html`<nve-switch variant="primary"></nve-switch>`);
     const label = el.shadowRoot?.querySelector('label[part="base"]');
     expect(el.variant).toBe('primary');
     expect(label?.classList.contains('switch--primary')).toBe(true);
   });
 
-  it('applies disabled class', async () => {
+  it('should apply disabled class', async () => {
     const el = await fixture<NveSwitch>(html`<nve-switch disabled></nve-switch>`);
     const label = el.shadowRoot?.querySelector('label[part="base"]');
     expect(el.disabled).toBe(true);
     expect(label?.classList.contains('switch--disabled')).toBe(true);
   });
 
-  it('has end as default label position', async () => {
+  it('should have end as default label position', async () => {
     const el = await fixture<NveSwitch>(html`<nve-switch></nve-switch>`);
     const label = el.shadowRoot?.querySelector('label[part="base"]');
     expect(el.labelPosition).toBe('end');
     expect(label?.classList.contains('switch--label-start')).toBe(false);
   });
 
-  it('applies switch--label-start class when label-position="start"', async () => {
+  it('should apply switch--label-start class when label-position="start"', async () => {
     const el = await fixture<NveSwitch>(html`<nve-switch label-position="start"></nve-switch>`);
     const label = el.shadowRoot?.querySelector('label[part="base"]');
     expect(el.labelPosition).toBe('start');

--- a/src/components/nve-switch/nve-switch.test.ts
+++ b/src/components/nve-switch/nve-switch.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { fixture, fixtureCleanup } from '@open-wc/testing';
+import { html } from 'lit';
+import NveSwitch from './nve-switch.component';
+
+if (!customElements.get('nve-switch')) {
+  customElements.define('nve-switch', NveSwitch);
+}
+
+describe('nve-switch', () => {
+  afterAll(() => {
+    fixtureCleanup();
+  });
+
+  it('has default as default variant', async () => {
+    const el = await fixture<NveSwitch>(html`<nve-switch></nve-switch>`);
+    expect(el.variant).toBe('default');
+    const label = el.shadowRoot?.querySelector('label[part="base"]');
+    expect(label?.classList.contains('switch--default')).toBe(true);
+  });
+
+  it('applies primary variant class', async () => {
+    const el = await fixture<NveSwitch>(html`<nve-switch variant="primary"></nve-switch>`);
+    const label = el.shadowRoot?.querySelector('label[part="base"]');
+    expect(el.variant).toBe('primary');
+    expect(label?.classList.contains('switch--primary')).toBe(true);
+  });
+
+  it('applies disabled class', async () => {
+    const el = await fixture<NveSwitch>(html`<nve-switch disabled></nve-switch>`);
+    const label = el.shadowRoot?.querySelector('label[part="base"]');
+    expect(el.disabled).toBe(true);
+    expect(label?.classList.contains('switch--disabled')).toBe(true);
+  });
+
+  it('has end as default label position', async () => {
+    const el = await fixture<NveSwitch>(html`<nve-switch></nve-switch>`);
+    const label = el.shadowRoot?.querySelector('label[part="base"]');
+    expect(el.labelPosition).toBe('end');
+    expect(label?.classList.contains('switch--label-start')).toBe(false);
+  });
+
+  it('applies switch--label-start class when label-position="start"', async () => {
+    const el = await fixture<NveSwitch>(html`<nve-switch label-position="start"></nve-switch>`);
+    const label = el.shadowRoot?.querySelector('label[part="base"]');
+    expect(el.labelPosition).toBe('start');
+    expect(label?.classList.contains('switch--label-start')).toBe(true);
+  });
+});


### PR DESCRIPTION
I denne pull requesten har jeg fjernet muligheten for at man kan sette farger selv og lagt til muligheten for å endre siden label er på. Cssproperty har blitt byttet ut med varianter hvor "default"  er lik som den var før og primary (blå,ny) har blitt lagt til. De som har valgt å bruke css property som har blitt fjernet kommer til å få "default color". Muligheten for å sette farger ble fjernet for å hindre variasjoner i bruken av nve-switch.

Hvis vi eventuelt skal utvide denne kan man lett legge til en ny farge ved å legge til litt css og en ny "variant".

**Label** går det nå ann å endre hvilken side den er på ved hjelp av label-position="start || end" hvor end er default (som før) 
