### PR TITLE
docs(design-beslutninger): oppdatert valg angående å ikke lage felleskomponent for filopplasting

### DIFF
--- a/design-beslutninger.md
+++ b/design-beslutninger.md
@@ -65,3 +65,16 @@ TODO: Skriv hvorfor vi valgte dette
 ## Eget designsystem eller ikke? (når bestemte vi dette?)
 
 TODO: Skriv hvorfor vi valgte dette
+
+## Felleskomponent for filopplasting
+
+Vi valgte å ikke lage en felles filopplasting-komponent i designsystemet på grunn av kompleksiteten og de forskjellige behovene teamene har.
+
+En slik komponent ville hovedsakelig være en wrapper rundt en input med `type="file"`. Utfordringen ligger ikke i selve UI-en, men i all logikken som må håndteres etter at filer er valgt:
+
+- Validering (filtype, størrelse, antall filer)
+- Opplasting til forskjellige endepunkter
+- Progresjonsvisning og feilhåndtering
+- Forskjellige krav til metadata og beskrivelser
+
+Siden hver applikasjon og team har unike krav til disse aspektene, bestemte vi at teamene selv implementerer filopplasting-funksjonaliteten tilpasset sine behov, fremfor å lage en generisk komponent som ville blitt for kompleks eller for begrenset. Designet skal likevel være likt på tvers av applikasjonene.


### PR DESCRIPTION
Jeg ryddet litt i issuesene med `wontfix` og fjernet ting som ikke skal utvikles. 

Jeg slettet issues angående felleskomponentifisering av file-upload, og dokumenterte heller hvorfor vi ikke valgte dette under `design-beslutninger.md`.