### PR TITLE
fix(nve-combobox): fjernet ekstra icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 *.tgz
 doc-site/.vitepress/cache
 doc-site/.vitepress/dist
+.idea/

--- a/src/components/nve-combobox/nve-combobox.component.ts
+++ b/src/components/nve-combobox/nve-combobox.component.ts
@@ -704,12 +704,7 @@ export default class NveCombobox extends LitElement implements INveComponent {
                       ?disabled=${this.shouldDisplayOptionAsDisabled(option)}
                       .selected="${option.selected}"
                     >
-                      ${option.selected
-                        ? html`
-                            ${this.addHighlightingToSearchResult(option.label)}
-                            <nve-icon slot="prefix" name="check" style="font-size: 1.5rem;"></nve-icon>
-                          `
-                        : this.addHighlightingToSearchResult(option.label)}
+                        ${this.addHighlightingToSearchResult(option.label)}
                     </nve-option>
                   `
                 )
@@ -727,12 +722,7 @@ export default class NveCombobox extends LitElement implements INveComponent {
                     ?disabled=${this.shouldDisplayOptionAsDisabled(option)}
                     .selected="${option.selected}"
                   >
-                    ${option.selected
-                      ? html`
-                          ${option.label}
-                          <nve-icon slot="prefix" name="check" style="font-size: 1.5rem;"></nve-icon>
-                        `
-                      : option.label}
+                      ${option.label}
                   </nve-option>
                 `
               )


### PR DESCRIPTION
(ny pr)
Så at comboboxen hadde fått et ekstra ikon på søketreff. Går utafra at dette kan ha skjedd i forbindelse med en oppdatering (nve-option).

Fikset ved å benytte nve-option sitt checked ikon (samme bare mindre).

Bestemte at dette var best så nve-select og nve-combobox ser likere ut. Hvis vi ønsker en større størrelse på ikon kan denne endringen sikkert gjøres i nve-option.