### PR TITLE
feat(typography): Initielt oppsett av nve-heading og nve-paragraph

### DIFF
--- a/doc-site/components/nve-heading.md
+++ b/doc-site/components/nve-heading.md
@@ -1,0 +1,120 @@
+---
+layout: component
+---
+
+<CodeExamplePreview>
+
+```html
+<nve-heading level="1" size="headingLarge">Dette er en overskrift</nve-heading>
+```
+
+</CodeExamplePreview>
+
+## Eksempler
+
+Eksemplene viser hvordan du kan bruke heading-komponenten med ulike typografivarianter og nivåer for å tilpasse overskrifter til innholdet.
+
+### Heading-varianter
+
+Disse variantene gir deg de ulike typografistilene for hovedoverskrifter, og kan brukes på alle heading-nivåer etter behov.
+
+<CodeExamplePreview>
+
+```html
+<nve-heading level="1" size="headingXlarge">Dette er en h1 med heading-xlarge</nve-heading>
+<nve-heading level="2" size="headingLarge">Dette er en h2 med heading-large</nve-heading>
+<nve-heading level="3" size="headingMedium">Dette er en h3 med heading-medium</nve-heading>
+<nve-heading level="4" size="headingSmall">Dette er en h4 med heading-small</nve-heading>
+<nve-heading level="5" size="headingXsmall">Dette er en h5 med heading-xsmall</nve-heading>
+```
+
+</CodeExamplePreview>
+
+### Subheading-varianter
+
+Subheading-variantene gir undertitler med egne typografistiler, og brukes gjerne for å dele opp innhold under hovedoverskrifter.
+
+<CodeExamplePreview>
+
+```html
+<nve-heading level="2" size="subheadingLarge">Dette er en h2 med subheading-large</nve-heading>
+<nve-heading level="3" size="subheadingMedium">Dette er en h3 med subheading-medium</nve-heading>
+<nve-heading level="4" size="subheadingSmall">Dette er en h4 med subheading-small</nve-heading>
+```
+
+</CodeExamplePreview>
+
+### Default stil
+
+Når du ikke spesifiserer en variant, får heading-komponenten automatisk riktig typografi basert på valgt heading-nivå (`level`). Typografien følger designsystemets standard for h1–h6.
+
+<CodeExamplePreview>
+
+```html
+<nve-heading level="1">Heading h1</nve-heading>
+<nve-heading level="2">Heading h2</nve-heading>
+<nve-heading level="3">Heading h3</nve-heading>
+<nve-heading level="4">Heading h4</nve-heading>
+<nve-heading level="5">Heading h5</nve-heading>
+```
+
+</CodeExamplePreview>
+
+## Retningslinjer
+
+Heading brukes til å skape struktur og hierarki i innholdet. Bruk overskrifter for å dele opp innholdet i logiske seksjoner. Pass på at du bruker riktige overskriftsnivåer (h1-h6) for å sikre god semantisk struktur.
+
+### Mobilskalering
+
+Komponenten skalerer automatisk overskrifter på ulike skjermstørrelser. Dette sikrer god lesbarhet og tilgjengelighet på mobil og små skjermer.
+
+### Stil og fleksibilitet
+
+Alle overskriftsnivåer har en standard stil som passer i de fleste kontekster. Du kan velge stil og størrelse for hvert nivå etter behov og design, noe som gir fleksibilitet til å tilpasse typografien til ulike seksjoner og innholdstyper.
+
+Se mer detaljer om typografi og heading-hierarki i [introduksjonen til designsystemet](introduction/designelementer/typography.html).
+
+### Hierarki
+
+Komponenten bruker prop `level` for å sikre riktig heading-hierarki. Start alltid med `level="1"` (h1) for hovedtittel, deretter `level="2"` (h2) for mellomtitler og `level="3"` (h3) for underordnede titler. `Level="4"` og lavere kan brukes for ytterligere inndeling.
+
+Det er viktig å ikke hoppe over nivåer, for eksempel h2 til h4. En side skal aldri ha mer enn én h1. Riktig hierarki gir bedre tilgjengelighet, struktur og SEO, og sikrer konsistent navigasjon for brukere med hjelpemidler.
+
+#### Eksempel på artikkel
+
+<CodeExamplePreview>
+
+```html
+<nve-heading level="1" size="headingLarge">Energisparing i hjemmet</nve-heading>
+<nve-paragraph size="leadLargeRegular">
+  Ingress: Å spare energi er bra for både miljøet og lommeboken. Her får du tips til hvordan du kan redusere
+  strømforbruket hjemme.
+</nve-paragraph>
+
+<nve-heading level="2" size="headingMedium">Slik sparer du strøm</nve-heading>
+<nve-paragraph size="bodyLarge">
+  Bruk energieffektive lyspærer og slå av lys når du forlater rommet. Unngå å la elektronikk stå i standby-modus, og
+  trekk ut ladere når de ikke er i bruk.
+</nve-paragraph>
+
+<nve-heading level="3" size="headingSmall">Varmepumpe</nve-heading>
+<nve-paragraph size="bodyMedium">
+  En varmepumpe kan redusere oppvarmingskostnadene betydelig. Velg en modell som passer til boligens størrelse og klima.
+</nve-paragraph>
+
+<nve-heading level="3" size="headingSmall">Isolering</nve-heading>
+<nve-paragraph size="bodyMedium">
+  God isolering holder på varmen og gjør at du bruker mindre energi til oppvarming. Sjekk vinduer, dører og tak for
+  trekk.
+</nve-paragraph>
+```
+
+</CodeExamplePreview>
+
+## Tilgjengelighet
+
+Overskrifter bør brukes i riktig rekkefølge (h1–h6) for å skape en tydelig og forutsigbar struktur. Riktig hierarki gjør det enklere for brukere og hjelpemidler å navigere og forstå innholdet. Vær konsekvent på tvers av sider og seksjoner, slik at samme stil og semantikk brukes for samme overskriftsnivå.
+
+Bruk komponentens `level`-prop for korrekt HTML-tag (h1–h6). Teksten legges i slot for god tilgjengelighet.
+
+Husk at WCAG krever god fargekontrast. Det er ditt ansvar som designer eller utvikler å sikre at kontrasten oppfyller kravene.

