### PR TITLE
feat(nve-textarea): oppdatere textarea

### DIFF
--- a/doc-site/components/nve-combobox.md
+++ b/doc-site/components/nve-combobox.md
@@ -422,7 +422,7 @@ Bruk <span class="highlight">helpText</span> for å vise hjelpetekst over combob
 
 ### Hint-tekst
 
-Bruk <span class="highlight">hintText</span> for å vise hint-tekst under combobox.
+Bruk <span class="highlight">hint</span> for å vise hint-tekst under combobox.
 
 <CodeExamplePreview>
 
@@ -430,7 +430,7 @@ Bruk <span class="highlight">hintText</span> for å vise hint-tekst under combob
 <nve-combobox
   id="nve-avdeling-10"
   label="Velg en avdeling"
-  hintText="Avdeling velges for å sendes i skjema"
+  hint="Avdeling velges for å sendes i skjema"
   options='[ 
     { "value":"rme","label": "RME" },
     { "value":"ek","label": "EK" },

--- a/doc-site/components/nve-radio-group.md
+++ b/doc-site/components/nve-radio-group.md
@@ -140,15 +140,12 @@ Bruk <span class="highlight">helpText</span> for å vise hjelpetekst over feltet
 
 ### Hint-tekst
 
-Bruk <span class="highlight">hintText</span> for å vise hint-tekst under feltet.
+Bruk <span class="highlight">hint</span> for å vise hint-tekst under feltet.
 
 <CodeExamplePreview>
 
 ```html
-<nve-radio-group
-  label="Hva er status på tiltaket?"
-  hintText="Velg smart. Det finnes ingen vei tilbake fra dårlige valg."
->
+<nve-radio-group label="Hva er status på tiltaket?" hint="Velg smart. Det finnes ingen vei tilbake fra dårlige valg.">
   <nve-radio value="planned">Planlagt</nve-radio>
   <nve-radio value="current">Pågående</nve-radio>
   <nve-radio value="done">Ferdigstilt</nve-radio>
@@ -193,7 +190,7 @@ Bruk <span class="highlight">value</span> for å vise en forhåndsvalgt verdi. V
 
 Radiogruppen er implementert i tråd med [anbefalingene](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) i WAI-ARIA Authoring Practices Guide for radiogrupper, for å støtte tilgjengelig bruk i samsvar med WCAG.
 
-- Siden radiogruppen er bygget med <span class="highlight">fieldset</span> og <span class="highlight">legend</span>, kan den første radioknappen som får fokus ved tab-navigasjon lese opp ledeteksten sammen med eventuell tilleggstekst fra <span class="highlight">helpText</span>, <span class="highlight">hintText</span> og <span class="highlight">errorMessage</span>. Tillegsteksten legges til i <span class="highlight">aria-describedby</span> på <span class="highlight">fieldset</span>. (VoiceOver i Safari på macOS kan slite litt med <span class="highlight">aria-describedby</span> og ikke lese den).
+- Siden radiogruppen er bygget med <span class="highlight">fieldset</span> og <span class="highlight">legend</span>, kan den første radioknappen som får fokus ved tab-navigasjon lese opp ledeteksten sammen med eventuell tilleggstekst fra <span class="highlight">helpText</span>, <span class="highlight">hint</span> og <span class="highlight">errorMessage</span>. Tillegsteksten legges til i <span class="highlight">aria-describedby</span> på <span class="highlight">fieldset</span>. (VoiceOver i Safari på macOS kan slite litt med <span class="highlight">aria-describedby</span> og ikke lese den).
 - <span class="highlight">nve-radio</span> har intern tilstand for <span class="highlight">checked</span>, <span class="highlight">pos</span> og <span class="highlight">setsize</span>, som styres av <span class="highlight">nve-radio-group</span>. Disse brukes til å sette riktige ARIA-attributter (<span class="highlight">aria-checked</span> <span class="highlight">aria-posinset</span>,<span class="highlight">aria-setsize</span>) på radio-knappen.
 - <span class="highlight">aria-posinset</span> og <span class="highlight">aria-setsize</span> brukes for å fortelle brukeren hvor i gruppen den aktuelle radio-knappen ligger, og hvor mange valg som finnes totalt.
 - <span class="highlight">aria-disabled</span> og <span class="highlight">aria-invalid</span> settes på <span class="highlight">nve-radio</span> basert på egenskapene <span class="highlight">disabled</span> og <span class="highlight">invalid</span>.

--- a/doc-site/components/nve-textarea.md
+++ b/doc-site/components/nve-textarea.md
@@ -26,7 +26,7 @@ outline: [2, 3]
       <li><span class="highlight">spellcheck</span></li>
     </ul>
 <br>
-  <p> Komponentens hendelser bobler også ut fra komponenten; vi bruker spesielt:  </p>
+  <p>Komponenten videresender relevante hendelser fra det native <span class="highlight">&lt;textarea&gt;</span>-elementet slik at de kan fanges utenfor komponentens Shadow DOM:</p>
     <ul>
       <li><span class="highlight">change</span>- når verdien endres og feltet mister fokus</li> 
       <li><span class="highlight">select</span>- når brukeren markerer tekst</li> 
@@ -162,7 +162,7 @@ Bruk <span class="highlight">rows</span> for å velge høyde. Standard er to rad
 
 </CodeExamplePreview>
 
-### Resize
+### Endring av størrelse
 
 Om man ikke ønsker at bruker kan endre størrelsen på textarea kan man legge på <span class="highlight">resize: none</span> i css på <span class="highlight">textarea</span>-delen:
 
@@ -197,4 +197,4 @@ Hvis du vil gjøre textarea smalere enn 100%, kan du bruke <span class="highligh
 
 I tillegg brukes aria-describedby for å knytte supplerende tekst til feltet. Når <span class="highlight">helpText</span>, <span class="highlight">hint</span> eller <span class="highlight">errorMessage</span> er satt vil skjermlesere normalt lese dem opp i forbindelse med fokus på feltet (ved bruk av <span class="highlight">aria-describedby</span>).
 
-Ikoner i tekstare er dekorative og ikke ment som ensete informasjonsbærer.
+Ikoner i <span class="highlight">nve-textarea</span> er dekorative og ikke ment som ensete informasjonsbærer.

--- a/doc-site/components/nve-textarea.md
+++ b/doc-site/components/nve-textarea.md
@@ -6,181 +6,195 @@ outline: [2, 3]
 <CodeExamplePreview>
 
 ```html
