### PR TITLE
fix(css): Juster på plassering av font-import i global.css for å sikre riktig nedlasting av Source Sans Pro fontene

### DIFF
--- a/public/css/global.css
+++ b/public/css/global.css
@@ -1,9 +1,9 @@
+@import '../../dist/nve-designsystem.css';
+
 @import url('https://fonts.cdnfonts.com/css/source-sans-pro');
 /* Hvis du ikke vil at applikasjonen henter fonter fra nettet under kjøring, kan du laste dem ned på forhånd og legge dem i prosjektet ditt.
    Bytt ut linja under med @font-face for hver av fontene som du laster lokalt. 
    Designsystemet bruker Source Sans Pro med font-vekt 400 og 600*/
-
-@import '../../dist/nve-designsystem.css';
 
 :root {
   --transition-time: 0.3s;


### PR DESCRIPTION
**Hva er endret**: 
Flytter kommentaren knyttet til `@import url('https://fonts.cdnfonts.com/css/source-sans-pro');` i `global.css` slik at den ligger **under** import-linjen i stedet for over.

**Årsak til endring**:
Etter at kommentaren ble introdusert i denne [PR-en](https://github.com/NVE/Designsystem/pull/688/files), klarte ikke Next.js sin CSS-bygger lenger å håndtere `@import`-regelen riktig. 

Tidligere ble `@import` automatisk flyttet til toppen av den bygde CSS-filen, men når kommentaren lå over importen, virker det som bygget tolket det som at `@import` ikke lenger var en topp-nivå regel. Dermed endte importen ett sted midt i den bundla CSS-filen, noe som førte til:

- `@import` havnet ikke øverst i output
- kallet til `https://fonts.cdnfonts.com/css/source-sans-pro` ble ikke utført
- fontene ble derfor ikke lastet inn

Ved å flytte kommentaren under importen fungerer Next.js sin CSS-behandling igjen, og font-importen lastes korrekt. Har testet dette med lokalt bygg/pack av DS, og referert til den fra Nextjs-prosjektet og bygd på nytt der. Da lastes fontene som før og `@import` kommer øverst i bygd CSS-fil.