--- a/doc-site/components/nve-heading.md
+++ b/doc-site/components/nve-heading.md
@@ -72,7 +72,7 @@ Komponenten skalerer automatisk overskrifter på ulike skjermstørrelser. Dette 
 
 Alle overskriftsnivåer har en standard stil som passer i de fleste kontekster. Du kan velge stil og størrelse for hvert nivå etter behov og design, noe som gir fleksibilitet til å tilpasse typografien til ulike seksjoner og innholdstyper.
 
-Se mer detaljer om typografi og heading-hierarki i [introduksjonen til designsystemet](introduction/designelementer/typography.html).
+Se mer detaljer om typografi og heading-hierarki i [introduksjonen til designsystemet](/introduction/designelementer/typography).
 
 ### Hierarki
 

--- a/doc-site/components/nve-paragraph.md
+++ b/doc-site/components/nve-paragraph.md
@@ -1,0 +1,110 @@
+---
+layout: component
+---
+
+<CodeExamplePreview>
+
+```html
+<nve-paragraph size="bodyLarge">Dette er et vanlig avsnitt</nve-paragraph>
+```
+
+</CodeExamplePreview>
+
+## Eksempler
+
+Eksemplene viser hvordan du kan bruke paragraph-komponenten med ulike typografivarianter for å tilpasse tekst til innhold og kontekst.
+
+### Lead-varianter
+
+Lead-varianter brukes typisk som ingress, altså et kortfattet sammendrag mellom heading og brødtekst.
+
+<CodeExamplePreview>
+
+```html
+<nve-paragraph size="leadLargeRegular">Lead Large Regular</nve-paragraph>
+<nve-paragraph size="leadMediumRegular">Lead Medium Regular</nve-paragraph>
+<nve-paragraph size="leadSmallRegular">Lead Small Regular</nve-paragraph>
+<nve-paragraph size="leadLargeSemibold">Lead Large Semibold</nve-paragraph>
+<nve-paragraph size="leadMediumSemibold">Lead Medium Semibold</nve-paragraph>
+<nve-paragraph size="leadSmallSemibold">Lead Small Semibold</nve-paragraph>
+```
+
+</CodeExamplePreview>
+
+### Body-varianter
+
+Body-varianter brukes til vanlig brødtekst i artikler, hjelpetekster og lignende.
+
+<CodeExamplePreview>
+
+```html
+<nve-paragraph size="bodyLarge">Body Large</nve-paragraph>
+<nve-paragraph size="bodyMedium">Body Medium</nve-paragraph>
+<nve-paragraph size="bodySmall">Body Small</nve-paragraph>
+<nve-paragraph size="bodyXSmall">Body XSmall</nve-paragraph>
+<nve-paragraph size="bodyLargeUnderline">Body Large Underline</nve-paragraph>
+<nve-paragraph size="bodyMediumUnderline">Body Medium Underline</nve-paragraph>
+<nve-paragraph size="bodySmallUnderline">Body Small Underline</nve-paragraph>
+<nve-paragraph size="bodyXSmallUnderline">Body XSmall Underline</nve-paragraph>
+```
+
+</CodeExamplePreview>
+
+### Body-compact-varianter
+
+Body-compact-varianter gir ekstra kompakt brødtekst, egnet for tabeller, lister eller områder med begrenset plass.
+
+<CodeExamplePreview>
+
+```html
+<nve-paragraph size="bodyLargeCompact">Body Compact Large</nve-paragraph>
+<nve-paragraph size="bodyMediumCompact">Body Compact Medium</nve-paragraph>
+<nve-paragraph size="bodySmallCompact">Body Compact Small</nve-paragraph>
+<nve-paragraph size="bodyXSmallCompact">Body Compact XSmall</nve-paragraph>
+<nve-paragraph size="bodyLargeUnderlineCompact">Body Compact Large Underline</nve-paragraph>
+<nve-paragraph size="bodyMediumUnderlineCompact">Body Compact Medium Underline</nve-paragraph>
+<nve-paragraph size="bodySmallUnderlineCompact">Body Compact Small Underline</nve-paragraph>
+<nve-paragraph size="bodyXSmallUnderlineCompact">Body Compact XSmall Underline</nve-paragraph>
+```
+
+</CodeExamplePreview>
+
+## Retningslinjer
+
+Paragraph brukes til å formidle løpende tekst, mengdetekst og ingress på en tydelig og strukturert måte. Del opp innholdet i avsnitt for å gjøre det lettere å lese og forstå.
+
+### Brukes til
+
+- Avsnitt i artikler
+- Mengdetekst
+- Ingress (lead-varianter)
+
+### Brukes ikke til
+
+- Inline tekst
+- Annen semantisk tekst: overskrift, liste, ledetekst, tabelltittel.
+
+### Varianter
+
+Det finnes stiler for brødtekst og ingress. Du velger selv hvilken stil (størrelse og vekt) du skal bruke: body-stiler for brødtekst og lead-stiler for ingress. "Medium" er standard størrelse for tekst. Bruk andre størrelser om teksten skal fremheves eller tones ned.
+
+### Hvilken stil?
+
+Navn på stilene kombinerer semantisk element (avsnitt eller ingress) og størrelse. Velg variant ut fra hvor teksten skal brukes og hvor mye oppmerksomhet den skal få.
+
+### Struktur og lesbarhet
+
+Hold avsnitt fokuserte og godt strukturerte, og del opp lange tekstblokker i mindre deler for å gjøre innholdet lettere å skanne og forstå. Sørg for at linjelengde og luft rundt teksten bidrar til god leseflyt.
+
+Brødtekst skal være tydelig, konsis og skrevet i klart språk. Start med det viktigste innholdet slik at brukerne raskt forstår sammenhengen. Hvert avsnitt bør handle om ett tema eller én idé av gangen.
+
+Lead brukes typisk som ingress, altså et kortfattet sammendrag mellom heading og brødtekst.
+
+## Tilgjengelighet
+
+- Paragraph-komponenten bruker `<p>`-tag for korrekt semantikk.
+- Teksten legges i slot, slik at den er tilgjengelig for skjermlesere.
+- Sørg for god fargekontrast mellom tekst og bakgrunn, i tråd med WCAG-krav. Det er ditt ansvar som designer eller utvikler å sikre at kontrasten oppfyller kravene.
+- Del opp lange tekstblokker for å gjøre innholdet lettere å lese og forstå for alle brukere.
+
+Se designsystemet for alle varianter og tokens.