-<nve-textarea label="Her kan du skrive akkurat hva du vil"></nve-textarea>
+<nve-textarea label="Beskriv saken"></nve-textarea>
 ```
 
 </CodeExamplePreview>
+
+<nve-message-card variant="primary" label="Native textarea-attributter" size="compact">
+  <p>
+    <span class="highlight">nve-textarea</span> bygger på et native <span class="highlight">&lt;textarea&gt;</span>-element
+    og støtter derfor de fleste vanlige textarea-attributter:  </p>
+    <ul>
+      <li><span class="highlight">autocapitalize</span></li>
+      <li><span class="highlight">autocomplete</span></li>
+      <li><span class="highlight">autocorrect</span></li>
+      <li><span class="highlight">autofocus</span> - husk at kun ett element kan autofokuseres</li>
+      <li><span class="highlight">maxLength</span> - selv om vi ikke støtter constraint validation, den brukes til å begrense antall tegn en bruker kan skrive. </li>
+      <li><span class="highlight">placeholder</span></li>
+      <li><span class="highlight">rows</span> - lenke til hvordan den brukes</li>
+      <li><span class="highlight">spellcheck</span></li>
+    </ul>
+<br>
+  <p> Komponentens hendelser bobler også ut fra komponenten; vi bruker spesielt:  </p>
+    <ul>
+      <li><span class="highlight">change</span>- når verdien endres og feltet mister fokus</li> 
+      <li><span class="highlight">select</span>- når brukeren markerer tekst</li> 
+    </ul>
+    <p><span class="highlight">selectionchange</span> støttes ikke foreløpig siden den ikke er fullstøttet i mange nettlesere.</p>
+<br>
+  <p>
+    Noen native attributter er bevisst ikke støttet:
+  </p>
+  <ul>
+    <li><span class="highlight">cols</span> – komponenten bruker CSS for bredde. Den er alltid 100% basert på foreldren sin bredde.</li>
+    <li><span class="highlight">dirname</span> – ikke støttet.</li>
+    <li><span class="highlight">form</span>, <span class="highlight">name</span> og <span class="highlight">wrap</span> – komponenten er ikke laget for native form submission.</li>
+    <li><span class="highlight">minlength</span> – ikke støttet (vi tilbyr ikke denne typen innebygd constraint-/formvalidering).</li>
+  </ul>
+</nve-message-card>
+
+## Retningslinjer
+
+- Gi alltid feltet en tydelig <span class="highlight">label</span>. Ikke stol på <span class="highlight">placeholder</span> alene.
+- Bruk <span class="highlight">disabled</span> med omhu. Deaktiverte felt kan ikke fokuseres og kan derfor være vanskeligere å oppdage med tastatur/skjermleser. Hvis innholdet skal kunne leses, vurder <span class="highlight">readonly</span> i stedet.
+- Sett en fornuftig høyde med <span class="highlight">rows</span> (for eksempel 3–5 rader) når du forventer lengre svar. For korte svar bør du vurdere <span class="highlight">nve-input</span> i stedet.
+- Hvis du bruker <span class="highlight">maxlength</span>, informer gjerne brukeren om grensen (for eksempel i <span class="highlight">hint</span>) slik at det ikke oppleves som “feltet slutter å virke”.
 
 ## Eksempler
 
-### Ledetekst
+### Ledetekst og tooltip
 
-En ledetekst kan legges til på to måter. Ved å bruke `label`-egenskapen – enklest når du kun trenger tekst eller ved å bruke `label`-sporet – som gir mer fleksibilitet, f.eks. hvis du vil inkludere HTML eller egne komponenter sammen med teksten.
+Bruk <span class="highlight">label</span> for å vise en tydelig ledetekst for feltet. Attributtet er påkrevd – hvert skjemafelt skal ha en ledetekst som skjermlesere kan bruke for å forstå hva feltet gjelder.
+
+Bruk i tillegg <span class="highlight">tooltip</span> for å vise utfyllende informasjon ved ledeteksten. Innholdet kan være ren tekst eller HTML, for eksempel lenker eller formattert hjelpetekst.
 
 <CodeExamplePreview>
 
 ```html
-<nve-textarea>
-  <nve-label value="Ledeteksten spor" slot="label">
-    <nve-spinner slot="suffix"></nve-spinner>
-  </nve-label>
-</nve-textarea>
-
-<nve-textarea label="Ledetekst egenskap"></nve-textarea>
+<nve-textarea label="Beskriv saken" tooltip="Skriv hva saken gjelder."> </nve-textarea>
 ```
 
 </CodeExamplePreview>
 
-### Hjelpetekst
+### Påkrevd
 
-En hjelpetekst er en tekst som nærmere bestemmer hva som skal fylles inn i inndatafeltet, og brukes som et tillegg
-til ledeteksten for inndatafeltet. Hjelpeteksten legges over inndatafeltet.
-
-<CodeExamplePreview>
-
-```html
-<nve-textarea label="Label" helpText="En tekst som presiserer hva som skal fylles inn"> </nve-textarea>
-```
-
-</CodeExamplePreview>
-
-### Hint
-
-Et hint er en kortfattet tekst under inndatafeltet, kan brukes for å gi eksempler på inndata. Hintet legges under inndatafeltet.
+Bruk <span class="highlight">required</span> for å vise et stjernesymbol på slutten av ledeteksten som markerer at feltet er påkrevd.  
+Bruk i tillegg <span class="highlight">requiredLabel</span> for å vise en forklarende tekst sammen med stjernen (for eksempel 'obligatorisk'). Dette gir brukerne en bedre forståelse av at feltet er påkrevd, siden ikke alle brukere forstår eller oppfatter stjernesymbolet alene.
 
 <CodeExamplePreview>
 
 ```html
-<nve-textarea
-  label="Fugler i Norge"
-  helpText="Nevn en eller flere fuglearter som finnes i norsk fauna"
-  hint="Hint: Dompap, tiur, fossekall"
->
-</nve-textarea>
+<nve-textarea label="Beskriv saken" required requiredLabel="Obligatorisk"> </nve-textarea>
 ```
 
 </CodeExamplePreview>
 
 ### Mørk bakgrunn
 
-Bruk `filled` for mørk bakgrunnsfarge
+Bruk <span class="highlight">filled</span> for mørk bakgrunnsfarge
 
 <CodeExamplePreview>
 
 ```html
-<nve-textarea value="filled" filled></nve-textarea>
-
-<nve-textarea value="ikke filled"></nve-textarea>
+<nve-textarea label="Beskriv saken" filled> </nve-textarea>
 ```
 
 </CodeExamplePreview>
 
-### Verktøyhint
+### Hjelpetekst
 
-Bruk `label` og `tooltip` for å vise ledetekst med verktøyhint
+Bruk <span class="highlight">helpText</span> for å vise en tekst som nærmere bestemmer hva som skal fylles inn i inndatafeltet, og brukes som et tillegg til ledeteksten for inndatafeltet. Hjelpeteksten legges over inndatafeltet.
 
 <CodeExamplePreview>
 
 ```html
-<nve-textarea label="Svev over ikonet" tooltip="Hjelpetekst"> </nve-textarea>
+<nve-textarea label="Beskriv saken" helpText="En tekst som presiserer hva som skal fylles inn"> </nve-textarea>
 ```
 
 </CodeExamplePreview>
 
-### Deaktivering
+### Hint
 
-Bruk `disabled` for å deaktivere feltet. Låse-ikon vises automatisk.
+Bruk <span class="highlight">hint</span> for å vise en kortfattet tekst, som kan brukes for å gi eksempler på inndata. Hintet legges under inndatafeltet.
 
 <CodeExamplePreview>
 
 ```html
