### PR TITLE
fix(tokens): kjøre tokenbuild script på en PR oppretting

### DIFF
--- a/.github/workflows/build-css-tokens.yml
+++ b/.github/workflows/build-css-tokens.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'tokens/**'
 
+permissions:
+  contents: write
+
 jobs:
   build_tokens:
     runs-on: ubuntu-latest
@@ -24,3 +27,10 @@ jobs:
 
       - name: Bygg tokens
         run: npm run tokenbuild
+      - name: Commit and push changes
+              run: |
+                git config --global user.name "github-actions[bot]"
+                git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                git add .
+                git diff --cached --quiet || git commit -m "(tokens): oppdatert css basert på nye tokens"
+                git push


### PR DESCRIPTION
tokenbuild skal nå kjøre når tokens-mappen blir oppdatert og en PR opprettes. Slik slipper vi å kjøre tokenbuild lokalt. Designere kan bare oppdatere tokene, opprette en PR på git, og så skal scriptet lage css filer. Den må testes etter merging.