### PR TITLE
docs(bacstage): fikset skrivefeil i spesifikasjon 

### DIFF
--- a/docs/catalog-info.yaml
+++ b/docs/catalog-info.yaml
@@ -30,4 +30,4 @@ spec:
   lifecycle: production
   owner: nve
   dependsOn:
-    - component: nve-designsystem
+    - component:nve-designsystem


### PR DESCRIPTION
Forsøk på å fikse denne feilmeldinga i Backstage:

2025-09-29T11:07:45.105534120Z  2025-09-29T11:07:45.105Z catalog warn Processor BuiltinKindsEntityProcessor threw an error while validating the entity component:default/nve-vue-components; caused by TypeError: /spec/dependsOn/0 must be string - type: string entity=component:default/nve-vue-components location=url:https://github.com/NVE/Designsystem/tree/main/docs/catalog-info.yaml