-<nve-textarea value="aktiv"></nve-textarea>
+<nve-textarea label="Fugler i Norge" hint="Hint: Dompap, tiur, fossekall"> </nve-textarea>
+```
 
-<nve-textarea disabled value="deaktivert"></nve-textarea>
+</CodeExamplePreview>
+
+### Deaktivert
+
+<nve-message-card variant="warning" label="Obs!" size="compact">
+  <p>
+    Et deaktivert felt (<span class="highlight">disabled</span>) kan ikke få fokus og blir derfor ofte ikke oppdaget av
+    brukere som navigerer med tastatur eller skjermleser. Bruk <span class="highlight">disabled</span> med omhu, og vurder
+    å gi en tydelig forklaring i tekst på hvorfor feltet er deaktivert.
+  </p>
+</nve-message-card>
+
+Bruk attributtet <span class="highlight">disabled</span> for å hindre at brukeren kan endre innholdet.
+
+<CodeExamplePreview>
+
+```html
+<nve-textarea label="Beskriv saken" disabled> </nve-textarea>
 ```
 
 </CodeExamplePreview>
 
 ### Skrivebeskyttet
 
-Bruk `readonly` for å stenge mulighet for å endre innholdet
+Bruk <span  class="highlight">readonly</span> for å stenge mulighet for å endre innholdet
 
 <CodeExamplePreview>
 
 ```html
-<nve-textarea readonly value="Dette får du ikke endret"></nve-textarea>
-
-<nve-textarea value="men dette kan du endre"></nve-textarea>
-```
-
-</CodeExamplePreview>
-
-### Obligatorisk
-
-Bruk `required` for å tvinge bruker til å skrive noe og legg inn en feilmelding i `errorMessage` om du ikke vil ha standard-feilmeldinga.
-Bruk `requiredlabel` hvis du vil vise noe annet enn `*Obligatorisk`. Feltet må ligge i en `<form>` for at validering skal funke.
-
-<CodeExamplePreview>
-
-```html
-<!-- Bruker preventDefault så ikke sida lastes på nytt når du trykker på knappen -->
-<form onsubmit="event.preventDefault();">
-  <nve-textarea label="Hva synes du?" required errorMessage="Her må du skrive noe"></nve-textarea>
-
-  <nve-textarea
-    label="What do you think?"
-    required
-    requiredLabel="*Required"
-    errorMessage="Please answer"
-  ></nve-textarea>
-
-  <nve-button type="submit">Submit</nve-button>
-</form>
-```
-
-</CodeExamplePreview>
-
-### Validering av lengde
-
-I tillegg til `required` støtter vi `minLength` og `maxLength` for å validere lengden på innholdet. Pass på at du setter en feilmelding i `errorMessage`.
-Feltet må ligge i en `<form>` for at validering skal funke.
-
-<CodeExamplePreview>
-
-```html
-<!-- Bruker preventDefault så ikke sida lastes på nytt når du trykker på knappen -->
-<form onsubmit="event.preventDefault();">
-  <nve-textarea
-    required
-    minlength="3"
-    maxLength="5"
-    label="Minimum 3 og maks 5 tegn"
-    errorMessage="Mellom 3 og 5 tegn her, takk"
-  ></nve-textarea>
-  <nve-textarea
-    filled
-    required
-    minlength="3"
-    maxLength="5"
-    label="Minimum 3 og maks 5 tegn"
-    errorMessage="Mellom 3 og 5 tegn her, takk"
-  ></nve-textarea>
-  <nve-button type="submit" variant="primary">Submit</nve-button>
-</form>
+<nve-textarea label="Beskriv saken" readonly value="Dette får du ikke endret"></nve-textarea>
 ```
 
 </CodeExamplePreview>
 
 ### Antall rader
 
-Bruk `rows` for å velge høyde. Standard er to rader
+Bruk <span class="highlight">rows</span> for å velge høyde. Standard er to rader
 
 <CodeExamplePreview>
 
 ```html
-<nve-textarea rows="5" value="5 rader"></nve-textarea>
+<nve-textarea label="Beskriv saken" rows="5" value="5 rader"></nve-textarea>
 
-<nve-textarea value="2 rader"></nve-textarea>
+<nve-textarea label="Beskriv saken" value="2 rader"></nve-textarea>
 ```
 
 </CodeExamplePreview>
+
+### Resize
+
+Om man ikke ønsker at bruker kan endre størrelsen på textarea kan man legge på <span class="highlight">resize: none</span> i css på <span class="highlight">textarea</span>-delen:
+
+<CodeExamplePreview>
+
+```html
+<nve-textarea class="textarea-1" label="Beskriv saken"></nve-textarea>
+<style>
+  .textarea-1::part(textarea) {
+    resize: none;
+  }
+</style>
+```
+
+</CodeExamplePreview>
+
+### Maksimal bredde
+
+Hvis du vil gjøre textarea smalere enn 100%, kan du bruke <span class="highlight">--textarea-max-width</span> css-property til det.
+
+<CodeExamplePreview>
+
+```html
+<nve-textarea label="Beskriv saken" style="--textarea-max-width:100px;"></nve-textarea>
+```
+
+</CodeExamplePreview>
+
+## Tilgjengelighet
+
+<span class="highlight">nve-textarea</span> er bygget på et native <span class="highlight">&lt;textarea&gt;</span> og bruker en tilknyttet <a href="#ledetekst-og-tooltip">ledetekst</a>. Når feltet får fokus vil skjermlesere lese opp ledeteksten, slik at brukeren forstår hva som skal fylles inn.
+
+I tillegg brukes aria-describedby for å knytte supplerende tekst til feltet. Når <span class="highlight">helpText</span>, <span class="highlight">hint</span> eller <span class="highlight">errorMessage</span> er satt vil skjermlesere normalt lese dem opp i forbindelse med fokus på feltet (ved bruk av <span class="highlight">aria-describedby</span>).
+
+Ikoner i tekstare er dekorative og ikke ment som ensete informasjonsbærer.

--- a/src/components/nve-combobox/nve-combobox.component.ts
+++ b/src/components/nve-combobox/nve-combobox.component.ts
@@ -76,7 +76,7 @@ export default class NveCombobox extends LitElement implements INveComponent {
   /** Hjelpetekst som vises over feltet */
   @property({ type: String, reflect: true }) helpText = '';
   /** Hint-tekst som vises under feltet */
-  @property({ type: String, reflect: true }) hintText = '';
+  @property({ type: String, reflect: true }) hint = '';
   /** Ledetekst */
   @property({ type: String }) label: string = '';
   /** Tekst som vises for å markere at et felt er obligatorisk */
@@ -972,7 +972,7 @@ export default class NveCombobox extends LitElement implements INveComponent {
     const selectedValuesId = `${this.id}-selected-values`;
     const describedBy = [
       helpTextId,
-      this.errorMessage || this.hintText ? hintTextId : '',
+      this.errorMessage || this.hint ? hintTextId : '',
       this.multiple ? selectedValuesId : '',
     ]
       .filter(Boolean)
@@ -1145,10 +1145,8 @@ export default class NveCombobox extends LitElement implements INveComponent {
             : nothing}
         </div>
         <!-- Hint-tekst og feilmelding -->
-        ${this.errorMessage || this.hintText
-          ? html`<p part="hint-text" class="field__hint-text" id=${hintTextId}>
-              ${this.errorMessage || this.hintText}
-            </p>`
+        ${this.errorMessage || this.hint
+          ? html`<p part="hint-text" class="field__hint-text" id=${hintTextId}>${this.errorMessage || this.hint}</p>`
           : nothing}
       </div>
     `;

