### PR TITLE
fix(nve-link-card): fikse a styling

### DIFF
--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -11,11 +11,16 @@ export default css`
     align-items: center;
     cursor: pointer;
     text-decoration: none;
+  }
+
+  /*bruker color på a, ikke på link-card fordi link-card overskriver standard lenke farge i remmeverker som next js som har sin egen
+  wrappar rundt lenke og som støtter :visited*/
+  a {
     color: var(--neutrals-foreground-primary, #0d0d0e);
   }
 
   .link-card--visited,
-  .link-card:visited {
+  .a:visited {
     color: var(--interactive-links-visited);
   }
 
@@ -46,7 +51,6 @@ export default css`
 
   .link-card__label {
     font-size: 1rem;
-    color: inherit;
     font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;


### PR DESCRIPTION
Her setter jeg font farge på a ikke i link-card css-klassen.
Grunnen til det er at link-card overskriver fargene på a hvis f.eks en app har sin egen <Link /> komponent som støtter <a>-psuedoklasser som :visited. Vi har opplevd dette i next.js applikasjon. Dette løser problemet.