### PR TITLE
fix(pipelines): fjerne branch oppdatering etter release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -12,17 +12,6 @@
       {
         "npmPublish": false
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "package.json",
-          "package-lock.json",
-          "CHANGELOG.md"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
     ]
   ]
 }


### PR DESCRIPTION
Dette blir innført fordi vi lagde nye regler i branchen at man ikke kan pushe til main. Det hjelper ikke å sette release bot som unntak. Det er også verdt å nevne at selve semantic release anbefaler ikke at github action oppdaterer package.json med ny versjon selv. 