### PR TITLE
fix(nve-warning-level): bruke riktig token navn på rammen rundt farenivå

### DIFF
--- a/src/components/nve-warning-level/nve-warning-level.styles.ts
+++ b/src/components/nve-warning-level/nve-warning-level.styles.ts
@@ -85,7 +85,7 @@ export default css`
   }
 
   .border {
-    border: var(--border-width) solid var(--color-Sdangerlevel-foreground-default-level1);
+    border: var(--border-width) solid var(--color-dangerlevel-foreground-default-level1);
   }
 
   .warning-level-badge {


### PR DESCRIPTION
Fikse manglende ramme rundt farenivå komponenten. 