### PR TITLE
feat: Fjernet global import av skrifttyper

### DIFF
--- a/doc-site/.vitepress/theme/style.css
+++ b/doc-site/.vitepress/theme/style.css
@@ -43,6 +43,9 @@
  *   in custom container, badges, etc.
  * -------------------------------------------------------------------------- */
 
+/* Skrifttyper som designsystemet bruker */
+@import url('https://fonts.cdnfonts.com/css/source-sans-pro');
+
 :root {
   --vp-c-default-1: var(--vp-c-gray-1);
   --vp-c-default-2: var(--vp-c-gray-2);

--- a/doc-site/introduction/forDevelopers/import.md
+++ b/doc-site/introduction/forDevelopers/import.md
@@ -33,6 +33,57 @@ import 'nve-designsystem/css/varsom.css';
 
 Det finnes også varianter av disse to filene med mørkt tema.
 
+## Import av skrifttyper
+
+Designsystemet bruker skrifttypen Source Sans Pro med font-vekt 400 og 600.
+Den enkleste måten å importere skrifttyper på er å hente dem direkte fra cdnfonts.com, ved å legge dette i en global css-fil:
+
+```css
+@import url('https://fonts.cdnfonts.com/css/source-sans-pro');
+```
+
+Et alternativ som gir raskere oppstart er å importere skrifttypene i HTML med `<link rel="preload" as="font" ...>`, men da må du spesifisere hver font-fil for seg.
+
+Du kan også laste ned og distribuere skrifttypene sammen med applikasjonen din. Dette gir færre avhengigheter til eksterne kilder og kan gi enda raskere oppstartstid. Du får også offline-støtte.
+Slik kan du inkludere skrifttyper distribuert med applikasjonen (sjekk at du bruker samme sti og navn på filene):
+
+```css
+@font-face {
+  font-family: 'Source Sans Pro';
+  src:
+    local('Source Sans Pro'),
+    url('/fonts/source-sans-3-latin-400-normal.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'Source Sans Pro';
+  src:
+    local('Source Sans Pro'),
+    url('/fonts/source-sans-3-latin-400-italic.woff2') format('woff2');
+  font-weight: 400;
+  font-style: italic;
+}
+@font-face {
+  font-family: 'Source Sans Pro';
+  src:
+    local('Source Sans Pro'),
+    url('/fonts/source-sans-3-latin-600-normal.woff2') format('woff2');
+  font-weight: 600;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'Source Sans Pro';
+  src:
+    local('Source Sans Pro'),
+    url('/fonts/source-sans-3-latin-600-italic.woff2') format('woff2');
+  font-weight: 600;
+  font-style: italic;
+}
+```
+
+[Her](/introduction/designelementer/typography.html) er mer info om skrifttypene som brukes i Designsystemet.
+
 ## Import via CDN
 
 Både stiler og komponenter kan importeres via CDN.

--- a/public/css/global.css
+++ b/public/css/global.css
@@ -1,10 +1,5 @@
 @import '../../dist/nve-designsystem.css';
 
-@import url('https://fonts.cdnfonts.com/css/source-sans-pro');
-/* Hvis du ikke vil at applikasjonen henter fonter fra nettet under kjøring, kan du laste dem ned på forhånd og legge dem i prosjektet ditt.
-   Bytt ut linja under med @font-face for hver av fontene som du laster lokalt. 
-   Designsystemet bruker Source Sans Pro med font-vekt 400 og 600*/
-
 :root {
   --transition-time: 0.3s;
 


### PR DESCRIPTION
Fixes #698.
Vet saken er merket med "må diskuteres", så ta gjerne dette som et innspill til diskusjonen:)
Det beste hadde kanskje vært om designsystemet kunne distribueres med font-filene designsystemet trenger. Jeg har tidligere gjort et forsøk på dette uten å lykkes. Se #684, som senere ble rullet tilbake fordi @tomapedersen fikk problemer med noen av applikasjonene de forvalter.

Denne PR'en er en enkel fiks som gjør at vi slipper advarsler og unødvendige kall til cdnfonts.com i offline-applikasjoner. 
Har fjernet denne fra global.css:
```css
@import url('https://fonts.cdnfonts.com/css/source-sans-pro');
```
Dette gjør at alle som bruker designsystemet fra nå av må laste skrifttyper selv i sine applikasjoner. 
Har beskrevet dette i sida ["Importering av filer" under "For utviklere"](https://brave-meadow-0c645bd03-743.westeurope.5.azurestaticapps.net/introduction/forDevelopers/import.html#import-av-skrifttyper).

- [ ] Dette er en BREAKING CHANGE. Jeg prøvde å ta med "BREAKING CHANGE" i PR-tittelen, men det likte ikke byggesystemet, så tar gjerne imot tips om hvordan vi får endret hoved-versjon automatisk.
