### PR TITLE
fix(nve-message-card): label-tekst kan nå gå over flere linjer 

### DIFF
--- a/src/components/nve-message-card/nve-message-card.styles.ts
+++ b/src/components/nve-message-card/nve-message-card.styles.ts
@@ -44,11 +44,6 @@ export default css`
     padding: 2px 0;
     font: var(--header-small);
     line-height: 140%;
-    :is(span) {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
   }
 
   .message-card__body {


### PR DESCRIPTION
For å kunne se hele teksten om den er lenger enn bredden på kortet.

https://github.com/NVE/Designsystem/issues/653