--- a/src/components/nve-radio-group/nve-radio-group.component.ts
+++ b/src/components/nve-radio-group/nve-radio-group.component.ts
@@ -28,7 +28,7 @@ export default class NveRadioGroup extends LitElement implements INveComponent {
   /** Hjelpetekst som vises over feltet */
   @property({ type: String, reflect: true }) helpText = '';
   /** Hint-tekst som vises under feltet */
-  @property({ type: String, reflect: true }) hintText = '';
+  @property({ type: String, reflect: true }) hint = '';
   /** Ledetekst for radio-gruppen */
   @property({ type: String }) label: string | undefined = undefined;
   /** Retning for gruppen av radioknapper */
@@ -214,7 +214,7 @@ export default class NveRadioGroup extends LitElement implements INveComponent {
     const helpTextId = `${this.radioGroupName}-helptext`;
     const hintTextId = `${this.radioGroupName}-hinttext`;
 
-    const describedBy = [this.helpText ? helpTextId : null, this.errorMessage || this.hintText ? hintTextId : null]
+    const describedBy = [this.helpText ? helpTextId : null, this.errorMessage || this.hint ? hintTextId : null]
       .filter(Boolean)
       .join(' ');
 
@@ -248,10 +248,8 @@ export default class NveRadioGroup extends LitElement implements INveComponent {
           <slot @slotchange=${this.handleSlotChange}></slot>
         </div>
         <!-- Hint-tekst og feilmelding -->
-        ${this.errorMessage || this.hintText
-          ? html`<p part="hint-text" class="field__hint-text" id=${hintTextId}>
-              ${this.errorMessage || this.hintText}
-            </p>`
+        ${this.errorMessage || this.hint
+          ? html`<p part="hint-text" class="field__hint-text" id=${hintTextId}>${this.errorMessage || this.hint}</p>`
           : nothing}
       </fieldset>
     `;

--- a/src/components/nve-radio-group/nve-radio-group.test.ts
+++ b/src/components/nve-radio-group/nve-radio-group.test.ts
@@ -56,9 +56,9 @@ describe('nve-radio-group', () => {
     expect(group?.classList.contains('radio-group--horizontal')).toBe(true);
   });
 
-  it('renders helpText and hintText with the correct classes', async () => {
+  it('renders helpText and hint with the correct classes', async () => {
     const el = await fixture<NveRadioGroup>(html`
-      <nve-radio-group label="Status" helpText="Hjelpetekst" hintText="Hinttekst">
+      <nve-radio-group label="Status" helpText="Hjelpetekst" hint="Hinttekst">
         <nve-radio value="planned">Planlagt</nve-radio>
       </nve-radio-group>
     `);

--- a/src/components/nve-textarea/nve-textarea.component.ts
+++ b/src/components/nve-textarea/nve-textarea.component.ts
@@ -1,299 +1,198 @@
-import { LitElement, html, nothing } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
-import styles from './nve-textarea.styles';
-import { ifDefined } from 'lit/directives/if-defined.js';
-import { live } from 'lit/directives/live.js';
-import { classMap } from 'lit/directives/class-map.js';
+import { html, LitElement, nothing, PropertyValues } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
 import { INveComponent } from '@interfaces/NveComponent.interface';
-
+import styles from './nve-textarea.styles';
 import '../nve-icon/nve-icon.component';
-import '../nve-label/nve-label.component';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { getLabel, labelStyles } from '../../templates/label';
+
+let id = 0;
 
 /**
- * Skal brukes til å lage lang tekstfelt. Min høyde er satt opp til --sizing-2x-small. De fleste attributer som brukes på vanlig textarea
- * burde bli støttet her. Hvis det er noe som mangler, bare å legge til.
- * Man kan bruke label og tooltip attributer for å vise label over textarea. Samt med helpText. Trenger ikke noe eksta slots per i dag. Trengs ikke å lage separate slots for det.
- * Siden vi skulle bruke ikoner inn i textarea var det enklere å lage vår egen komponent enn å leke med sl-textarea
+ * Textarea brukes når brukeren skal kunne skrive inn lengre tekst over flere linjer. Komponenten passer godt til
+ * fritekstfelt som beskrivelser, kommentarer, begrunnelser eller meldinger.
+ * Textarea kan også endre størrelse slik at brukeren får bedre plass til lengre innhold.
  *
- * Validering. Siden textarea ikke er shoelace komponent, constraint valdiering skal ikke fungere så bra med andre shoelace komponenter i formen.
- * Shoelace wrapper alle sine form komponenter i en form kontroll som gjør at alle blir validert samtidig når man bruker constraint validering. Det er ikke en default
- * nettlesersen oppførsel. Submit event stopper på den første feil den møter i formen. Per i dag siden vi blander både shoelace komponenter og våre egne
- * våre komponeter skal bli diskriminert i gruppe validering. Derfor anbefales det å bruke custom validering på textarea med setCustomValidation.
- * @dependency nve-icon
- * @dependency nve-label
+ * @event change - når verdien i textarea endres og elementet mister fokus
+ * @event select - når brukeren markerer tekst i textarea
  *
- * Bruker sl-eventer for å være konsistent. Kan bruke våre egne eventer når vi droppper shoelace
- * @event sl-blur - trigges når textarea mister fokus
- * @event sl-change - trigges når textarea endrer verdi
- * @event sl-input - trigges når textarea endrer verdi
- * @event sl-invalid - trigges når textarea er invalid
- *
- * @csspart form-control - hoved komponent sitt container
- * @csspart textarea-label - label og requiredLabel container
- * @csspart base - textarea og ikone container
- * @csspart help-text-container - container for hjelpetekst
- *
+ * @csspart field - wrapper rundt hele textarea-komponenten
+ * @csspart help-text - hjelpetekst som vises over textarea
+ * @csspart textarea - wrapper rundt textarea-elementet og eventuelle ikoner
+ * @csspart textarea__control - selve textarea-elementet
+ * @csspart hint-text - hint-tekst som vises under textarea, eller feilmelding hvis det er en valideringsfeil
  */
-// @ts-expect-error - SlInput has autocorrect as string type but type system expects boolean
 @customElement('nve-textarea')
 export default class NveTextarea extends LitElement implements INveComponent {
-  static styles = [styles];
-
-  /** Navnet på tekstområdet, sendt som et navn/verdi-par med skjemadata */
-  @property() name = '';
-
-  /** Textarea verdi, sendt som et navn/verdi-par med skjemadata */
-  @property() value = '';
-
-  /** Feil melding som vises under gruppe hvis validering feiler */
-  @property() errorMessage?: string;
-
-  @property() title = '';
-
-  /** Viser filled variant */
-  @property({ type: Boolean, reflect: true }) filled = false;
-
-  /** Label tekst */
-  @property() label = '';
-
-  /** Hjelpetekst under textarea */
-  @property() helpText = '';
-
-  /** Hint - tekst under inndatafelt */
-  @property() hint = '';
-
-  /** Om textarea er deaktivert */
+  @property({ type: String }) testId: string | undefined = undefined;
+  /* Native textarea attributes */
+  /** Om autocomplete skal være aktivert */
+  @property({ type: String }) autocomplete?: string;
+  /** Om inputfeltet skal være deaktivert */
   @property({ type: Boolean, reflect: true }) disabled = false;
-
-  /** Om textarea er skrivebeskyttet */
+  /** Maksimalt antall tegn som kan skrives inn */
+  @property({ type: Number }) maxLength?: number;
+  /** Placeholder-tekst som vises når feltet er tomt */
+  @property({ type: String }) placeholder?: string;
+  /** Om textareafeltet skal være skrivebeskyttet */
   @property({ type: Boolean, reflect: true }) readonly = false;
-
-  /** Placeholder tekst */
-  @property() placeholder = '';
-
-  /** Om textarea er obligatorisk */
+  /** Om minst en sjekkboks er sjekket på */
   @property({ type: Boolean, reflect: true }) required = false;
+  /** Antall synlige tekstlinjer i textarea */
+  @property({ type: Number }) rows?: number;
+  /** Verdien i textarea */
+  @property({ type: String }) value?: string;
 
-  /** Tekst som vises for å markere at et felt er obligatorisk. Er satt til "*Obligatorisk" som standard.*/
-  @property() requiredLabel = '*Obligatorisk';
+  /* Custom textarea attributes */
+  /** Om textareafeltet skal ha en mørk bakgrunn */
+  @property({ type: Boolean }) filled: boolean = false;
+  /** Hjelpetekst som vises over feltet */
+  @property({ type: String }) helpText = '';
+  /** Hint-tekst som vises under feltet */
+  @property({ type: String }) hint = '';
+  /** Ledetekst */
+  @property() label?: string;
+  /** Feilmelding som vises ved valideringsfeil. Hvis den er satt blir input-felt ugyldig og feil melding vises.*/
+  @property({ type: String, reflect: true }) errorMessage?: string;
+  /** Tekst som vises for å markere at et felt er obligatorisk */
+  @property() requiredLabel = '';
+  /** Tooltip-tekst for label */
+  @property({ type: String }) tooltip = '';
+  @query('.textarea__control') textarea!: HTMLTextAreaElement;
+  private readonly textareaId = `textarea-${++id}`;
 
-  /** Den minste lengden på inndata som vil bli betraktet som gyldig. */
-  @property({ type: Number }) minlength?: number;
+  static styles = [styles, labelStyles];
 
-  /** Maksimal lengde på inndata som vil bli betraktet som gyldig. */
-  @property({ type: Number }) maxlength?: number;
-
-  /** Kontrollerer om og hvordan tekstinnput automatisk blir gjort stor som det blir skrevet inn av brukeren. */
-  @property() autocapitalize: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters' = 'off';
-
-  /** Indikerer om nettleserens autokorrekturfunksjon er på eller av. */
-  // @ts-expect-error - Lit tvinger boolean her, men den er ikke rikitg
-  @property() autocorrect: 'on' | 'off' = 'off';
-
-  /** Indikerer om nettleserens autokorrekturfunksjon er på eller av. */
-  @property() tooltip?: string;
+  protected async firstUpdated(_changedProperties: PropertyValues): Promise<void> {
+    await this.updateComplete;
+    if (this.autofocus) {
+      this.focus();
+    }
+    if (!this.label) {
+      console.warn(
+        'nve-textarea: label is not set. It is recommended to set a label for each component for better accessibility.'
+      );
+    }
+  }
 
   /**
-   * Brukes for å kunne identifisere komponenten i tester
+   * Sender en egendefinert hendelse.
+   * @param name - Navn på hendelsen
+   * @param detail - Detaljer som skal inkluderes i hendelsen
    */
-  @property({ reflect: true, type: String }) testId: string = '';
+  private emitEvent<D>(name: string, detail: D) {
+    this.dispatchEvent(
+      new CustomEvent<D>(name, {
+        detail,
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  //Blur og focus trenger ikke å støtte her siden de sendes fra host elementet.
 
   /**
-   * Forteller nettleseren hvilken type data som vil bli skrevet inn av brukeren, slik at den kan vise det passende virtuelle
-   * tastaturet på støttede enheter.
+   * Sender en 'change' hendelse når verdien i textarea endres og elementet mister fokus. D
+   * etaljene i hendelsen inneholder den nye verdien.
+   * @param e - Event som utløser endringen
    */
-  @property() inputmode?: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
+  private handleChange(e: Event) {
+    const target = e.target as HTMLTextAreaElement;
+    this.emitEvent('change', target.value);
+  }
 
-  /** Antall rader med tekst i textarea-taggen.
-   * Browser-default dersom denne ikke er satt er 2 i alle browsere
-   *
-   * Bestemmer initiell høyde på textarea-boksen
-   * (settes slik at antall rader * font-høyde får plass)
+  /**
+   * Sender en 'select' hendelse når brukeren markerer tekst i textarea.
+   * Detaljene i hendelsen inneholder den markerte teksten.
+   * @param e - Event som utløser markeringen
    */
-  @property() rows?: number;
-
-  /** Bestemmer om feilmelding skal vises når validering feiler  */
-  @state() private showErrorMessage = false;
-
-  /** Om bruker starter å skrive noe i textarea */
-  @state() private touched = false;
-
-  /** Hoved input felt i nve-textarea komponentet. Brukes til constraint validering */
-  // @ts-expect-error - Decorator typing issue with Lit query decorator
-  @query('.textarea__control') input!: HTMLTextAreaElement;
-
-  constructor() {
-    super();
-  }
-  private resizeObserver: ResizeObserver | null = null;
-  firstUpdated() {
-    if (this.requiredLabel) {
-      this.style.setProperty('--textarea-required-content', `"${this.requiredLabel}"`);
-    }
-
-    // Sjekker om data-valid når komponenten først lastes
-    if (this.required) {
-      const isValid = this.input.checkValidity();
-      this.toggleAttribute('data-valid', isValid);
-      this.toggleAttribute('data-invalid', !isValid);
-    }
-
-    // for å endre bredde på label container når textarea endrer størrelse, må vi bruke ResizeObserver.
-    // den observerer endringer i størrelse på textarea og endrer bredden på label container + padding
-    const textarea = this.shadowRoot?.querySelector('.textarea__control');
-    const formControlLabel = this.shadowRoot?.querySelector('.textarea__label') as HTMLElement;
-    if (textarea && formControlLabel) {
-      this.resizeObserver = new ResizeObserver((entries) => {
-        for (const entry of entries) {
-          formControlLabel.style.width = `${entry.contentRect.width + 32}px`;
-        }
-      });
-
-      this.resizeObserver.observe(textarea);
-    }
+  private handleSelect(e: Event) {
+    const target = e.target as HTMLTextAreaElement;
+    this.emitEvent('select', target.value);
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    const formElement = this.closest('form');
-    formElement?.addEventListener('submit', this.handleSubmit.bind(this));
+  // @selectionchange ble ikke støttet i mange nettleseren når koden ble skrevet, derfor er det utelatt.
+
+  /**
+   * Fokuserer textarea når label klikkes. Viktig for tilgjenelighet.
+   */
+  private handleLabelClick() {
+    this.focus();
   }
 
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    const formElement = this.closest('form');
-    formElement?.removeEventListener('submit', this.handleSubmit.bind(this));
-    this.resizeObserver?.disconnect();
-  }
-
-  // kan senere flyttes til utils hvis blir brukt flere steder
-  private emit(eventName: string) {
-    this.dispatchEvent(new CustomEvent(eventName));
-  }
-
-  private handleSubmit(e: SubmitEvent) {
-    e.preventDefault();
-    this.checkValidity();
-  }
-
-  // validerer ikke hvis bruker ikke har tatt på input feltet
-  private handleBlur() {
-    if (this.touched) {
-      this.checkValidity();
-    }
-    this.emit('sl-blur');
-  }
-
-  private handleChange() {
-    this.value = this.input.value;
-    this.emit('sl-change');
-  }
-
-  private handleInput() {
-    this.touched = true;
-    this.value = this.input.value;
-    this.emit('sl-input');
-  }
-
-  /** Sjekker constraint validation og hvis man kjørte setCustomValidity med en melding, checkValidity blir falsk og. Hvis man ikke bruker errorMessage property vil den vise default engelsk tekst istedenfor */
-  private checkValidity() {
-    const isValid = this.input.checkValidity();
-    if (!isValid) {
-      this.makeInvalid();
-    } else {
-      this.resetValidation();
-    }
-  }
-
-  setCustomValidity(message = '') {
-    this.input.setCustomValidity(message);
-    this.checkValidity();
-  }
-
-  private makeInvalid() {
-    this.errorMessage = this.errorMessage || this.input.validationMessage;
-    this.showErrorMessage = true;
-    this.emit('sl-invalid');
-    this.toggleValidationAttributes(false);
-  }
-
-  private resetValidation() {
-    this.showErrorMessage = false;
-    this.toggleValidationAttributes(true);
-  }
-
-  /** Toggler riktig validering attribute for å vise riktig style */
-  private toggleValidationAttributes(isValid: boolean) {
-    this.toggleAttribute('data-valid', isValid);
-    this.toggleAttribute('data-user-valid', isValid);
-    this.toggleAttribute('data-invalid', !isValid);
-    this.toggleAttribute('data-user-invalid', !isValid);
+  /**
+   * Fokuserer textarea-elementet. Kan ta imot valgfri FocusOptions for å spesifisere fokusatferd.
+   * @param options - Valgfri FocusOptions for å spesifisere fokusatferd
+   */
+  focus(options?: FocusOptions) {
+    this.textarea.focus(options);
   }
 
   render() {
-    const hasLabelSlot = !!this.querySelector('[slot="label"]');
-    return html`
-      <div part="form-control" class=${classMap({ 'form-control': true, 'form-control--has-label': this.label })}>
-        ${hasLabelSlot
-          ? html`<slot name="label"></slot>`
-          : this.label
-            ? html`<nve-label
-                id="label"
-                value=${this.label}
-                size="small"
-                tooltip=${ifDefined(this.tooltip)}
-              ></nve-label>`
-            : nothing}
-        ${this.helpText
-          ? html` <div part="help-text-container" class="textarea__help-text__container">
-              <span class="textarea__help-text" aria-hidden=${this.helpText ? 'false' : 'true'}>${this.helpText}</span>
-            </div>`
-          : nothing}
+    const labelId = `${this.id || this.textareaId}`;
+    const helpTextId = `${this.id || this.textareaId}-helptext`;
+    const hintTextId = `${this.id || this.textareaId}-hinttext`;
+    const describedBy = [this.helpText ? helpTextId : '', this.errorMessage || this.hint ? hintTextId : '']
+      .filter(Boolean)
+      .join(' ');
 
-        <div part="base" class="textarea__base">
+    const statusIcon = this.errorMessage ? 'error' : this.disabled ? 'lock' : this.readonly ? 'visibility' : undefined;
+    return html`
+      <div
+        part="field"
+        class=${classMap({
+          field: true,
+          'field--error': !!this.errorMessage,
+          'field--readonly': this.readonly,
+          'field--disabled': this.disabled,
+          'field--filled': this.filled,
+        })}
+      >
+        <!-- Ledetekst -->
+        ${getLabel(labelId, this.label, this.tooltip, this.required, this.requiredLabel, this.handleLabelClick)}
+        <!-- Hjelpetekst -->
+        ${this.helpText
+          ? html`<p part="help-text" class="field__help-text" id=${helpTextId}>${this.helpText}</p>`
+          : nothing}
+        <div
+          part="textarea"
+          class=${classMap({
+            textarea: true,
+          })}
+        >
           <textarea
-            part="textarea"
-            class="textarea__control"
-            title=${this.title /** En tom tittel hindrer nettleserens valideringsverktøy i å vises ved overføring */}
-            name=${ifDefined(this.name)}
-            .value=${live(this.value)}
-            ?disabled=${this.disabled}
+            part="textarea__control"
+            id=${labelId}
+            class=${classMap({
+              textarea__control: true,
+            })}
+            autocapitalize=${ifDefined(this.autocapitalize)}
+            autocomplete=${ifDefined(this.autocomplete)}
+            autocorrect=${ifDefined(this.autocorrect)}
+            maxlength=${ifDefined(this.maxLength)}
+            placeholder=${ifDefined(this.placeholder)}
             ?readonly=${this.readonly}
             ?required=${this.required}
-            placeholder=${ifDefined(this.placeholder)}
-            minlength=${ifDefined(this.minlength)}
-            maxlength=${ifDefined(this.maxlength)}
-            autocapitalize=${ifDefined(this.autocapitalize)}
-            autocorrect=${ifDefined(this.autocorrect)}
-            ?autofocus=${this.autofocus}
-            inputmode=${ifDefined(this.inputmode)}
-            aria-describedby="help-text"
-            rows=${ifDefined(this.rows && this.rows >= 3 ? this.rows : 3)}
+            rows=${this.rows || 2}
+            spellcheck=${ifDefined(this.spellcheck)}
             @change=${this.handleChange}
-            @input=${this.handleInput}
-            @blur=${this.handleBlur}
+            ?disabled=${this.disabled}
+            @select=${this.handleSelect}
+            aria-describedby=${ifDefined(describedBy || undefined)}
+            aria-invalid=${ifDefined(this.errorMessage ? 'true' : undefined)}
+            .value=${this.value || ''}
           ></textarea>
-          <!-- Her kommer litt hokus pokus med å poisjonere ikonen. Det er en ekstra div med posisjon relativt 
-          som skal vises rett etter textarea, og den skal inneholde ikone med position absolute som skal deretter vises inn i textarea.
-          Må gjøres sånn fordi vi vil ikke begrense textarea__base brede til fit-content (da textarea kan aldri ta så mye plass som er 
-          tilgjengelig i nettleseren og man må alltid sette brede på den manuelt. Nei takk.) -->
-          <!-- Foreløpig kan man ha enten 'lock' eller 'error' ikone -->
-          ${this.disabled || this.showErrorMessage
-            ? html`<div class="textarea__icon__container">
-                ${this.disabled ? html`<nve-icon name="lock"></nve-icon>` : null}
-                ${this.showErrorMessage ? html`<nve-icon class="textarea__icon--error" name="error"></nve-icon>` : null}
-              </div>`
+          <!-- Ikoner -->
+          ${statusIcon
+            ? html`<nve-icon class="textarea__control__icon" name=${statusIcon} aria-hidden="true"></nve-icon>`
             : nothing}
         </div>
-        <div part="hint-text-container" class="textarea__hint-text__container">
-          <!-- Ikke vis hint dersom feil -->
-          ${!this.showErrorMessage && this.hint
-            ? html`<span class="textarea__hint" aria-hidden=${this.hint ? 'false' : 'true'}>${this.hint}</span>`
-            : nothing}
-          ${this.showErrorMessage
-            ? html`<span class="textarea__help-text textarea__help-text--error">${this.errorMessage}</span>`
-            : nothing}
-        </div>
+        <!-- Hint-tekst og feilmelding -->
+        ${this.errorMessage || this.hint
+          ? html`<p part="hint-text" class="field__hint-text" id=${hintTextId}>${this.errorMessage || this.hint}</p>`
+          : nothing}
       </div>
     `;
   }

--- a/src/components/nve-textarea/nve-textarea.styles.ts
+++ b/src/components/nve-textarea/nve-textarea.styles.ts
@@ -2,115 +2,119 @@ import { css } from 'lit';
 
 export default css`
   :host {
-    display: flex;
-    --textarea-required-content: '*Obligatorisk';
+    --icon: 18px;
+    --textarea-max-width: 100%;
+    --textarea-min-height: calc(var(--spacing-small) * 2 + var(--icon));
+    width: 100%;
   }
 
-  .form-control {
+  .field {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-x-small);
+    box-sizing: border-box;
     width: 100%;
+    --_color: var(--color-neutrals-foreground-primary);
+    --_border-color: var(--color-interactive-border-secondary-enabled);
+    --_background-color: var(--color-neutrals-background-primary);
+    color: var(--_color);
   }
 
-  .textarea__base {
-    display: flex;
+  .field--disabled {
+    --_color: var(--color-interactive-background-primary-disabled);
+    --_background-color: var(--color-interactive-background-secondary-disabled);
+    --_border-color: var(--color-interactive-border-secondary-disabled);
+    .textarea,
+    .textarea__control {
+      cursor: not-allowed;
+    }
+    .textarea nve-icon {
+      color: var(--color-neutrals-foreground-subtle);
+    }
+  }
+
+  .field--readonly {
+    --_color: var(--color-neutrals-foreground-subtle);
+    --_background-color: var(--color-neutrals-background-secondary);
+    --_border-color: transparent;
+  }
+
+  .field--error {
+    border-left: var(--border-width-strong) solid var(--color-feedback-border-emphasized-error);
+    padding-left: var(--spacing-x-small);
+    --_border-color: var(--color-feedback-border-emphasized-error);
+    .field__hint-text,
+    .textarea nve-icon {
+      color: var(--color-feedback-foreground-error);
+    }
+  }
+
+  .field--filled {
+    --_background-color: var(--color-neutrals-background-primary-contrast);
+    --_border-color: var(--color-interactive-border-tertiary-enabled);
+  }
+
+  .field__hint-text {
+    margin: 0;
+    color: var(--color-neutrals-foreground-primary);
+    font: var(--typography-detailtext-caption);
+    text-align: start;
+  }
+
+  .field__help-text {
+    margin: 0;
+    margin-top: calc(var(--spacing-2x-small) - var(--spacing-x-small));
+    color: var(--color-neutrals-foreground-subtle);
+    font: var(--typography-detailtext-caption);
+    text-align: start;
+  }
+
+  /* for å inkludere ikoner i textarea, brukes denne wrappen for å endre størrelsen i textarea. 
+  selve textare__controller får ingen resizing. 
+  */
+  .textarea {
+    position: relative;
+    width: 100%;
+    max-width: var(--textarea-max-width);
+    min-height: var(--textarea-min-height);
+    min-width: var(--textarea-min-height);
+    resize: both;
+    overflow: auto;
+    background: var(--_background-color);
+    border-radius: var(--border-radius-small);
+    border: var(--border-width-default) solid var(--_border-color);
+    transition: border-color 0.3s ease;
+    nve-icon {
+      position: absolute;
+      top: var(--spacing-small);
+      right: var(--spacing-x-small);
+      --icon-size: var(--icon);
+    }
+    &:focus-within {
+      outline: var(--border-width-strong, 2px) solid var(--color-interactive-primary-border-focus, #008ffb);
+    }
+  }
+
+  .field:not(.field--readonly):not(.field--disabled) .textarea:hover {
+    --_border-color: var(--color-interactive-border-secondary-hover);
+  }
+
+  .textarea:focus,
+  .textarea:focus-visible {
+    outline: none;
   }
 
   .textarea__control {
-    font: var(--typography-body-small);
-    box-sizing: border-box;
-    padding: var(--sizing-4x-small);
-    padding-right: var(--sizing-2x-small); /** trenger padding for å vise ikone så at teksten ikke dekker den */
-    border-radius: var(--border-radius-small);
-    border: var(--border-width-default, 1px) solid var(--color-neutrals-border-default);
-    min-height: var(--sizing-2x-small);
-    transition: border var(--transition-time) ease-in-out;
     width: 100%;
-    &:hover:not(:disabled) {
-      border-color: var(--color-neutrals-foreground-primary);
-    }
-
-    &:focus-visible {
-      outline: var(--sl-focus-ring);
-      outline-offset: var(--sl-focus-ring-offset);
-    }
-  }
-
-  :host([data-user-invalid]) .textarea__control {
-    border-color: var(--color-feedback-background-emphasized-error);
-  }
-
-  :host([disabled]) .textarea__control {
-    opacity: 0.38;
-    background: var(--color-neutrals-background-primary-contrast);
-  }
-
-  :host([filled]) .textarea__control {
-    background: var(--color-neutrals-background-primary-contrast);
-    border: var(--border-width-default, 1px) solid var(--color-neutrals-border-subtle);
-
-    &:hover:not(:disabled) {
-      border-color: var(--color-neutrals-border-default);
-    }
-  }
-
-  :host([filled][data-user-invalid]) .textarea__control {
-    border-color: var(--color-feedback-background-emphasized-error);
-  }
-
-  :host([readonly]) .textarea__control {
-    background: var(--color-neutrals-background-secondary);
-    color: var(--color-neutrals-foreground-subtle,);
+    height: 100%;
+    font: var(--typography-body-medium);
+    color: var(--_color);
+    font-size: 1rem;
+    display: block;
+    box-sizing: border-box;
+    background-color: transparent;
     border: none;
-  }
-
-  .textarea__label {
-    display: flex;
-    justify-content: space-between;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
-  :host([required]) nve-label::after {
-    content: var(--textarea-required-content);
-    font: var(--typography-label-x-small-light);
-    margin-left: auto;
-    color: var(--color-feedback-background-emphasized-error);
-  }
-
-  .textarea__help-text__container {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .textarea__help-text {
-    font: var(--typography-label-x-small-light);
-    color: var(--sl-input-help-text-color);
-  }
-
-  .textarea__help-text--error {
-    color: var(--color-feedback-background-emphasized-error);
-  }
-
-  .textarea__hint {
-    font: var(--typography-label-x-small-light);
-    color: var(--color-neutrals-foreground-primary);
-  }
-
-  .textarea__icon__container {
-    position: relative; /** trengs for å posisjonere ikonen */
-  }
-
-  .textarea__icon--error {
-    position: absolute;
-    left: -24px;
-    top: 10px;
-    color: var(--color-feedback-background-emphasized-error);
-  }
-
-  nve-label {
-    width: unset;
+    padding: var(--spacing-small);
+    resize: none;
   }
 `;

--- a/src/components/nve-textarea/nve-textarea.test.ts
+++ b/src/components/nve-textarea/nve-textarea.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { fixture, fixtureCleanup } from '@open-wc/testing';
+import { html } from 'lit';
+import NveTextarea from './nve-textarea.component';
+
+if (!customElements.get('nve-textarea')) {
+  customElements.define('nve-textarea', NveTextarea);
+}
+
+describe('nve-textarea', () => {
+  afterAll(() => {
+    fixtureCleanup();
+  });
+
+  it('is attached to the DOM', async () => {
+    const el = await fixture<NveTextarea>(html`<nve-textarea label="Beskriv saken"></nve-textarea>`);
+    expect(document.body.contains(el)).toBe(true);
+  });
+
+  it('associates label "for" with the internal textarea id', async () => {
+    const el = await fixture<NveTextarea>(html`<nve-textarea label="Beskriv saken"></nve-textarea>`);
+    await el.updateComplete;
+
+    const label = el.shadowRoot?.querySelector<HTMLLabelElement>('label.field__label');
+    const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea.textarea__control');
+
+    expect(label).not.toBeNull();
+    expect(textarea).not.toBeNull();
+    expect(textarea?.id).toBeTruthy();
+    expect(label?.getAttribute('for')).toBe(textarea?.id);
+  });
+
+  it('renders helpText and hint text when provided', async () => {
+    const el = await fixture<NveTextarea>(html`
+      <nve-textarea label="Beskriv saken" helpText="Hjelpetekst" hint="Hinttekst"></nve-textarea>
+    `);
+    await el.updateComplete;
+
+    const helpText = el.shadowRoot?.querySelector('.field__help-text');
+    const hintText = el.shadowRoot?.querySelector('.field__hint-text');
+
+    expect(helpText?.textContent?.trim()).toBe('Hjelpetekst');
+    expect(hintText?.textContent?.trim()).toBe('Hinttekst');
+  });
+
+  it('applies error state class, aria-invalid, and shows errorMessage in hint text', async () => {
+    const el = await fixture<NveTextarea>(html`
+      <nve-textarea label="Beskriv saken" hint="Hinttekst" errorMessage="Dette er en feil"></nve-textarea>
+    `);
+    await el.updateComplete;
+
+    const field = el.shadowRoot?.querySelector('.field');
+    const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea.textarea__control');
+    const hintText = el.shadowRoot?.querySelector('.field__hint-text');
+    const icon = el.shadowRoot?.querySelector('nve-icon');
+
+    expect(field?.classList.contains('field--error')).toBe(true);
+    expect(textarea?.getAttribute('aria-invalid')).toBe('true');
+    expect(hintText?.textContent?.trim()).toBe('Dette er en feil');
+    expect(icon?.getAttribute('name')).toBe('error');
+  });
+
+  it('toggles modifier classes from properties (filled, disabled, readonly)', async () => {
+    const el = await fixture<NveTextarea>(html`<nve-textarea label="Beskriv saken"></nve-textarea>`);
+    await el.updateComplete;
+
+    el.filled = true;
+    el.disabled = true;
+    el.readonly = true;
+    await el.updateComplete;
+
+    const field = el.shadowRoot?.querySelector('.field');
+    const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea.textarea__control');
+
+    expect(field?.classList.contains('field--filled')).toBe(true);
+    expect(field?.classList.contains('field--disabled')).toBe(true);
+    expect(field?.classList.contains('field--readonly')).toBe(true);
+    expect(textarea?.disabled).toBe(true);
+    expect(textarea?.readOnly).toBe(true);
+  });
+
+  it('uses visibility icon when readonly and not disabled/error', async () => {
+    const el = await fixture<NveTextarea>(html`<nve-textarea label="Beskriv saken" readonly></nve-textarea>`);
+    await el.updateComplete;
+
+    const icon = el.shadowRoot?.querySelector('nve-icon');
+    expect(icon?.getAttribute('name')).toBe('visibility');
+  });
+
+  it('uses lock icon when disabled and not readonly/error', async () => {
+    const el = await fixture<NveTextarea>(html`<nve-textarea label="Beskriv saken" disabled></nve-textarea>`);
+    await el.updateComplete;
+
+    const icon = el.shadowRoot?.querySelector('nve-icon');
+    expect(icon?.getAttribute('name')).toBe('lock');
+  });
+
+  it('sets default rows to 2 and respects rows property', async () => {
+    const el = await fixture<NveTextarea>(html`<nve-textarea label="Beskriv saken" rows=${5}></nve-textarea>`);
+    await el.updateComplete;
+    const textareaRows = el.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea.textarea__control');
+    expect(textareaRows?.rows).toBe('5');
+  });
+
+  it('builds aria-describedby as a space-separated list of existing ids', async () => {
+    const el = await fixture<NveTextarea>(html`
+      <nve-textarea label="Beskriv saken" helpText="Hjelpetekst" hint="Hinttekst"></nve-textarea>
+    `);
+    await el.updateComplete;
+
+    const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea.textarea__control');
+    expect(textarea).not.toBeNull();
+
+    const describedBy = textarea?.getAttribute('aria-describedby') ?? '';
+    const tokens = describedBy.split(/\s+/).filter(Boolean);
+
+    expect(describedBy.includes(',')).toBe(false);
+    expect(tokens.length).toBe(2);
+    for (const token of tokens) {
+      const node = el.shadowRoot?.getElementById(token);
+      expect(node).not.toBeNull();
+    }
+  });
+
+  it('emits a custom change event with the textarea value as detail', async () => {
+    const el = await fixture<NveTextarea>(html`<nve-textarea label="Beskriv saken"></nve-textarea>`);
+    await el.updateComplete;
+
+    const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea.textarea__control');
+    expect(textarea).not.toBeNull();
+
+    const eventPromise = new Promise<CustomEvent<string>>((resolve) => {
+      el.addEventListener(
+        'change',
+        (event) => {
+          resolve(event as CustomEvent<string>);
+        },
+        { once: true }
+      );
+    });
+
+    textarea!.value = 'Ny verdi';
+    textarea!.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+
+    const event = await eventPromise;
+    expect(event.detail).toBe('Ny verdi');
+  });
+});

--- a/src/templates/label.ts
+++ b/src/templates/label.ts
@@ -72,6 +72,6 @@ export function getLabel(
   `;
 
   return useLegend
-    ? html`<legend class="field__legend" id="${id}" @click=${onClick}>${content}</legend>`
-    : html`<label class="field__label" id="${id}" @click=${onClick}>${content}</label>`;
+    ? html`<legend class="field__legend" @click=${onClick}>${content}</legend>`
+    : html`<label class="field__label" for="${id}" @click=${onClick}>${content}</label>`;
 }


### PR DESCRIPTION
PR på textarea-komponenten. Den er ikke veldig annerledes – den bruker bare samme struktur som de andre skjemakomponentene. Jeg tenker å lage en dispatchEvent-metode i utils.ts senere. Jeg vil først isolere dispatchEvent-metodene litt for å se om parameterne blir veldig forskjellige osv.

Jeg la også til støtte for [select](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event)-hendelsen. Jeg testet [selectionchange](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/selectionchange_event), men det skjedde ingenting, så jeg antar at den ikke er fullt støttet overalt.

Validering or errorMessage variant kommer senere.

Jeg ser at det tidligere ble brukt `hint` på textarea, og ikke `hintText`, så jeg tenker å endre `hintText` til bare `hint` på de andre komponentene også. Dette kan fortsatt justeres hvis vi synes `hintText` er bedre.

Jeg merket også at getLabel returnerte en ledetekst uten for-attributtet, noe som gjorde at ledeteksten ikke ble lest riktig når man fokuserte textarea-feltet.