--- a/doc-site/introduction/designelementer/typography.md
+++ b/doc-site/introduction/designelementer/typography.md
@@ -16,6 +16,15 @@ Source Sans Pro/3 er en «open-source» sans serif skrifttype, laget for å gi g
 
 Typografiske tokens brukes for å opprettholde en ensartet samling av fonter i hele utviklingsprosessen.
 
+#### Typografikomponenter
+
+Designsystemet tilbyr ferdige komponenter for typografi som gjør det enkelt å implementere riktig styling i dine applikasjoner:
+
+- **[nve-heading](/components/nve-heading)** – For overskrifter (h1-h6) med riktig semantikk og typografi
+- **[nve-paragraph](/components/nve-paragraph)** – For avsnitt med ulike typografivarianter (lead, body, body compact)
+
+Disse komponentene sikrer automatisk riktig bruk av typografi-tokens og semantisk HTML, samtidig som de gir fleksibilitet til å overstyre styling ved behov.
+
 #### Typografi i Figma
 
 Fonten heter Source Sans 3 i Figma, og er tilgjenglig uten at du trenger å laste ned eller installere fonten selv.
@@ -47,22 +56,31 @@ I Figma-skisser blir disse font-egenskapene typisk brukt på ulike tekststiler o
 
 ### Header
 
