### PR TITLE
fix(fonter): Fjernet offline-fonter og bruk av disse

### DIFF
--- a/public/css/global.css
+++ b/public/css/global.css
@@ -1,4 +1,8 @@
 @import '../../dist/nve-designsystem.css';
+
+/* Hvis du ikke vil at applikasjonen henter fonter fra nettet under kjøring, kan du laste dem ned på forhånd og legge dem i prosjektet ditt.
+   Bytt ut linja under med @font-face for hver av fontene som du laster lokalt. 
+   Designsystemet bruker Source Sans Pro med font-vekt 400 og 600*/
 @import url('https://fonts.cdnfonts.com/css/source-sans-pro');
 
 :root {


### PR DESCRIPTION
Denne commiten er kun for å tvinge publisering av  en ny versjon, fordi fiksen som fjernet fontene ikke fulgte conventional commit-standarden, så release-bygget feilet.
For å trigge release-bygget må jeg ha med en endring i /src eller /public/css, så da la jeg inn en kommentar i public.css om offline-håndtering av fonter.