### PR TITLE
fix(nve-carousel): Importer direkte fra komponentfil

### DIFF
--- a/src/components/nve-carousel-thumbnail/nve-carousel-thumbnail.component.ts
+++ b/src/components/nve-carousel-thumbnail/nve-carousel-thumbnail.component.ts
@@ -1,7 +1,7 @@
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { INveComponent } from '@interfaces/NveComponent.interface';
-import { NveCarousel } from 'nve-designsystem';
+import NveCarousel from '../nve-carousel/nve-carousel.component.ts';
 import styles from './nve-carousel-thumbnail.styles';
 
 /**


### PR DESCRIPTION
Importerer Nve-Carousel direkte fra fil - ikke designsystempakken

Closes: #860 