### PR TITLE
fix(navigation-card): sentrerer innhold vertikalt i kortet

### DIFF
--- a/src/components/nve-navigation-card/nve-navigation-card.styles.ts
+++ b/src/components/nve-navigation-card/nve-navigation-card.styles.ts
@@ -43,6 +43,7 @@ export default css`
   .navigation-card__content {
     display: flex;
     flex-direction: column;
+    justify-content: center;
     gap: var(--spacing-medium);
     align-items: flex-start;
     align-self: stretch;


### PR DESCRIPTION
### Beskrivelse

Lagt til vertikal sentrering av innhold i `nve-navigation-card` for å sikre at tekst og ikon er riktig plassert når kortet har ekstra høyde. Dette skulle vært med i opprettelsen av `nve-navigation-card` som jeg lagde tidligere, så denne PR-en er en fix som legger på det nå. 

### Endringer
- La til `justify-content: center` på `.navigation-card__content` i `nve-navigation-card.styles.ts`

### Påvirkning
- Innholdet i navigasjonskortet vil nå være vertikalt sentrert