-Header typografi variabler skal vanligvis brukes på html heading-tagene som `<h1>`, `<h2>` osv.
+Header typografi kan brukes gjennom [nve-heading](/components/nve-heading#heading-varianter)-komponenten.
+
 <TypographyTable tableContentType="headings"></TypographyTable>
 
 ### Subheader
+
+Subheader typografi kan brukes gjennom [nve-heading](/components/nve-heading#subheading-varianter)-komponenten.
 
 <TypographyTable tableContentType="subheadings"></TypographyTable>
 
 ### Lead
 
+Lead typografi kan brukes gjennom [nve-paragraph](/components/nve-paragraph#lead-varianter)-komponenten.
+
 <TypographyTable tableContentType="lead"></TypographyTable>
 
 ### Body
 
+Body typografi kan brukes gjennom [nve-paragraph](/components/nve-paragraph#body-varianter)-komponenten.
+
 <TypographyTable tableContentType="body"></TypographyTable>
 
 ### Body compact
+
+Body compact typografi kan brukes gjennom [nve-paragraph](/components/nve-paragraph#body-compact-varianter)-komponenten.
 
 <TypographyTable tableContentType="body-compact"></TypographyTable>
 

--- a/src/components/nve-heading/nve-heading.component.ts
+++ b/src/components/nve-heading/nve-heading.component.ts
@@ -1,0 +1,79 @@
+import { LitElement } from 'lit';
+import { unsafeStatic, html } from 'lit/static-html.js';
+import { customElement, property } from 'lit/decorators.js';
+import { INveComponent } from '@interfaces/NveComponent.interface';
+import styles from './nve-heading.styles';
+
+/**
+ * nve-heading gir semantisk og tilgjengelig overskrift med riktig typografi fra designsystemet.
+ * Brukes for å sikre korrekt heading-hierarki (h1–h6) og typografi, og kan overstyres med variant for heading eller subheading.
+ *
+ * @slot - tekst - Selve overskriften (innholdet).
+ *
+ * @csspart nve-heading Hele heading-elementet
+ *
+ * Se designsystemet for alle varianter og tokens.
+ */
+@customElement('nve-heading')
+export default class NveHeading extends LitElement implements INveComponent {
+  @property({ type: String }) testId: string | undefined = undefined;
+  /** Heading level - Hvilket nivå overskriften skal ha (h1-h6) */
+  @property({ type: Number, reflect: true }) level: 1 | 2 | 3 | 4 | 5 | 6 = 1;
+
+  /** Typografitype - Kan overstyre det som er standard typografi basert på nivå */
+  @property({ type: String, reflect: true }) size?:
+    | 'headingXlarge'
+    | 'headingLarge'
+    | 'headingMedium'
+    | 'headingSmall'
+    | 'headingXsmall'
+    | 'subheadingLarge'
+    | 'subheadingMedium'
+    | 'subheadingSmall';
+
+  static styles = [styles];
+
+  constructor() {
+    super();
+  }
+  protected getTagName() {
+    if (!this.level || this.level < 1 || this.level > 6 || isNaN(this.level)) {
+      return 'h1';
+    }
+    return `h${this.level}`;
+  }
+
+  protected getDefaultTypographyType() {
+    switch (this.level) {
+      case 1:
+        return 'headingXlarge';
+      case 2:
+        return 'headingLarge';
+      case 3:
+        return 'headingMedium';
+      case 4:
+        return 'headingSmall';
+      case 5:
+        return 'headingXsmall';
+      case 6:
+        return 'headingXsmall';
+      default:
+        return 'headingMedium';
+    }
+  }
+
+  render() {
+    const tagName = this.getTagName();
+    return html`
+      <${unsafeStatic(tagName)} part="nve-heading" data-testid=${this.testId} class="heading ${this.size ? this.size : this.getDefaultTypographyType()}">
+        <slot></slot>
+      </${unsafeStatic(tagName)}>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-heading': NveHeading;
+  }
+}

--- a/src/components/nve-heading/nve-heading.styles.ts
+++ b/src/components/nve-heading/nve-heading.styles.ts
@@ -1,0 +1,39 @@
+import { css } from 'lit';
+
+export default css`
+  .heading {
+    margin: 0;
+  }
+
+  .headingXlarge {
+    font: var(--typography-heading-x-large);
+  }
+
+  .headingLarge {
+    font: var(--typography-heading-large);
+  }
+
+  .headingMedium {
+    font: var(--typography-heading-medium);
+  }
+
+  .headingSmall {
+    font: var(--typography-heading-small);
+  }
+
+  .headingXsmall {
+    font: var(--typography-heading-x-small);
+  }
+
+  .subheadingLarge {
+    font: var(--typography-subheading-large);
+  }
+
+  .subheadingMedium {
+    font: var(--typography-subheading-medium);
+  }
+
+  .subheadingSmall {
+    font: var(--typography-subheading-small);
+  }
+`;

--- a/src/components/nve-heading/nve-heading.test.ts
+++ b/src/components/nve-heading/nve-heading.test.ts
@@ -1,0 +1,19 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { fixture, fixtureCleanup } from '@open-wc/testing';
+import { html } from 'lit';
+import NveHeading from './nve-heading.component';
+
+if (!customElements.get('nve-heading')) {
+  customElements.define('nve-heading', NveHeading);
+}
+
+describe('nve-heading', () => {
+  afterAll(() => {
+    fixtureCleanup();
+  });
+
+  it('is attached to the DOM', async () => {
+    const el = await fixture<NveHeading>(html`<nve-heading></nve-heading>`);
+    expect(document.body.contains(el)).toBe(true);
+  });
+});

--- a/src/components/nve-heading/nve-heading.test.ts
+++ b/src/components/nve-heading/nve-heading.test.ts
@@ -8,12 +8,77 @@ if (!customElements.get('nve-heading')) {
 }
 
 describe('nve-heading', () => {
-  afterAll(() => {
-    fixtureCleanup();
-  });
+  afterAll(() => fixtureCleanup());
 
-  it('is attached to the DOM', async () => {
+  it('should be attached to the DOM', async () => {
     const el = await fixture<NveHeading>(html`<nve-heading></nve-heading>`);
     expect(document.body.contains(el)).toBe(true);
+  });
+
+  describe('Heading element', () => {
+    const headingLevels = [
+      { level: 1, tag: 'h1', defaultSize: 'headingXlarge' },
+      { level: 2, tag: 'h2', defaultSize: 'headingLarge' },
+      { level: 3, tag: 'h3', defaultSize: 'headingMedium' },
+      { level: 4, tag: 'h4', defaultSize: 'headingSmall' },
+      { level: 5, tag: 'h5', defaultSize: 'headingXsmall' },
+      { level: 6, tag: 'h6', defaultSize: 'headingXsmall' },
+    ] as const;
+
+    headingLevels.forEach(({ level, tag, defaultSize }) => {
+      it(`should render as ${tag} and apply correct default typography`, async () => {
+        const el = await fixture<NveHeading>(html`<nve-heading level="${level}">Heading ${tag}</nve-heading>`);
+        const heading = el.shadowRoot?.querySelector(tag);
+
+        expect(heading).toBeTruthy();
+        expect(heading?.classList.contains(defaultSize)).toBe(true);
+        expect(el.textContent?.trim()).toBe(`Heading ${tag}`);
+      });
+    });
+  });
+
+  describe('size override', () => {
+    const headingSizes = ['headingXlarge', 'headingLarge', 'headingMedium', 'headingSmall', 'headingXsmall'] as const;
+
+    headingSizes.forEach((size) => {
+      it(`should apply correct class for size="${size}"`, async () => {
+        const el = await fixture<NveHeading>(html`<nve-heading size="${size}">Text ${size}</nve-heading>`);
+        const heading = el.shadowRoot?.querySelector('h1');
+
+        expect(heading?.classList.contains(size)).toBe(true);
+        expect(el.textContent?.trim()).toBe(`Text ${size}`);
+      });
+    });
+  });
+
+  describe('subheading variants', () => {
+    const subheadingSizes = ['subheadingLarge', 'subheadingMedium', 'subheadingSmall'] as const;
+
+    subheadingSizes.forEach((size) => {
+      it(`should apply correct class for size="${size}"`, async () => {
+        const el = await fixture<NveHeading>(html`<nve-heading size="${size}">Text ${size}</nve-heading>`);
+        const heading = el.shadowRoot?.querySelector('h1');
+
+        expect(heading?.classList.contains(size)).toBe(true);
+      });
+    });
+  });
+
+  it('should expose CSS part', async () => {
+    const el = await fixture<NveHeading>(html`<nve-heading>Test</nve-heading>`);
+    const heading = el.shadowRoot?.querySelector('[part="nve-heading"]');
+    expect(heading).toBeTruthy();
+  });
+
+  it('should set testId when provided', async () => {
+    const el = await fixture<NveHeading>(html`<nve-heading testId="my-heading">Test</nve-heading>`);
+    const heading = el.shadowRoot?.querySelector('[data-testid="my-heading"]');
+    expect(heading).toBeTruthy();
+  });
+
+  it('should apply heading class', async () => {
+    const el = await fixture<NveHeading>(html`<nve-heading>Test</nve-heading>`);
+    const heading = el.shadowRoot?.querySelector('.heading');
+    expect(heading).toBeTruthy();
   });
 });

--- a/src/components/nve-paragraph/nve-paragraph.component.ts
+++ b/src/components/nve-paragraph/nve-paragraph.component.ts
@@ -1,0 +1,63 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { INveComponent } from '@interfaces/NveComponent.interface';
+import styles from './nve-paragraph.styles';
+
+/**
+ * nve-paragraph gir fleksibel og tilgjengelig typografi for avsnitt i designsystemet.
+ * Brukes til brødtekst, mengdetekst og ingress (lead), og gir riktig styling basert på designsystemets tokens.
+ *
+ * Du styrer typografivariant med size-prop, og kan velge mellom ulike varianter for brødtekst (body), ingress (lead) og kompakt tekst (body-compact).
+ *
+ * @slot - tekst - Selve avsnittet (innholdet).
+ *
+ * @csspart paragraph Hele paragraph-elementet
+ *
+ * Se designsystemet for alle varianter og tokens.
+ */
+@customElement('nve-paragraph')
+export default class NveParagraph extends LitElement implements INveComponent {
+  @property({ type: String }) testId: string | undefined = undefined;
+
+  /** Typografivariant for paragrafen */
+  @property({ type: String, reflect: true }) size?:
+    | 'leadLargeRegular'
+    | 'leadLargeSemibold'
+    | 'leadMediumRegular'
+    | 'leadMediumSemibold'
+    | 'leadSmallRegular'
+    | 'leadSmallSemibold'
+    | 'bodyLarge'
+    | 'bodyLargeUnderline'
+    | 'bodyMedium'
+    | 'bodyMediumUnderline'
+    | 'bodySmall'
+    | 'bodySmallUnderline'
+    | 'bodyXSmall'
+    | 'bodyXSmallUnderline'
+    | 'bodyLargeCompact'
+    | 'bodyLargeUnderlineCompact'
+    | 'bodyMediumCompact'
+    | 'bodyMediumUnderlineCompact'
+    | 'bodySmallCompact'
+    | 'bodySmallUnderlineCompact'
+    | 'bodyXSmallCompact'
+    | 'bodyXSmallUnderlineCompact';
+
+  static styles = [styles];
+
+  render() {
+    const variantClass = this.size ? `${this.size}` : '';
+    return html`
+      <p class="paragraph ${variantClass}" data-testid="${this.testId}">
+        <slot></slot>
+      </p>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-paragraph': NveParagraph;
+  }
+}

--- a/src/components/nve-paragraph/nve-paragraph.component.ts
+++ b/src/components/nve-paragraph/nve-paragraph.component.ts
@@ -49,7 +49,7 @@ export default class NveParagraph extends LitElement implements INveComponent {
   render() {
     const variantClass = this.size ? `${this.size}` : '';
     return html`
-      <p class="paragraph ${variantClass}" data-testid="${this.testId}">
+      <p class="paragraph ${variantClass}" part="paragraph" data-testid="${this.testId}">
         <slot></slot>
       </p>
     `;

--- a/src/components/nve-paragraph/nve-paragraph.styles.ts
+++ b/src/components/nve-paragraph/nve-paragraph.styles.ts
@@ -1,0 +1,103 @@
+import { css } from 'lit';
+
+export default css`
+  .paragraph {
+    margin: 0;
+  }
+
+  .leadLargeRegular {
+    font: var(--typography-lead-large-regular);
+  }
+
+  .leadLargeSemibold {
+    font: var(--typography-lead-large-semibold);
+  }
+
+  .leadMediumRegular {
+    font: var(--typography-lead-medium-regular);
+  }
+
+  .leadMediumSemibold {
+    font: var(--typography-lead-medium-semibold);
+  }
+
+  .leadSmallRegular {
+    font: var(--typography-lead-small-regular);
+  }
+
+  .leadSmallSemibold {
+    font: var(--typography-lead-small-semibold);
+  }
+
+  .bodyLarge {
+    font: var(--typography-body-large);
+  }
+
+  .bodyLargeUnderline {
+    font: var(--typography-body-large-underline);
+    text-decoration: underline;
+  }
+
+  .bodyMedium {
+    font: var(--typography-body-medium);
+  }
+
+  .bodyMediumUnderline {
+    font: var(--typography-body-medium-underline);
+    text-decoration: underline;
+  }
+
+  .bodySmall {
+    font: var(--typography-body-small);
+  }
+
+  .bodySmallUnderline {
+    font: var(--typography-body-small-underline);
+    text-decoration: underline;
+  }
+
+  .bodyXSmall {
+    font: var(--typography-body-x-small);
+  }
+
+  .bodyXSmallUnderline {
+    font: var(--typography-body-x-small-underline);
+    text-decoration: underline;
+  }
+
+  .bodyLargeCompact {
+    font: var(--typography-body-compact-large-compact);
+  }
+
+  .bodyLargeUnderlineCompact {
+    font: var(--typography-body-compact-large-underline-compact);
+    text-decoration: underline;
+  }
+
+  .bodyMediumCompact {
+    font: var(--typography-body-compact-medium-compact);
+  }
+
+  .bodyMediumUnderlineCompact {
+    font: var(--typography-body-compact-medium-underline-compact);
+    text-decoration: underline;
+  }
+
+  .bodySmallCompact {
+    font: var(--typography-body-compact-small-compact);
+  }
+
+  .bodySmallUnderlineCompact {
+    font: var(--typography-body-compact-small-underline-compact);
+    text-decoration: underline;
+  }
+
+  .bodyXSmallCompact {
+    font: var(--typography-body-compact-x-small-compact);
+  }
+
+  .bodyXSmallUnderlineCompact {
+    font: var(--typography-body-compact-x-small-underline-compact);
+    text-decoration: underline;
+  }
+`;

--- a/src/components/nve-paragraph/nve-paragraph.test.ts
+++ b/src/components/nve-paragraph/nve-paragraph.test.ts
@@ -1,20 +1,115 @@
-import { afterAll, describe, expect, it, } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 import { fixture, fixtureCleanup } from '@open-wc/testing';
 import { html } from 'lit';
 import NveParagraph from './nve-paragraph.component';
-  
+
 if (!customElements.get('nve-paragraph')) {
   customElements.define('nve-paragraph', NveParagraph);
 }
 
 describe('nve-paragraph', () => {
-  afterAll(() => {
-    fixtureCleanup();
-  });
-  
-  it('is attached to the DOM', async () => {
+  afterAll(() => fixtureCleanup());
+
+  it('should be attached to the DOM', async () => {
     const el = await fixture<NveParagraph>(html`<nve-paragraph></nve-paragraph>`);
     expect(document.body.contains(el)).toBe(true);
   });
+
+  it('should render as p element', async () => {
+    const el = await fixture<NveParagraph>(html`<nve-paragraph>Test paragraph</nve-paragraph>`);
+    const paragraph = el.shadowRoot?.querySelector('p');
+
+    expect(paragraph).toBeTruthy();
+    expect(el.textContent?.trim()).toBe('Test paragraph');
+  });
+
+  it('should render without size class when size is not provided', async () => {
+    const el = await fixture<NveParagraph>(html`<nve-paragraph>Default paragraph</nve-paragraph>`);
+    const paragraph = el.shadowRoot?.querySelector('p');
+
+    expect(paragraph?.classList.contains('paragraph')).toBe(true);
+    expect(paragraph?.className.trim()).toBe('paragraph');
+  });
+
+  describe('Lead variants', () => {
+    const leadSizes = [
+      'leadLargeRegular',
+      'leadLargeSemibold',
+      'leadMediumRegular',
+      'leadMediumSemibold',
+      'leadSmallRegular',
+      'leadSmallSemibold',
+    ] as const;
+
+    leadSizes.forEach((size) => {
+      it(`should apply correct class for size="${size}"`, async () => {
+        const el = await fixture<NveParagraph>(html`<nve-paragraph size="${size}">Lead text</nve-paragraph>`);
+        const paragraph = el.shadowRoot?.querySelector('p');
+
+        expect(paragraph?.classList.contains(size)).toBe(true);
+      });
+    });
+  });
+
+  describe('Body variants', () => {
+    const bodySizes = [
+      'bodyLarge',
+      'bodyLargeUnderline',
+      'bodyMedium',
+      'bodyMediumUnderline',
+      'bodySmall',
+      'bodySmallUnderline',
+      'bodyXSmall',
+      'bodyXSmallUnderline',
+    ] as const;
+
+    bodySizes.forEach((size) => {
+      it(`should apply correct class for size="${size}"`, async () => {
+        const el = await fixture<NveParagraph>(html`<nve-paragraph size="${size}">Body text</nve-paragraph>`);
+        const paragraph = el.shadowRoot?.querySelector('p');
+
+        expect(paragraph?.classList.contains(size)).toBe(true);
+      });
+    });
+  });
+
+  describe('Body compact variants', () => {
+    const compactSizes = [
+      'bodyLargeCompact',
+      'bodyLargeUnderlineCompact',
+      'bodyMediumCompact',
+      'bodyMediumUnderlineCompact',
+      'bodySmallCompact',
+      'bodySmallUnderlineCompact',
+      'bodyXSmallCompact',
+      'bodyXSmallUnderlineCompact',
+    ] as const;
+
+    compactSizes.forEach((size) => {
+      it(`should apply correct class for size="${size}"`, async () => {
+        const el = await fixture<NveParagraph>(html`<nve-paragraph size="${size}">Compact text</nve-paragraph>`);
+        const paragraph = el.shadowRoot?.querySelector('p');
+
+        expect(paragraph?.classList.contains(size)).toBe(true);
+      });
+    });
+  });
+
+  it('should expose CSS part', async () => {
+    const el = await fixture<NveParagraph>(html`<nve-paragraph>Test</nve-paragraph>`);
+    const paragraph = el.shadowRoot?.querySelector('[part="paragraph"]');
+    expect(paragraph).toBeTruthy();
+  });
+
+  it('should set testId when provided', async () => {
+    const el = await fixture<NveParagraph>(html`<nve-paragraph testId="my-paragraph">Test</nve-paragraph>`);
+    const paragraph = el.shadowRoot?.querySelector('[data-testid="my-paragraph"]');
+    expect(paragraph).toBeTruthy();
+  });
+
+  it('should apply paragraph class', async () => {
+    const el = await fixture<NveParagraph>(html`<nve-paragraph>Test</nve-paragraph>`);
+    const paragraph = el.shadowRoot?.querySelector('.paragraph');
+    expect(paragraph).toBeTruthy();
+  });
 });
-  

--- a/src/components/nve-paragraph/nve-paragraph.test.ts
+++ b/src/components/nve-paragraph/nve-paragraph.test.ts
@@ -1,0 +1,20 @@
+import { afterAll, describe, expect, it, } from 'vitest';
+import { fixture, fixtureCleanup } from '@open-wc/testing';
+import { html } from 'lit';
+import NveParagraph from './nve-paragraph.component';
+  
+if (!customElements.get('nve-paragraph')) {
+  customElements.define('nve-paragraph', NveParagraph);
+}
+
+describe('nve-paragraph', () => {
+  afterAll(() => {
+    fixtureCleanup();
+  });
+  
+  it('is attached to the DOM', async () => {
+    const el = await fixture<NveParagraph>(html`<nve-paragraph></nve-paragraph>`);
+    expect(document.body.contains(el)).toBe(true);
+  });
+});
+  

--- a/src/nve-designsystem.ts
+++ b/src/nve-designsystem.ts
@@ -16,6 +16,7 @@ export { default as NveDialog } from './components/nve-dialog/nve-dialog.compone
 export { default as NveDivider } from './components/nve-divider/nve-divider.component';
 export { default as NveDrawer } from './components/nve-drawer/nve-drawer.component';
 export { default as NveDropdown } from './components/nve-dropdown/nve-dropdown.component';
+export { default as NveHeading } from './components/nve-heading/nve-heading.component';
 export { default as NveIcon } from './components/nve-icon/nve-icon.component';
 export { default as NveInput } from './components/nve-input/nve-input.component';
 export { default as NveLabel } from './components/nve-label/nve-label.component';
@@ -25,6 +26,7 @@ export { default as NveMenuItem } from './components/nve-menu-item/nve-menu-item
 export { default as NveMessageCard } from './components/nve-message-card/nve-message-card.component';
 export { default as NveNavigationCard } from './components/nve-navigation-card/nve-navigation-card.component';
 export { default as NveOption } from './components/nve-option/nve-option.component';
+export { default as NveParagraph } from './components/nve-paragraph/nve-paragraph.component';
 export { default as NvePopup } from './components/nve-popup/nve-popup.component';
 export { default as NveRadio } from './components/nve-radio/nve-radio.component';
 export { default as NveRadioButton } from './components/nve-radio-button/nve-radio-button.component';


### PR DESCRIPTION
###  Nye Typografi-komponenter

Draft-PR med forslag til oppsett av nye typografi-komponenter: `nve-heading` og `nve-parapgrah`. 

### Nye komponenter

Heading-komponenten

- Bruker `level` prop for semantisk HTML-nivå (h1-h6)
- Bruker `size` prop for visuell typografi-stil (`headingXlarge`, `headingLarge`, `headingMedium`, etc.)
- Skiller mellom semantikk og visuell presentasjon
- Støtter både heading- og subheading-varianter

Paragraph-komponenten

- Bruker `size` prop for typografi-varianter
- Støtter lead-varianter (ingress): `leadLargeRegular`, `leadMediumRegular`, etc.
- Støtter body-varianter (brødtekst): `bodyLarge`, `bodyMedium`, `bodySmall`, etc.
- Støtter body-compact-varianter for kompakt tekst
- Blir `p`-tag

Paragraph kan evt deles opp dersom man føler den dekker for mange områder (lead, body, compact, underline osv)