### PR TITLE
chore(ts): Benytt rootDir i tsconfig da baseurl er deprecated

### DIFF
--- a/src/components/nve-carousel-thumbnail/nve-carousel-thumbnail.component.ts
+++ b/src/components/nve-carousel-thumbnail/nve-carousel-thumbnail.component.ts
@@ -1,8 +1,7 @@
-
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { INveComponent } from '@interfaces/NveComponent.interface';
-import { NveCarousel } from 'src/nve-designsystem';
+import { NveCarousel } from 'nve-designsystem';
 import styles from './nve-carousel-thumbnail.styles';
 
 /**
@@ -11,9 +10,7 @@ import styles from './nve-carousel-thumbnail.styles';
  */
 
 @customElement('nve-carousel-thumbnail')
-
 export default class NveCarouselThumbnail extends LitElement implements INveComponent {
-
   static styles = [styles];
 
   constructor() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,10 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "baseUrl": "./",
+    "rootDir": "./src",
     "paths": {
-      "@interfaces/*": ["src/interfaces/*"]
+      "@interfaces/*": ["./src/interfaces/*"],
+      "nve-designsystem": ["./src/nve-designsystem"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
Endrer tsconfig til å ta i bruk "rootDir"; bruk av "baseUrl" gir feilmelding ved bygging.