### PR TITLE
fix(nve-link-card): flytter global a style til

### DIFF
--- a/doc-site/.vitepress/theme/style.css
+++ b/doc-site/.vitepress/theme/style.css
@@ -130,6 +130,10 @@
   --docsearch-primary-color: var(--vp-c-brand-1) !important;
 }
 
+.vp-doc a {
+  text-decoration: unset;
+}
+
 .vp-doc div[class*='language-'] {
   margin: 0;
   border-top-left-radius: 0px;
@@ -207,4 +211,18 @@ html.nve_darkmode nve-tab-group::part(button-backward-base),
 html.varsom_darkmode nve-tab-group::part(button-forward-base),
 html.varsom_darkmode nve-tab-group::part(button-backward-base) {
   --scroll-button-background: #1b1b1f;
+}
+
+a {
+  color: var(--neutrals-foreground-primary, #0d0d0e);
+}
+
+/* Brukes for å fjerne standard linje i <a> hvis man skal wrappe nve-link-card med routerLink component i SPA*/
+a:has(nve-link-card) {
+  text-decoration: unset;
+}
+
+/* Brukes for å overskrive standard lenke visited styling fra eksterne rammeverker. */
+a:visited {
+  color: var(--interactive-links-visited);
 }

--- a/doc-site/components/nve-link-card.md
+++ b/doc-site/components/nve-link-card.md
@@ -138,9 +138,54 @@ Se anbefalinger for e-postlenker i seksjonen [Tilgjengelighet](#tilgjengelighet)
 
 Når man benytter klientside-routing, for eksempel med `routerLink`, genereres et eget `<a>`-element av rammeverket. I disse tilfellene blir `nve-link-card` pakket inn i en `<a>`. For å unngå ugyldig HTML-struktur med `<a>`-elementer inni hverandre, sjekker `nve-link-card` derfor om dets direkte forelder er et `<a>`. Hvis dette er tilfelle, rendres kortet som et `<div>` i stedet for et `<a>`.
 
-På denne måten beholdes mest funksjonalitet og styling fra `nve-link-card`, samtidig som man unngår semantiske og tekniske problemer med nestede lenker. Eneste som mangler er style på besøket lenker. For det kan du benytte bolsk `visited`- egenskap i `nve-link-card`. Man må skrive en egen logikk for å sjekke hvilke lenker var allerede besøket i SPA-router.
+SKRIV HER AT NOEN RAMMEVERKER STØTTER VISITED!!! ser ut at next js og vue støtter det i spa applikasjoner. verdt å teste i safari tenker jeg
 
-Les mer i seksjonen [Tilgjengelighet](#tilgjengelighet).
+På denne måten beholdes mest funksjonalitet og styling fra `nve-link-card`, samtidig som man unngår semantiske og tekniske problemer med nestede lenker.
+
+Bruk av nve-link-card i Vue:
+
+```vue
+<RouterLink to="components/Komponentoversikt">
+  <nve-link-card
+    label="Gå til komponentoversikt"
+    variant="contrast"
+    clickAction="internal"
+  >
+  </nve-link-card>
+</RouterLink>
+```
+
+Bruk av nve-link-card i React:
+
+```jsx
+<Link to="/components/Komponentoversikt">
+  <nve-link-card
+    label="Gå til komponentoversikt"
+    variant="contrast"
+    clickAction="internal"
+  >
+</Link>
+```
+
+## Besøkt lenke
+
+I henhold til krav for universell utforming skal besøkte lenker ha `besøkt`-tilstand. De fleste nettlesere håndterer dette automatisk ved å bruke CSS-pseudoklassen `:visited` på lenker som er besøkt. Vi definerer egen styling for besøkte lenker i `global.css`, som hentes inn via tema-filer (for eksempel `varsom.css` eller `nve.css`) som bruker denne pseudoklassen.
+
+Ved bruk av lenkekomponenter fra JS-rammeverk, kan det i enkelte tilfeller forekomme at `:visited`-tilstanden ikke fungerer som forventet i noen nettlesere. Dersom du opplever dette, kan du aktivere `visited`-egenskapen på `nve-link-card` når den er pakket inn i en rammeverkslenke. ( Denne egenskapen har ingen effekt dersom `nve-link-card` brukes som en selvstendig lenke, ettersom den da støtter `:visited`-tilstanden direkte gjennom nettleseren.).
+
+For å bruke `visited`-egenskapen må du selv håndtere logikken for besøkte lenker — for eksempel ved å lagre besøkte URL-er i lokal lagring (localStorage).
+
+Dette er likevel en sjelden problemstilling. Lenkekomponentene i Vue, React og Next.js støtter `:visited` som forventet, og du trenger som regel ikke gjøre noe spesielt. Bruker du et annet rammeverk, anbefaler vi å teste om `:visited`-tilstanden settes korrekt i DevTools før du tar i bruk `visited`-egenskapen.
+
+<CodeExamplePreview>
+
+```html
+<a class="rammeverk-sin-lenke-komponent" href="/components/Komponentoversikt">
+  <nve-link-card label="Gå til komponentoversikt" variant="contrast" clickAction="internal" visited> </nve-link-card>
+</a>
+```
+
+</CodeExamplePreview>
 
 ## Tilgjengelighet
 

--- a/public/css/global.css
+++ b/public/css/global.css
@@ -51,9 +51,19 @@
   --sl-input-letter-spacing: var(--sl-letter-spacing-normal);
 }
 
-/* Brukes for å fjerne standard linje i <a> hvis man skal wrappe nve-link-card med routerLink component i SPA*/
+/* Brukes på lenkene som ikke er i Shadow-DOMen som f.eks de som skal wrappe <nve-link-card> */
+a {
+  color: var(--neutrals-foreground-primary, #0d0d0e);
+}
+
+/* Brukes for å fjerne standard linje i <a>  som ikke er i Shadow-DOMen som f.eks de som skal wrappe <nve-link-card> */
 a:has(nve-link-card) {
   text-decoration: unset;
+}
+
+/* Brukes for å overskrive standard lenke visited styling som ikke er i Shadow-DOMen som f.eks de som skal wrappe <nve-link-card> */
+a:visited {
+  color: var(--interactive-links-visited);
 }
 
 /* Brukes i nve-alert for å vise toast*/

--- a/src/components/nve-link-card/nve-link-card.styles.ts
+++ b/src/components/nve-link-card/nve-link-card.styles.ts
@@ -20,7 +20,7 @@ export default css`
   }
 
   .link-card--visited,
-  .a:visited {
+  a:visited {
     color: var(--interactive-links-visited);
   }
 
@@ -87,7 +87,7 @@ export default css`
   }
 
   .link-card--visited .link-card__additional-text,
-  .link-card:visited .link-card__additional-text {
+  a:visited .link-card__additional-text {
     color: var(--interactive-links-visited);
   }
 


### PR DESCRIPTION
Her legger jeg til en a styling i global.css. Det er for å sørge at lenkene som brukes i rammeverker (som wrapper nve-link-card blant annet) har riktig styling. Man kan fortsatt style a-taggene selv hvis man vil overskrive den, men jeg tror det er greit å ha lik, global styling på det. 

Har også oppdatert docs sidene om nve-link-card