### PR TITLE
docs(nve-icon): Forbedret dokumentasjon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,22 @@ Kommentaren `/* Label/small */` betyr at vi skal bruke css-variabelen `--label-s
 }
 ```
 
-### Mapping av shoelace-tokens til NVE-tokens
+## Offline-støtte for ikoner
+
+For at designsystemet skal funke offline i f.eks. hybrid-applikasjoner, kan ikke NVE-komponentene laste ned ikoner eller skrifttyper fra nettet under kjøring.
+Derfor må ikoner og skrifttyper som designsystemet bruker internt være lastet ned på forhånd.
+
+Vi bruker `<nve-icon name="..."` for å vise et ikon fra Material Symbols. Dette bruker vi også internt i komponentene for å vise "innebygde" ikoner, men slike ikoner lastes fra [offline-icons.ts](\src\components\nve-icon\offline-icons.ts).
+
+`<nve-icon>` sjekker automatisk om ikonet finnes lokalt før den prøver å hente det fra nettet.
+
+Når du tar i bruk nye ikoner, pass på at de finnes i [offline-icons.ts](\src\components\nve-icon\offline-icons.ts).
+
+### Offline-skrifttyper
+
+Skrifttyper henter vi fortsatt fra nettet. Men du kan inkludere skrifttypene designsystemet trenger i ditt eget prosjekt, så vil det funke offline.
+
+## Mapping av shoelace-tokens til NVE-tokens
 
 Det hadde vært fint om vi kunne sette en NVE-verdi for alle Shoelace-tokens. Men dette går ikke fordi strukturen i Shoelace og NVE Designsystem er forskjellig.
 Vi har satt NVE-verdier for en del Shoelace-tokens, og disse ligger i `global.css`.

--- a/doc-site/components/nve-icon.md
+++ b/doc-site/components/nve-icon.md
@@ -10,34 +10,33 @@ layout: component
 
 </CodeExamplePreview>
 
-Her er [oversikt over ikoner i Material Symbols](https://fonts.google.com/icons).
+Her er [oversikt over ikoner i Material Symbols](https://fonts.google.com/icons?icon.style=Sharp).
 
 ## Eksempler
 
 ### Størrelse
 
-For å endre størrelsen, bruk `--icon-size` css custom property.
+24px er standard. For å endre størrelse, bruk `--icon-size` css custom property.
 
-Man kan fortsatt bruke bare `font-size` css property (se siste eksempel), men man må huske å endre `line-height` også så at den stemmer med valgte `font-size`.
+`font-size` i kombinasjon med `line-height` kan også brukes. Begge må være like.
 
-24px er standard.
 <CodeExamplePreview>
 
 ```html
-<nve-icon name="Rocket" style="--icon-size: 20px;"></nve-icon>
+<nve-icon name="Rocket" style="--icon-size: 20px;"></nve-icon>20px
 
-<nve-icon name="Rocket"></nve-icon>
+<nve-icon name="Rocket"></nve-icon> 24px (standard størrelse)
 
-<nve-icon name="Rocket" style="--icon-size: 28px;"></nve-icon>
+<nve-icon name="Rocket" style="--icon-size: 28px;"></nve-icon> 28px med bruk av --icon-size
 
-<nve-icon name="Rocket" style="font-size: 28px; line-height: 28px;"></nve-icon>
+<nve-icon name="Rocket" style="font-size: 28px; line-height: 28px;"></nve-icon>28px med bruk av font-size og line-height
 ```
 
 </CodeExamplePreview>
 
 ### Skarpe eller mye kanter
 
-Bruk `library="Outlined"` for myke kanter. `Sharp` er standard. `Outlined` skal kun brukes hvis symbolet blir lettere å lese.
+Bruk `library="Outlined"` for myke kanter. `Sharp` er standard. `Outlined` skal kun brukes hvis symbolet blir lettere å lese. `Fill` skal ikke brukes.
 <CodeExamplePreview>
 
 ```html
@@ -46,7 +45,7 @@ Bruk `library="Outlined"` for myke kanter. `Sharp` er standard. `Outlined` skal 
 
 </CodeExamplePreview>
 
-### Offline støtte / Bruke ikoner direkte fra eget repo
+### Offline-støtte / Bruke ikoner direkte fra eget repo
 
 Hvis du bruker `name`, lastes ikonet med aktuelt navn fra Material Symbols når komponenten blir registrert første gang. Dette funker ikke offline. Men med `src`, kan du bruke ikoner som er lagret i eget repo.
 
@@ -62,8 +61,14 @@ det er mulig.
 <CodeExamplePreview>
 
 ```html
-<nve-icon src="/assets/home-icon.svg" alt="hjem"></nve-icon>
-<nve-icon src="/assets/home-icon.svg" alt="hjem" style="--icon-size:24px"></nve-icon>
+<nve-icon src="/assets/home-icon.svg" alt="hjemme"></nve-icon>
+<nve-icon src="/assets/home-icon.svg" alt="hytta" style="--icon-size:20px"></nve-icon>
 ```
 
 </CodeExamplePreview>
+
+#### Offline-støtte internt (kun relevant for utviklere av designsystemet)
+
+Noen av designsystem-komponentene viser også ikoner som en del av komponenten. Et eksempel er `nve-message-card`:
+<nve-message-card size="simple" label="Info-ikonet i dette kortet blir ikke lastet fra Material Symbols"/>
+Siden designsystemet skal kunne brukes også i applikasjoner uten nett, har vi kopiert de få ikonene vi trenger fra Material Symbols inn i designsystemet. Det står mer om hvordan du gjør dette i [CONTRIBUTING.md](https://github.com/NVE/Designsystem/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Se saken (resolves #479)
Er helt enig med Lisas forslag. Derfor har jeg bare oppdatert dokumentasjonssida for `nve-icon`.
Jeg tror vi nå dekker [alt som står i Figma](https://www.figma.com/design/JA9IXcmhPvQIgdsFPr4ysB/03---Ikoner?node-id=155-641&t=RNx6AUmzxBtJlOTF-0), som er relevant for utviklere.

La til et lite avsnitt helt nederst om at vi har egen løsning for offline-støtte internt i designsystemet. Ikke relevant for de som kun bruker designsystemet, men er litt redd for at folk vil glemme å ta kopi av svg fra Material Symbols når de innfører nye ikoner.
 
Har også tatt inn dok på offline, som ble utelatt når vi flytta mye tekst fra readme til contributing (#678). Tipper det gikk tapt i flettinga til main fordi jeg hadde lagt inn mer info i readme (#684) etter at malin startet på sin branch.