### PR TITLE
feat(nve-checkbox): oppdatere sjekkbokser og sjekkboks gruppen

### DIFF
--- a/doc-site/components/nve-checkbox-group.md
+++ b/doc-site/components/nve-checkbox-group.md
@@ -1,125 +1,222 @@
 ---
 layout: component
+outline: [2, 3]
 ---
 
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Vennligst velg 1 og/eller 2">
-  <nve-checkbox>1</nve-checkbox>
-  <nve-checkbox>2</nve-checkbox>
+<nve-checkbox-group label="Hvilker varsler vil du se på?">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
 </nve-checkbox-group>
 ```
 
 </CodeExamplePreview>
+
+Bruk <span class="highlight">nve-checkbox-group</span> med <a href="./nve-checkbox">nve-checkbox</a> når brukeren skal kunne velge flere alternativer.
+Hvis brukeren bare skal kunne velge ett alternativ, bruk <a href="./nve-radio-group">nve-radio-group</a> i stedet. Med veldi mange
+alternativer vurder å bruke <a href="./nve-combobox">nve-combobox</a>.
+
+Hver <span class="highlight">nve-checkbox</span> i gruppen bør ha <span class="highlight">value</span>. Når et valg markeres eller fjernes, trigges <span class="highlight">change</span>-hendelsen, og verdien fra den aktuelle checkboksen returneres i hendelsen sammen med handlingen som er utført (<span class="highlight">select</span> eller <span class="highlight">deselect</span>).
+
+Hendelsestype kan importers ved:
+
+```js
+import type { NveCheckboxGroupChangeEvent } from 'nve-designsystem/components/nve-checkbox-group/nve-checkbox-group.component.js';
+```
+
+Den returnerer:
+
+```js
+type NveCheckboxGroupChangeEvent<T> = {
+  value: string;
+  action: 'select' | 'deselect';
+}
+```
+
+## Retningslinjer
+
+- Gi alltid feltet en tydelig <span class="highlight">label</span>.
+- Bruk <span class="highlight">disabled</span> med omhu. Deaktiverte felt kan ikke fokuseres og kan derfor være vanskeligere å oppdage med tastatur/skjermleser.
+- Gi hver sjekkboks en unik og stabil <span class="highlight">value</span> i gruppen, slik at <span class="highlight">change</span>-hendelsen alltid kan tolkes riktig.
+- Bruk tydelige og korte etiketter per valg, så brukeren raskt forstår forskjellen mellom alternativene.
+- Bruk vertikal visning når du har mange valg eller lange etiketter, for bedre lesbarhet.
 
 ## Eksempler
 
+### Ledetekst og tooltip
+
+Bruk <span class="highlight">label</span> for å vise en tydelig ledetekst for feltet. Attributtet er påkrevd – hvert skjemafelt skal ha en ledetekst som skjermlesere kan bruke for å forstå hva feltet gjelder.
+
+Bruk i tillegg <span class="highlight">tooltip</span> for å vise utfyllende informasjon ved ledeteksten. Innholdet kan være ren tekst eller HTML, for eksempel lenker eller formattert hjelpetekst.
+
+<CodeExamplePreview>
+
+```html
+<nve-checkbox-group label="Hvilker varsler vil du se på?" tooltip="Gjelder varslene som vises i kart">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
+</nve-checkbox-group>
+```
+
+</CodeExamplePreview>
+
+### Påkrevd
+
+Bruk <span class="highlight">required</span> for å vise et stjernesymbol på slutten av ledeteksten som markerer at feltet er påkrevd.  
+Bruk i tillegg <span class="highlight">requiredLabel</span> for å vise en forklarende tekst sammen med stjernen (for eksempel 'obligatorisk'). Dette gir brukerne en bedre forståelse av at feltet er påkrevd, siden ikke alle brukere forstår eller oppfatter stjernesymbolet alene.
+
+<CodeExamplePreview>
+
+```html
+<nve-checkbox-group label="Hvilker varsler vil du se på?" required requiredLabel="Obligatorisk">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
+</nve-checkbox-group>
+```
+
+</CodeExamplePreview>
+
 ### Retning
 
-Bruk `orientation` for å velge retning. `vertical` er standard.
+Bruk <span class="highlight">orientation</span> for å velge retning:
+
+- <span class="highlight">vertical</span> er standard og viser sjekkboksene under hverandre.
+- <span class="highlight">horizontal</span> viser sjekkboksene ved siden av hverandre.
 
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="vertical">
-  <nve-checkbox>1</nve-checkbox>
-  <nve-checkbox>2</nve-checkbox>
+<nve-checkbox-group label="Hvilker varsler vil du se på (vertical)?">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
 </nve-checkbox-group>
-<nve-checkbox-group label="horizontal" orientation="horizontal">
-  <nve-checkbox>1</nve-checkbox>
-  <nve-checkbox>2</nve-checkbox>
+
+<nve-checkbox-group label="Hvilker varsler vil du se på (horizontal)?" orientation="horizontal">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
 </nve-checkbox-group>
 ```
 
 </CodeExamplePreview>
 
-### Valgte verdier
+### Størrelse
 
-`selectedValues` gir deg en liste av valgte avkrysningsbokser sin `value`
+Størrelsen kan styres på gruppenivå. Bruk <span class="highlight">size</span> for å velge størrelse:
 
-<SandboxPreview>
-
-```
-<template>
-  <nve-checkbox-group label="Vennligst velg 1 eller 2" :selectedValues="result">
-    <nve-checkbox value="value1">1</nve-checkbox>
-    <nve-checkbox value="value2">2</nve-checkbox>
-  </nve-checkbox-group>
-  Du har valgt: {{ result }}
-</template>
-
-<script setup lang="ts">
-import 'nve-designsystem/components/nve-checkbox-group/nve-checkbox-group.component.js';
-import 'nve-designsystem/components/nve-checkbox/nve-checkbox.component.js';
-import { ref } from 'vue';
-
-const result = ref<string[]>([]);
-</script>
-```
-
-</SandboxPreview>
-
-### Hjelpetekst
-
-Bruk `tooltip` for å legge til et info-ikon etter ledetekst. Ikonet vises ikke hvis ikke `label` er satt.
+- <span class="highlight">small</span>
+- <span class="highlight">medium</span> - er standard
+- <span class="highlight">large</span>
 
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Svev over ikonet for å se hjelpeteksten" tooltip="Hjelpetekst">
-  <nve-checkbox>1</nve-checkbox>
-  <nve-checkbox>2</nve-checkbox>
+<nve-checkbox-group label="Hvilker varsler vil du se på (small)?" size="small">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
+</nve-checkbox-group>
+
+<nve-checkbox-group label="Hvilker varsler vil du se på (medium)?">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
+</nve-checkbox-group>
+
+<nve-checkbox-group label="Hvilker varsler vil du se på (large)?" size="large">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
 </nve-checkbox-group>
 ```
 
 </CodeExamplePreview>
 
-### Deaktivering
+### Hjelptekst
 
-Bruk `disabled` for å deaktivere hele gruppa.
+Bruk <span class="highlight">helpText</span> for å vise hjelpetekst over feltet.
 
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="disabled" disabled>
-  <nve-checkbox>1</nve-checkbox>
-  <nve-checkbox>2</nve-checkbox>
-</nve-checkbox-group>
-
-<nve-checkbox-group label="enabled">
-  <nve-checkbox>1</nve-checkbox>
-  <nve-checkbox>2</nve-checkbox>
+<nve-checkbox-group label="Hvilker varsler vil du se på?" helpText="Ditt valg påvirker mange!">
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
 </nve-checkbox-group>
 ```
 
 </CodeExamplePreview>
 
-### Obligatorisk
+### Hint
 
-Bruk `required` for å tvinge bruker til å velge minst ett av valgene i gruppa og legg inn en feilmelding i `errorMessage`.
-Bruk `requiredlabel` hvis du vil vise noe annet enn `*Obligatorisk`. Gruppa må ligge i en `<form>` for at validering skal funke.
+Bruk <span class="highlight">hintText</span> for å vise hint-tekst under feltet.
 
-<CodeExamplePreview arrangeComponentsVertically>
+<CodeExamplePreview>
 
 ```html
-<!-- Bruker preventDefault så ikke sida lastes på nytt når du trykker på knappen -->
-<form onsubmit="event.preventDefault();">
-  <nve-checkbox-group label="Her må du velge noe" required errorMessage="Velg minst en">
-    <nve-checkbox>1</nve-checkbox>
-    <nve-checkbox>2</nve-checkbox>
-  </nve-checkbox-group>
-  <nve-checkbox-group
-    label="Please choose at least one"
-    required
-    requiredLabel="*Required"
-    errorMessage="Please choose at least one"
-  >
-    <nve-checkbox>1</nve-checkbox>
-    <nve-checkbox>2</nve-checkbox>
-  </nve-checkbox-group>
-  <nve-button type="submit">Submit</nve-button>
-</form>
+<nve-checkbox-group
+  label="Hvilker varsler vil du se på?"
+  hint="Velg smart. Det finnes ingen vei tilbake fra dårlige valg."
+>
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
+</nve-checkbox-group>
 ```
 
 </CodeExamplePreview>
+
+### Deaktivert
+
+<nve-message-card variant="warning" label="Obs!" size="compact">
+  <p>
+    Et deaktivert felt (<span class="highlight">disabled</span>) kan ikke få fokus og blir derfor ofte ikke oppdaget av
+    brukere som navigerer med tastatur eller skjermleser. Bruk <span class="highlight">disabled</span> med omhu, og vurder
+    å gi en tydelig forklaring i tekst på hvorfor feltet er deaktivert.
+  </p>
+</nve-message-card>
+
+Bruk attributtet <span class="highlight">disabled</span> for å hindre at verdien kan endres i hele gruppen. For å deaktivere enkelte sjekkbokser, bruk <span class="highlight">disabled</span> direkte på dem.
+
+<CodeExamplePreview>
+
+```html
+<nve-checkbox-group label="Hvilker varsler vil du se på?" disabled>
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
+</nve-checkbox-group>
+```
+
+</CodeExamplePreview>
+
+### Forhåndsvalgte verdier
+
+Bruk <span class="highlight">selectedValues</span>-array for å vise forhåndsvalgt verdier. Verdier må samsvare med <span class="highlight">value</span>-attributtet til en av <span class="highlight">nve-checkbox</span>-komponentene i gruppen.
+
+<CodeExamplePreview>
+
+```html
+<nve-checkbox-group label="Hvilker varsler vil du se på?" selectedValues='["flood", "landslide"]'>
+  <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+  <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
+  <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
+</nve-checkbox-group>
+```
+
+</CodeExamplePreview>
+
+## Tilgjengelighet
+
+<span class="highlight">nve-checkbox-group</span> bruker en tilknyttet <a href="#ledetekst-og-tooltip">ledetekst</a>. Når feltet får fokus vil skjermlesere lese opp ledeteksten, slik at brukeren forstår hva som skal fylles inn.
+
+I tillegg brukes <span class="highlight">aria-describedby</span> for å knytte supplerende tekst til feltet. Når <span class="highlight">helpText</span>, <span class="highlight">hint</span> eller <span class="highlight">errorMessage</span> er satt vil skjermlesere normalt lese dem opp i forbindelse med fokus på feltet. (VoiceOver i Safari på macOS kan slite litt med aria-describedby og ikke lese den).
+
+Brukere kan navigere gjennom sjekkboksene i gruppen ved å trykke <span class="highlight">Tab</span> for å fokusere hver sjekkboks. Når en sjekkboks har fokus, brukes <span class="highlight">Space</span>-tasten til å velge eller fjerne valget.

--- a/doc-site/components/nve-checkbox-group.md
+++ b/doc-site/components/nve-checkbox-group.md
@@ -6,7 +6,7 @@ outline: [2, 3]
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Hvilker varsler vil du se på?">
+<nve-checkbox-group label="Hvilke varsler vil du se på?">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
@@ -16,10 +16,10 @@ outline: [2, 3]
 </CodeExamplePreview>
 
 Bruk <span class="highlight">nve-checkbox-group</span> med <a href="./nve-checkbox">nve-checkbox</a> når brukeren skal kunne velge flere alternativer.
-Hvis brukeren bare skal kunne velge ett alternativ, bruk <a href="./nve-radio-group">nve-radio-group</a> i stedet. Med veldi mange
+Hvis brukeren bare skal kunne velge ett alternativ, bruk <a href="./nve-radio-group">nve-radio-group</a> i stedet. Ved mange
 alternativer vurder å bruke <a href="./nve-combobox">nve-combobox</a>.
 
-Hver <span class="highlight">nve-checkbox</span> i gruppen bør ha <span class="highlight">value</span>. Når et valg markeres eller fjernes, trigges <span class="highlight">change</span>-hendelsen, og verdien fra den aktuelle checkboksen returneres i hendelsen sammen med handlingen som er utført (<span class="highlight">select</span> eller <span class="highlight">deselect</span>).
+Hver <span class="highlight">nve-checkbox</span> i gruppen bør ha <span class="highlight">value</span>. Når et valg markeres eller fjernes, trigges <span class="highlight">change</span>-hendelsen, og verdien fra den aktuelle sjekkboksen returneres i hendelsen sammen med handlingen som er utført (<span class="highlight">select</span> eller <span class="highlight">deselect</span>).
 
 Hendelsestype kan importers ved:
 
@@ -55,7 +55,7 @@ Bruk i tillegg <span class="highlight">tooltip</span> for å vise utfyllende inf
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Hvilker varsler vil du se på?" tooltip="Gjelder varslene som vises i kart">
+<nve-checkbox-group label="Hvilke varsler vil du se på?" tooltip="Gjelder varslene som vises i kart">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
@@ -72,7 +72,7 @@ Bruk i tillegg <span class="highlight">requiredLabel</span> for å vise en forkl
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Hvilker varsler vil du se på?" required requiredLabel="Obligatorisk">
+<nve-checkbox-group label="Hvilke varsler vil du se på?" required requiredLabel="Obligatorisk">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
@@ -91,13 +91,13 @@ Bruk <span class="highlight">orientation</span> for å velge retning:
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Hvilker varsler vil du se på (vertical)?">
+<nve-checkbox-group label="Hvilke varsler vil du se på (vertical)?">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
 </nve-checkbox-group>
 
-<nve-checkbox-group label="Hvilker varsler vil du se på (horizontal)?" orientation="horizontal">
+<nve-checkbox-group label="Hvilke varsler vil du se på (horizontal)?" orientation="horizontal">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
@@ -117,19 +117,19 @@ Størrelsen kan styres på gruppenivå. Bruk <span class="highlight">size</span>
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Hvilker varsler vil du se på (small)?" size="small">
+<nve-checkbox-group label="Hvilke varsler vil du se på (small)?" size="small">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
 </nve-checkbox-group>
 
-<nve-checkbox-group label="Hvilker varsler vil du se på (medium)?">
+<nve-checkbox-group label="Hvilke varsler vil du se på (medium)?">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
 </nve-checkbox-group>
 
-<nve-checkbox-group label="Hvilker varsler vil du se på (large)?" size="large">
+<nve-checkbox-group label="Hvilke varsler vil du se på (large)?" size="large">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
@@ -138,14 +138,14 @@ Størrelsen kan styres på gruppenivå. Bruk <span class="highlight">size</span>
 
 </CodeExamplePreview>
 
-### Hjelptekst
+### Hjelpetekst
 
 Bruk <span class="highlight">helpText</span> for å vise hjelpetekst over feltet.
 
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Hvilker varsler vil du se på?" helpText="Ditt valg påvirker mange!">
+<nve-checkbox-group label="Hvilke varsler vil du se på?" helpText="Ditt valg påvirker mange!">
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
@@ -162,7 +162,7 @@ Bruk <span class="highlight">hintText</span> for å vise hint-tekst under feltet
 
 ```html
 <nve-checkbox-group
-  label="Hvilker varsler vil du se på?"
+  label="Hvilke varsler vil du se på?"
   hint="Velg smart. Det finnes ingen vei tilbake fra dårlige valg."
 >
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
@@ -188,7 +188,7 @@ Bruk attributtet <span class="highlight">disabled</span> for å hindre at verdie
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Hvilker varsler vil du se på?" disabled>
+<nve-checkbox-group label="Hvilke varsler vil du se på?" disabled>
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>
@@ -204,7 +204,7 @@ Bruk <span class="highlight">selectedValues</span>-array for å vise forhåndsva
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox-group label="Hvilker varsler vil du se på?" selectedValues='["flood", "landslide"]'>
+<nve-checkbox-group label="Hvilke varsler vil du se på?" selectedValues='["flood", "landslide"]'>
   <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
   <nve-checkbox value="landslide">Jordskredvarsel</nve-checkbox>
   <nve-checkbox value="rain">Regnvarsel</nve-checkbox>

--- a/doc-site/components/nve-checkbox.md
+++ b/doc-site/components/nve-checkbox.md
@@ -114,4 +114,12 @@ Når den overordnede sjekkboksen klikkes, skal den enten velge alle eller fjerne
 
 </CodeExamplePreview>
 
-### Accessibility
+## Tilgjengelighet
+
+Når en bruker tabber til sjekkboksen og trykker Space, toggles den valgte tilstanden.
+
+Komponenten bruker et <span class="highlight">&lt;label&gt;</span> -element som wraper både input og tekst, så både det visuelle feltet og teksten er klikkebare.
+
+<span class="highlight">Indeterminate</span>-tilstanden vises visuelt, men Screen readers vil normalt annonsere den som en valgbar tilstand.
+
+<span class="highlight">required</span> er bare tilgjengelig på <a href="./nve-checkbox-group.md">nve-checkbox-group</a>, ikke på individuelle sjekkbokser.

--- a/doc-site/components/nve-checkbox.md
+++ b/doc-site/components/nve-checkbox.md
@@ -1,52 +1,117 @@
 ---
 layout: component
+outline: [2, 3]
 ---
 
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox>Ja, jeg vil!</nve-checkbox>
+<nve-checkbox value="showDocs">Vis dokumenter</nve-checkbox>
 ```
 
 </CodeExamplePreview>
+
+<nve-message-card variant="primary" label="Native sjekkboks-attributter" size="compact">
+  <p>
+    <span class="highlight">nve-checkbox</span> bygger på et native <span class="highlight">&lt;input&gt;</span>-element
+    med type <span class="highlight">checkbox</span> og støtter derfor de fleste vanlige input-attributter som passer med checkbox:  </p>
+    <ul>
+      <li><span class="highlight">checked</span></li>
+      <li><span class="highlight">disabled</span></li>
+      <li><span class="highlight">value</span></li>
+    </ul>
+<br>
+ <p>
+  Komponenten videresender relevante hendelser fra det interne input-elementet slik at de kan lyttes til utenfor komponentens Shadow DOM.
+</p>
+
+<ul>
+  <li>
+    <span class="highlight">change</span> – sendes når valgt verdi endres.
+  </li>
+</ul>
+<br>
+  <p>
+    Noen native attributter er bevisst ikke støttet:
+  </p>
+  <ul>
+    <li><span class="highlight">form</span> og <span class="highlight">name</span> – komponenten er ikke laget for native form submission.</li>
+    <li><span class="highlight">required</span> – ikke støttet på enkelte sjekkbokser, den støttes kun i <a href="./nve-checkbox-group.md">nve-checkbox-group</a></li>
+     <li><span class="highlight">switch</span> – ny attributt som ikke er støttet i alle nettleserne enda. Vi har vår egen <a href="./nve-switch.md">nve-switch</a> komponent som vi anbefaler å bruke i stedet. </li>
+  </ul>
+</nve-message-card>
+
+## Retningslinjer
+
+- Gi alltid feltet en tydelig <span class="highlight">label</span> og <span class="highlight">value</span>.
+- Bruk <span class="highlight">indeterminate</span>-propertyen bare for en overordnet sjekkboks (med flere sjekkbokser under), og kun når noen av barna er valgt.
+- Bruk sjekkboks når valget skal få effekt med én gang. Hvis avhuking utløser en asynkron operasjon, ikke vent med å oppdatere <span class="highlight">checked</span> til etter await – gi umiddelbar tilbakemelding og rull tilbake ved feil.
 
 ## Eksempler
 
-### Ledetekst
-
-Teksten på høyre side kan legges inni `nve-checkbox`.
-
-<CodeExamplePreview>
-
-```html
-<nve-checkbox>Ledetekst</nve-checkbox>
-```
-
-</CodeExamplePreview>
-
 ### Checked
 
-`checked` er satt hvis boksen er krysset av og motsatt.
-Bruk `indeterminate` for å vise at man ikke har tatt stilling ennå.
+Bruk <span class="highlight">checked</span> for å vise at boksen er valgt.
 
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox checked>checked</nve-checkbox>
-<nve-checkbox>unchecked</nve-checkbox>
-<nve-checkbox indeterminate>indeterminate</nve-checkbox>
+<nve-checkbox checked value="showDocs">Vis dokumenter</nve-checkbox>
 ```
 
 </CodeExamplePreview>
 
-### Disabled
+### Størrelse
 
-Bruk `disabled` for å deaktivere boksen.
+Bruk <span class="highlight">size</span> for å endre størrelsen på en sjekkboks. Verdien kan være:
+
+- <span class="highlight">large</span>
+- <span class="highlight">medium</span> (standard)
+- <span class="highlight">small</span>
 
 <CodeExamplePreview>
 
 ```html
-<nve-checkbox disabled>Disabled</nve-checkbox> <nve-checkbox>Enabled</nve-checkbox>
+<nve-checkbox size="small" value="showDocs">Vis dokumenter (small)</nve-checkbox>
+<nve-checkbox value="showDocs">Vis dokumenter (medium)</nve-checkbox>
+<nve-checkbox size="large" value="showDocs">Vis dokumenter (large)</nve-checkbox>
 ```
 
 </CodeExamplePreview>
+
+### Deaktivert
+
+<nve-message-card variant="warning" label="Obs!" size="compact">
+  <p>
+    Et deaktivert felt (<span class="highlight">disabled</span>) kan ikke få fokus og blir derfor ofte ikke oppdaget av
+    brukere som navigerer med tastatur eller skjermleser. Bruk <span class="highlight">disabled</span> med omhu, og vurder
+    å gi en tydelig forklaring i tekst på hvorfor feltet er deaktivert.
+  </p>
+</nve-message-card>
+
+Bruk attributtet <span class="highlight">disabled</span> for å hindre muligheten for å endre et verdi.
+
+<CodeExamplePreview>
+
+```html
+<nve-checkbox disabled value="showDocs">Vis dokumenter</nve-checkbox>
+```
+
+</CodeExamplePreview>
+
+### Indeterminate
+
+Bruk <span class="highlight">indeterminate</span> når en overordnet sjekkboks representerer en gruppe der bare noen av valgene er krysset av.
+Tilstanden betyr delvis valgt, ikke ja eller nei.
+
+Når den overordnede sjekkboksen klikkes, skal den enten velge alle eller fjerne alle underliggende sjekkbokser.
+
+<CodeExamplePreview>
+
+```html
+<nve-checkbox indeterminate value="showDocs">Vis dokumenter</nve-checkbox>
+```
+
+</CodeExamplePreview>
+
+### Accessibility

--- a/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.component.ts
@@ -1,204 +1,169 @@
-import { html, LitElement, nothing } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
-import '../nve-label/nve-label.component';
+import { html, LitElement, nothing, PropertyValues } from 'lit';
+import { customElement, property, queryAssignedElements, state } from 'lit/decorators.js';
+import { INveComponent } from '@interfaces/NveComponent.interface';
 import styles from './nve-checkbox-group.styles';
-import toggleBooleanAttrOnListOfNodes from '../../utils/updateInvalidProperty';
-import deepCompare from '../../utils/deepCompare';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { classMap } from 'lit/directives/class-map.js';
+import NveCheckbox from '../nve-checkbox/nve-checkbox.component';
+import { getLabel, labelStyles } from '../../templates/label';
 
+let id = 0;
+
+type NveCheckboxGroupChangeEvent = {
+  value: string;
+  action: 'select' | 'deselect';
+};
 /**
- * Bruk denne for å håndtere flere avkrysningsbokser (nve-checkbox) som hører sammen.
- * selectedValues inneholder `value` til hver av avkrysningsboksene som er valgt i gruppa.
- * Gruppa oppdaterer seg automatisk når man klikker på en avkrysningsboks.
- * Støtter både constraint validation (kun `required`) og tilpasset validering.
- * Tilpasset validering prioriteres foran `required`.
- * @slot default - legg avkrysningsboksene inni denne.
- * */
+ * En gruppe med sjekkbokser som lar brukeren velge flere alternativer.
+ *
+ * @slot - Her plasseres nve-checkbox elementer som skal være en del av gruppen.
+ *
+ * @event change - når en sjekkboks i gruppen endres, sender ut en event med informasjon om hvilken verdi som ble endret og om den ble valgt eller fjernet.
+ *
+ * @csspart base - fieldset elementet som omslutter hele gruppen
+ * @csspart checkbox-group - div elementet som omslutter slottet med sjekkboksene
+ * @csspart help-text - p elementet som viser hjelpetekst, hvis satt
+ * @csspart hint-text - p elementet som viser hint-tekst eller feilmelding, hvis satt
+ */
 @customElement('nve-checkbox-group')
-export default class NveCheckboxGroup extends LitElement {
-  constructor() {
-    super();
-  }
-
-  /** Deaktiverer alle sjekkbokser hvis 'true' */
-  @property({ type: Boolean, reflect: true }) disabled = false;
-  /** Om minst en sjekkboks er sjekket på */
-  @property({ type: Boolean, reflect: true }) required = false;
+export default class NveCheckboxGroup extends LitElement implements INveComponent {
+  @property({ type: String }) testId: string | undefined = undefined;
+  /** Om sjekkboks-gruppen er deaktivert */
+  @property({ type: Boolean }) disabled = false;
+  /** Feilmelding som vises ved valideringsfeil. Hvis den er satt blir input-felt ugyldig og feil melding vises.*/
+  @property({ type: String, reflect: true }) errorMessage: string | undefined = undefined;
+  /** Hjelpetekst som vises over feltet */
+  @property({ type: String, reflect: true }) helpText = '';
+  /** Hint-tekst som vises under feltet */
+  @property({ type: String, reflect: true }) hint = '';
   /** Ledetekst */
   @property() label?: string;
-  /** Viser i-ikon og hjelpetekst ved siden av label. Du må ha en label for å bruke denne. */
-  @property() tooltip?: string;
   /** Om gruppa skal vises horisontalt eller vertikalt */
   @property({ type: String, reflect: true }) orientation: 'horizontal' | 'vertical' = 'vertical';
-  /** Feilmelding som vises under gruppe hvis validering feiler */
-  @property() errorMessage?: string;
+  /** Om minst en sjekkboks er sjekket på */
+  @property({ type: Boolean, reflect: true }) required = false;
   /** Tekst som vises for å markere at et felt er obligatorisk */
-  @property() requiredLabel = '*Obligatorisk';
-  /** Returnerer en tabell av value-attributet til alle sjekkbokser som er valgt. Man kan lagre både primitiver og objekter i selectedValues. */
-  @property({ type: Array }) selectedValues?: string[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  @query('slot') slot: any;
-  /** Bestemmer om feilmelding skal vises når validering feiler  */
-  @state() protected showErrorMessage = false;
-  /** Status for tilpasset validering. Den trengs for å kunne kjøre både constraint- og tilpasset validering samtidig. */
-  @state() protected isCustomValidationError = false;
+  @property() requiredLabel = '';
+  /** Initialt valgte verdier */
+  @property({ type: Array }) selectedValues: string[] = [];
+  /** Størrelse på sjekkboksene */
+  @property({ type: String }) size: 'small' | 'medium' | 'large' = 'medium';
+  /** Tooltip-tekst for label */
+  @property({ type: String }) tooltip = '';
+  /** Internt sporet valgte verdier. Brukes til validering, eksponeres ikke. */
+  @state() _selectedValues: string[] = [];
 
-  static styles = [styles];
+  @queryAssignedElements({ selector: 'nve-checkbox', flatten: true })
+  private checkboxes!: NveCheckbox[];
+  /** @internal */
+  private readonly checkboxGroupId = `checkbox-group-${++id}`;
 
-  connectedCallback() {
-    super.connectedCallback();
-    const formElement = this.closest('form');
-    // Kjører validering når den nærmeste formen trigger submit. Gjelder kun constraint validation.
-    formElement?.addEventListener('submit', this.handleSubmit.bind(this));
-    this.addEventListener('sl-change', this.handleChange.bind(this));
-  }
+  static styles = [styles, labelStyles];
 
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.removeEventListener('sl-change', this.handleChange);
-    this.removeEventListener('submit', this.handleSubmit);
-  }
-
-  protected firstUpdated() {
-    if (this.requiredLabel) {
-      this.style.setProperty('--sl-checkbox-required-content', `"${this.requiredLabel}"`);
-    }
-
-    // sjekker om selectedValues inneholder noe verdi fra starten
-    if (!this.selectedValues?.length) return;
-    const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
-    nveCheckboxes.forEach((ch) => {
-      if (this.selectedValues?.includes(ch.value)) {
-        ch.checked = true;
-      } else {
-        ch.checked = false;
-      }
-    });
-  }
-
-  updated(changedProperties: Map<string | number | symbol, unknown>) {
+  updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
+    if (changedProperties.has('errorMessage')) {
+      this.checkboxes.forEach((checkbox) => {
+        checkbox.invalid = !!this.errorMessage;
+      });
+    }
     if (changedProperties.has('disabled')) {
-      const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
-      toggleBooleanAttrOnListOfNodes(nveCheckboxes, this.disabled, 'disabled');
+      this.checkboxes.forEach((checkbox) => {
+        if (!checkbox.disabled) {
+          checkbox.disabled = this.disabled;
+        }
+      });
     }
   }
 
-  /** En 'fake' metode som gjør custom validering enklere på checkbox-group komponent */
-  setCustomValidity(message = '') {
-    const isValid = message.length ? false : true;
-    if (!isValid) {
-      this.errorMessage = message;
-      this.makeInvalid();
-    } else {
-      this.resetValidation();
+  /**
+   * Trigges når sjekkboksene i slottet endres (eller dukker opp første gang).
+   * Oppdaterer sjekkboksene i gruppen med riktig størrelse og valgte verdier.
+   */
+  private handleSlotChange() {
+    // sett størrelse på sjekkboksene
+    if (this.size !== 'medium') {
+      this.checkboxes.forEach((checkbox) => {
+        checkbox.size = this.size;
+      });
     }
-    this.isCustomValidationError = !isValid;
-    this.toggleValidationAttributes(isValid);
+
+    // når alle sjekkboksene er fullt renderert, oppdaterer vi checked attributtene basert på selectedValues property.
+    requestAnimationFrame(() => {
+      if (this.selectedValues?.length) {
+        for (const checkbox of this.checkboxes) {
+          const ch = checkbox.value !== null && this.selectedValues?.includes(checkbox.value);
+          this._selectedValues.push(checkbox.value);
+          checkbox.checked = ch;
+        }
+      }
+      this.removeAttribute('selectedValues');
+    });
   }
 
-  private handleSubmit(e: SubmitEvent) {
-    e.preventDefault();
-    this.checkValidity();
-  }
-
+  /**
+   * Trigges når en sjekkboks i gruppen endres.
+   * Oppdaterer selectedValues basert på hvilke sjekkbokser som er valgt.
+   * @param e Eventet som trigget endringen.
+   */
   private handleChange(e: Event) {
-    this.updateSelectedValues(e);
-    this.checkValidity();
-  }
-
-  /** Oppdaterer selectedValues property hver gang man endrer noen av sjekkbokser i sjekkboksgruppa.  */
-  private updateSelectedValues = (e: Event) => {
-    const target = e.target as HTMLInputElement;
-    if (target.checked) {
-      if (!this.selectedValues) {
-        this.selectedValues = [];
-      }
-      this.selectedValues.push(target.value);
-    } else if (this.selectedValues) {
-      const indexToRemove = this.selectedValues.findIndex((element) => deepCompare(element, target.value));
-      if (indexToRemove !== -1) {
-        this.selectedValues.splice(indexToRemove, 1);
-      }
-    }
-    this.requestUpdate();
-  };
-
-  /** Sjekker validity basert på constraint validation. Man kan legge til flere properties. */
-  private checkValidity() {
-    if (!this.required) return;
-    // custom validering er prioritert. Hvis den feiler constraint validering via checkValidity kjører ikke.
-    if (this.isCustomValidationError) return;
-    let isValid = true;
-    if (this.required) {
-      isValid = this.checkIfRequiredValid();
-    }
-
-    if (isValid) {
-      this.resetValidation();
+    const value = (e.target as NveCheckbox).value;
+    const checked = (e.target as NveCheckbox).checked;
+    const action = checked ? 'select' : 'deselect';
+    if (checked) {
+      this._selectedValues = [...this._selectedValues, value];
     } else {
-      this.makeInvalid();
+      this._selectedValues = this._selectedValues.filter((v) => v !== value);
     }
-    this.toggleValidationAttributes(isValid);
-  }
-
-  /** Toggler riktig validering attribute for å vise riktig style */
-  private toggleValidationAttributes(isValid: boolean) {
-    this.toggleAttribute('data-valid', isValid);
-    this.toggleAttribute('data-user-valid', isValid);
-    this.toggleAttribute('data-invalid', !isValid);
-    this.toggleAttribute('data-user-invalid', !isValid);
-  }
-
-  private resetValidation() {
-    const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
-    nveCheckboxes.forEach((c) => {
-      c.toggleAttribute('data-user-invalid', false);
-      c.setCustomValidity('');
-    });
-    this.showErrorMessage = false;
-  }
-
-  private makeInvalid() {
-    const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
-    // checkbox har data-valid prop derfor må vi endre den med å sette custom validity på alle barn. den gir også styling
-    nveCheckboxes.forEach((c) => {
-      c.toggleAttribute('data-user-invalid', true);
-      c.setCustomValidity(this.errorMessage || 'Error');
-    });
-    this.showErrorMessage = true;
-
-    const event = new Event('sl-invalid', {
-      bubbles: true,
-      cancelable: true,
-    });
-    this.dispatchEvent(event);
-  }
-
-  private checkIfRequiredValid(): boolean {
-    const nveCheckboxes = Array.from(this.querySelectorAll('nve-checkbox'));
-    const isValid = nveCheckboxes.some((checkbox) => checkbox.checked);
-    return isValid;
+    this.dispatchEvent(
+      new CustomEvent<NveCheckboxGroupChangeEvent>('change', {
+        detail: { value: value, action },
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   render() {
+    const helpTextId = `${this.checkboxGroupId}-helptext`;
+    const hintTextId = `${this.checkboxGroupId}-hinttext`;
+
+    const describedBy = [this.helpText ? helpTextId : null, this.errorMessage || this.hint ? hintTextId : null]
+      .filter(Boolean)
+      .join(' ');
+
     return html`
       <fieldset
-        class="checkbox-group"
-        aria-required=${this.required}
-        aria-labelledby="label"
-        aria-describedby="error-message"
-        aria-errormessage="error-message"
+        test-id=${ifDefined(this.testId)}
+        class=${classMap({
+          field: true,
+          'field--error': !!this.errorMessage,
+        })}
+        @change=${this.handleChange}
+        aria-invalid=${ifDefined(this.errorMessage ? 'true' : undefined)}
+        aria-describedby=${ifDefined(describedBy)}
+        part="base"
       >
-        ${this.label
-          ? html`<div class="checkbox-group__label">
-              <nve-label id="label" value=${this.label} size="small" tooltip=${this.tooltip!}></nve-label>
-            </div>`
+        <!-- Ledetekst -->
+        ${getLabel(this.checkboxGroupId, this.label, this.tooltip, this.required, this.requiredLabel, undefined, true)}
+        <!-- Hjelpetekst -->
+        ${this.helpText
+          ? html`<p part="help-text" class="field__help-text" id=${helpTextId} part="help-text">${this.helpText}</p>`
           : nothing}
-        <slot class="checkbox-group__checkboxes"></slot>
-        ${this.showErrorMessage
-          ? html`<span role="alert" id="error-message" class="checkbox-group__error-message"
-              >${this.errorMessage || nothing}</span
-            >`
+        <div
+          part="checkbox-group"
+          class=${classMap({
+            'checkbox-group': true,
+            [`checkbox-group--${this.orientation}`]: true,
+          })}
+        >
+          <slot @slotchange=${this.handleSlotChange}></slot>
+        </div>
+        <!-- Hint-tekst og feilmelding -->
+        ${this.errorMessage || this.hint
+          ? html`<p part="hint-text" class="field__hint-text" id=${hintTextId} part="hint-text">
+              ${this.errorMessage || this.hint}
+            </p>`
           : nothing}
       </fieldset>
     `;

--- a/src/components/nve-checkbox-group/nve-checkbox-group.styles.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.styles.ts
@@ -1,56 +1,56 @@
 import { css } from 'lit';
 
 export default css`
-  :host {
-    --sl-checkbox-required-content: '*Obligatorisk';
+  .field {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    margin: 0;
+    gap: var(--spacing-x-small);
+    min-inline-size: unset;
+    margin-inline: 0;
+    border-width: 0;
+    border-style: none;
+    border-color: none;
+    border-image: none;
+    padding-block: 0;
+    padding-inline: 0;
   }
 
-  fieldset {
-    border: none;
-    padding: unset;
-    margin: unset;
-    gap: var(--spacing-x-small);
+  .field__help-text {
+    margin: 0;
+    margin-top: calc(var(--spacing-2x-small) - var(--spacing-x-small));
+    color: var(--color-neutrals-foreground-subtle);
+    font: var(--typography-detailtext-caption);
+    text-align: start;
+  }
+
+  .field__hint-text {
+    margin: 0;
+    color: var(--color-neutrals-foreground-primary);
+    font: var(--typography-detailtext-caption);
+    text-align: start;
+  }
+
+  .field--error {
+    border-left: var(--border-width-strong) solid var(--color-feedback-border-emphasized-error);
+    padding-left: var(--spacing-x-small);
+    .field__hint-text {
+      color: var(--color-feedback-foreground-error);
+    }
   }
 
   .checkbox-group {
     display: flex;
-    flex-direction: column;
-  }
-
-  .checkbox-group__label {
-    font: var(--typography-label-small);
-    display: flex;
-    gap: var(--spacing-x-small);
-  }
-
-  :host([required]) nve-label::after {
-    content: var(--sl-checkbox-required-content);
-    font: var(--typography-label-x-small-light);
-    margin-left: auto;
-    color: var(--color-feedback-background-emphasized-error);
-  }
-
-  /* shoelace legger til styling når hele gruppa er disabled, så må overskrive den her */
-  :host([disabled]) {
-    opacity: 1 !important;
-    cursor: unset !important;
-  }
-
-  .checkbox-group__checkboxes {
-    display: flex;
     gap: var(--spacing-small);
   }
 
-  :host([orientation='vertical']) .checkbox-group__checkboxes {
+  .checkbox-group--vertical {
     flex-direction: column;
   }
 
-  .checkbox-group__error-message {
-    font: var(--typography-body-x-small);
-    color: var(--color-feedback-background-emphasized-error);
-  }
-
-  nve-label {
-    width: unset;
+  .checkbox-group--horizontal {
+    flex-direction: row;
+    align-items: center;
   }
 `;

--- a/src/components/nve-checkbox-group/nve-checkbox-group.test.ts
+++ b/src/components/nve-checkbox-group/nve-checkbox-group.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { fixture, fixtureCleanup } from '@open-wc/testing';
+import { html } from 'lit';
+import NveCheckboxGroup from './nve-checkbox-group.component';
+import '../nve-checkbox/nve-checkbox.component';
+
+if (!customElements.get('nve-checkbox-group')) {
+  customElements.define('nve-checkbox-group', NveCheckboxGroup);
+}
+
+async function waitForSlotWork(el: NveCheckboxGroup) {
+  await el.updateComplete;
+  await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+  await el.updateComplete;
+}
+
+describe('nve-checkbox-group', () => {
+  afterAll(() => {
+    fixtureCleanup();
+  });
+
+  it('has field--disabled when disabled attribute is set', async () => {
+    const el = await fixture<NveCheckboxGroup>(
+      html`<nve-checkbox-group disabled>
+        <nve-checkbox value="1">Option 1</nve-checkbox>
+        <nve-checkbox value="2">Option 2</nve-checkbox>
+      </nve-checkbox-group>`
+    );
+    await el.updateComplete;
+
+    const checkboxes = Array.from(el.querySelectorAll('nve-checkbox')) as Array<{ disabled: boolean }>;
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes.every((checkbox) => checkbox.disabled)).toBe(true);
+  });
+
+  it('field__help-text element with correct help text', async () => {
+    const el = await fixture<NveCheckboxGroup>(html`<nve-checkbox-group helpText="Help text"></nve-checkbox-group>`);
+    const text = el?.shadowRoot?.querySelector('.field__help-text')?.textContent?.trim();
+
+    expect(text).toBe('Help text');
+  });
+
+  it('horizontal layout', async () => {
+    const el = await fixture<NveCheckboxGroup>(
+      html`<nve-checkbox-group orientation="horizontal"></nve-checkbox-group>`
+    );
+
+    const container = el?.shadowRoot?.querySelector('.checkbox-group--horizontal');
+
+    expect(container).toBeTruthy();
+  });
+
+  it('has correct size', async () => {
+    const el = await fixture<NveCheckboxGroup>(
+      html`<nve-checkbox-group size="large">
+        <nve-checkbox value="1">Option 1</nve-checkbox>
+        <nve-checkbox value="2">Option 2</nve-checkbox>
+      </nve-checkbox-group>`
+    );
+    await el.updateComplete;
+    const slot = el.shadowRoot?.querySelector('slot');
+    slot?.dispatchEvent(new Event('slotchange'));
+    await waitForSlotWork(el);
+
+    const checkboxes = Array.from(el.querySelectorAll('nve-checkbox')) as Array<{ size: string }>;
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes.every((checkbox) => checkbox.size === 'large')).toBe(true);
+  });
+
+  it('field__hint-text element with correct hint text', async () => {
+    const el = await fixture<NveCheckboxGroup>(html`<nve-checkbox-group hint="Hint text"></nve-checkbox-group>`);
+    const text = el?.shadowRoot?.querySelector('.field__hint-text')?.textContent?.trim();
+
+    expect(text).toBe('Hint text');
+  });
+
+  it('test if selectedValues are removed from the DOM', async () => {
+    const options = [
+      { value: '1', label: 'Option 1' },
+      { value: '2', label: 'Option 2' },
+    ];
+    const selectedValues = ['1'];
+    const el = await fixture<NveCheckboxGroup>(
+      html`<nve-checkbox-group .options=${options} .selectedValues=${selectedValues}
+        ><nve-checkbox value="1">Option 1</nve-checkbox>
+        <nve-checkbox value="2">Option 2</nve-checkbox></nve-checkbox-group
+      >`
+    );
+    expect(el.hasAttribute('selectedValues')).toBeFalsy();
+  });
+
+  it('triggers change event when a checkbox is clicked', async () => {
+    const el = await fixture<NveCheckboxGroup>(html`
+      <nve-checkbox-group>
+        <nve-checkbox value="flood">Flomvarsel</nve-checkbox>
+      </nve-checkbox-group>
+    `);
+
+    type CheckboxGroupChangeDetail = {
+      value: string;
+      action: 'select' | 'deselect';
+    };
+
+    let selectedValue = '';
+
+    const submitSpy = vi.fn();
+
+    el.addEventListener('change', (event: Event) => {
+      const customEvent = event as CustomEvent<CheckboxGroupChangeDetail>;
+      selectedValue = customEvent.detail.value;
+      submitSpy(customEvent);
+    });
+
+    const checkbox = el.querySelector('nve-checkbox') as HTMLElement;
+    const input = checkbox.shadowRoot?.querySelector('input') as HTMLInputElement;
+    input.click();
+
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    expect(selectedValue).toBe('flood');
+  });
+});

--- a/src/components/nve-checkbox/nve-checkbox.component.ts
+++ b/src/components/nve-checkbox/nve-checkbox.component.ts
@@ -10,7 +10,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  *
  * @event change Når sjekkboksen blir valgt eller fravalgt. Inneholder den valgte verdien.
  *
- * @csspart base wraper rundt sjekkboksen.
+ * @csspart base wrapper rundt sjekkboksen.
  */
 @customElement('nve-checkbox')
 export default class NveCheckbox extends LitElement implements INveComponent {

--- a/src/components/nve-checkbox/nve-checkbox.component.ts
+++ b/src/components/nve-checkbox/nve-checkbox.component.ts
@@ -1,29 +1,105 @@
-import { customElement } from 'lit/decorators.js';
-import SlCheckbox from '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
+import { html, LitElement, PropertyValues } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { INveComponent } from '@interfaces/NveComponent.interface';
 import styles from './nve-checkbox.styles';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 /**
- * En avkrysningsboks.
- * Ikke bruk `size`, i NVE bruker vi kun en størrelse på avkrysningsbokser.
+ * Lar brukeren toggle mellom to tilstander, valgt og ikke valgt. Sjekkbokser kan brukes alene eller i grupper.
+ *
+ * @event change Når sjekkboksen blir valgt eller fravalgt. Inneholder den valgte verdien.
+ *
+ * @csspart base wraper rundt sjekkboksen.
  */
 @customElement('nve-checkbox')
-export default class NveCheckbox extends SlCheckbox {
-  constructor() {
-    super();
+export default class NveCheckbox extends LitElement implements INveComponent {
+  /* Siden sjekkboks kan brukes alene ulik radio - size, checked, indeterminate skal brukes som property, ikke state */
+  @property({ type: String }) testId: string | undefined = undefined;
+  /** Størrelse på sjekkboks */
+  @property({ type: String }) size: 'small' | 'medium' | 'large' = 'medium';
+  /** Om sjekkboksen er i en indeterminert tilstand */
+  @property({ type: Boolean, reflect: true }) indeterminate = false;
+  /** Om sjekkboksen er deaktivert */
+  @property({ type: Boolean, reflect: true }) disabled = false;
+  /** Om sjekkboksen er valgt */
+  @property({ type: Boolean, reflect: true }) checked = false;
+  /** Verdien til sjekkboksen. Når valgt, vil sjekkboksgruppen motta denne verdien. */
+  @property({ type: String, reflect: true }) value: string = '';
+  @query('input') input!: HTMLInputElement;
+  /** Om sjekkboksen er ugyldig. Valgt å bruke bare internt. Enkle sjekkbokser skal ikke vise ugyldig tilstand via properties. */
+  @state() invalid = false;
+  static styles = [styles];
+
+  updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties);
+    if (changedProperties.has('indeterminate') && this.input) {
+      this.input.indeterminate = this.indeterminate;
+    }
   }
 
-  static styles = [SlCheckbox.styles, styles];
-  connectedCallback() {
-    super.connectedCallback();
-    this.addEventListener('sl-invalid', (e) => {
-      // vi vil ikke at nettleseren viser feil meldingen til oss
-      e.preventDefault();
-    });
+  private handleChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.checked = input.checked;
+    this.indeterminate = false;
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        bubbles: true,
+        composed: true,
+        detail: { value: this.value },
+      })
+    );
   }
 
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.removeEventListener('sl-invalid', () => { });
+  protected firstUpdated(_changedProperties: PropertyValues): void {
+    if (!this.value) {
+      console.warn('Checkbox is missing a value. Please provide it for the checkbox to function properly.');
+    }
+  }
+
+  /**
+   * Gir fokus til sjekkboksen.
+   * @param options Valgfri fokusinnstillinger.
+   */
+  focus(options?: FocusOptions) {
+    this.input.focus(options);
+  }
+
+  // sjekkboks kan bli brukt alene og når brukt i en gruppe, den skal ikke annonsere posisjonen sin i en liste (f.eks 1 av 3) som radio og derfor
+  // kan det enklest gjøres med input element inn i label element.
+  render() {
+    return html`
+      <label
+        part="base"
+        class=${classMap({
+          checkbox: true,
+          [`checkbox--${this.size}`]: true,
+          'checkbox--disabled': this.disabled,
+          'checkbox--invalid': this.invalid,
+        })}
+      >
+        <!-- Input vises ikke, vi lager en sjekkboks med ::before via css -->
+        <input
+          type="checkbox"
+          .checked=${this.checked}
+          value=${ifDefined(this.value)}
+          name="option"
+          ?disabled=${this.disabled}
+          @change=${this.handleChange}
+        />
+        <svg class="checkbox__checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 8" fill="none">
+          <path
+            d="M3.16875 7.3125L0 4.125L0.9375 3.1875L3.16875 5.4L8.5875 0L9.525 0.95625L3.16875 7.3125Z"
+            fill="white"
+          />
+        </svg>
+        <svg class="checkbox__indeterminate" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 2" fill="none">
+          <path d="M0 1.2V0H8V1.2H0Z" fill="white" />
+        </svg>
+
+        <slot></slot>
+      </label>
+    `;
   }
 }
 

--- a/src/components/nve-checkbox/nve-checkbox.styles.ts
+++ b/src/components/nve-checkbox/nve-checkbox.styles.ts
@@ -1,54 +1,135 @@
 import { css } from 'lit';
 
 export default css`
-  .error {
-    border-color: var(--color-feedback-background-emphasized-error) !important;
-  }
-  .error-hover {
-    &:hover {
-    }
-  }
-
-  :host::part(control) {
-    border: var(--border-width-strong) solid var(--color-neutrals-foreground-primary);
-    border-radius: var(--border-radius-small);
-    width: 1.1rem;
-    height: 1.1rem;
-    transition: all var(--transition-time) ease-in;
-  }
-
-  :host::part(control control--checked),
-  :host::part(control control--indeterminate) {
-    background: var(--color-neutrals-foreground-primary) !important;
-    border-color: var(--color-neutrals-foreground-primary) !important;
-  }
-
-  :host([data-invalid])::part(control) {
-    border-color: var(--color-feedback-border-emphasized-error);
-  }
-  :host([data-invalid])::part(control control--checked),
-  :host([data-user-invalid])::part(control control--indeterminate) {
-    background: var(--color-feedback-background-emphasized-error);
-  }
-
-  :host(:not([disabled]):hover)::part(control) {
-    border-color: var(--color-neutrals-foreground-subtle) !important;
-  }
-
-  sl-icon {
-    --sl-color-neutral-0: var(--color-neutrals-background-primary);
-    color: var(--color-neutrals-background-primary);
-  }
-
-  :host(:hover)::part(control control--checked),
-  :host(:hover)::part(control control--indeterminate) {
-    background: var(--color-neutrals-foreground-subtle, #006b99);
+  :host {
+    --size: 1rem;
+    --_checked-background-color: var(--color-interactive-background-primary-enabled);
+    --_border-color: var(--color-interactive-border-primary-enabled);
+    --_hover-color: var(--color-interactive-background-primary-hover);
+    --_font: var(--typography-label-x-small-light);
   }
 
   .checkbox {
+    cursor: pointer;
+    box-sizing: border-box;
+    display: flex;
+    width: fit-content;
+    font: var(--_font);
+    line-height: 1;
+    color: var(--color-neutrals-foreground-primary);
+    margin-inline: 0;
+    gap: var(--spacing-x-small);
     align-items: center;
+    line-height: var(--size);
+    position: relative;
   }
-  .checkbox__label {
-    font: var(--typography-label-x-small-light);
+
+  /* Vi gjemmer checkbox input siden vi lager vår egen med ::before */
+  .checkbox input[type='checkbox'] {
+    opacity: 0;
+    position: absolute;
+    cursor: pointer;
+  }
+
+  /* Sjekkboks custom styling */
+  .checkbox::before {
+    content: '';
+    box-sizing: border-box;
+    width: var(--size);
+    height: var(--size);
+    border: var(--border-width-strong) solid var(--_border-color);
+    border-radius: calc(var(--size) * 0.25);
+    transition:
+      background-color 0.3s ease,
+      border-color 0.3s ease,
+      box-shadow 0.3s ease;
+  }
+
+  .checkbox:hover:not(.checkbox--disabled)::before {
+    box-shadow: 0 0 0 3px var(--color-interactive-border-primary-hover);
+  }
+
+  /* Sjekket styling */
+  .checkbox:has(input[type='checkbox']:checked)::before {
+    background-color: var(--_checked-background-color);
+  }
+
+  .checkbox:has(input[type='checkbox']:checked):hover:not(.checkbox--disabled)::before {
+    background-color: var(--_hover-color);
+  }
+
+  .checkbox:has(input[type='checkbox']:checked):hover:not(.checkbox--disabled) {
+    --_border-color: var(--_hover-color);
+  }
+
+  /* Sjekkmark er 10x8 i figma. For a sikre skallerbarhet nar font storrelsen endres kalulerer vi med 
+  rem og med 0.625 som tilsvarer 10px og 0.5 som tilsvarer 8px */
+  .checkbox__checkmark {
+    position: absolute;
+    width: 0.625rem;
+    height: 0.5rem;
+    display: none;
+    left: calc((var(--size) - 0.625rem) / 2);
+  }
+
+  /* Indeterminate er 8x2 i figma. For a sikre skallerbarhet nar font storrelsen endres kalulerer vi med 
+  rem og med 0.5 som tilsvarer 8px og 0.125 som tilsvarer 2px */
+  .checkbox__indeterminate {
+    position: absolute;
+    width: 0.5rem;
+    height: 0.125rem;
+    display: none;
+    left: calc((var(--size) - 0.5rem) / 2);
+  }
+
+  .checkbox__checkmark path,
+  .checkbox__indeterminate path {
+    fill: var(--color-interactive-foreground-primary-enabled);
+  }
+
+  .checkbox:has(input[type='checkbox']:checked) .checkbox__checkmark,
+  .checkbox:has(input[type='checkbox']:indeterminate) .checkbox__indeterminate {
+    display: block;
+  }
+
+  .checkbox:has(input[type='checkbox']:checked)::before,
+  .checkbox:has(input[type='checkbox']:indeterminate)::before {
+    background-color: var(--_checked-background-color);
+  }
+
+  /* Størrelser */
+  /* 16px */
+  .checkbox--small {
+    --size: 1rem;
+  }
+
+  /* 18px */
+  .checkbox--medium {
+    --size: 1.125rem;
+  }
+
+  /* 20x */
+  .checkbox--large {
+    --size: 1.25rem;
+    --_font: var(--typography-label-small-light);
+  }
+
+  .checkbox--invalid {
+    --_checked-background-color: var(--color-feedback-background-emphasized-error);
+    --_border-color: var(--color-feedback-border-emphasized-error);
+  }
+
+  .checkbox--disabled {
+    --_checked-background-color: var(--color-interactive-background-primary-disabled);
+    --_border-color: var(--color-interactive-border-primary-disabled);
+  }
+
+  .checkbox--disabled,
+  .checkbox--disabled input[type='checkbox'] {
+    cursor: not-allowed;
+  }
+
+  .checkbox:has(input[type='checkbox']:focus-visible)::before {
+    outline: 2px solid var(--color-interactive-border-accessibility-focus);
   }
 `;

--- a/src/components/nve-checkbox/nve-checkbox.test.ts
+++ b/src/components/nve-checkbox/nve-checkbox.test.ts
@@ -1,0 +1,38 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { fixture, fixtureCleanup } from '@open-wc/testing';
+import { html } from 'lit';
+import NveCheckbox from './nve-checkbox.component';
+
+if (!customElements.get('nve-checkbox')) {
+  customElements.define('nve-checkbox', NveCheckbox);
+}
+
+describe('nve-checkbox', () => {
+  afterAll(() => {
+    fixtureCleanup();
+  });
+
+  it('has checkbox--disabled when disabled attribute is set', async () => {
+    const el = await fixture<NveCheckbox>(html`<nve-checkbox disabled></nve-checkbox>`);
+    const checkbox = el.shadowRoot?.querySelector('.checkbox');
+    expect(checkbox?.classList.contains('checkbox--disabled')).toBe(true);
+  });
+
+  it('has checkbox--small when size attribute is set to small', async () => {
+    const el = await fixture<NveCheckbox>(html`<nve-checkbox size="small"></nve-checkbox>`);
+    const checkbox = el.shadowRoot?.querySelector('.checkbox');
+    expect(checkbox?.classList.contains('checkbox--small')).toBe(true);
+  });
+
+  it('has checkbox--large when size attribute is set to large', async () => {
+    const el = await fixture<NveCheckbox>(html`<nve-checkbox size="large"></nve-checkbox>`);
+    const checkbox = el.shadowRoot?.querySelector('.checkbox');
+    expect(checkbox?.classList.contains('checkbox--large')).toBe(true);
+  });
+
+  it('input element has correct value attribute', async () => {
+    const el = await fixture<NveCheckbox>(html`<nve-checkbox value="test-value"></nve-checkbox>`);
+    const input = el.shadowRoot?.querySelector('input');
+    expect(input?.getAttribute('value')).toBe('test-value');
+  });
+});


### PR DESCRIPTION
Da er det sjekkboksgruppen sin tur.

Lik opplegg som for radio og combobox.

Her bruker vi native `input` og `label` på sjekkboksene, siden tilgjengelighetsreglene ikke er like strenge her. Man trenger heller ikke å oppgi hvor mange sjekkbokser man kan velge mellom. Hver sjekkboks skal fortsatt fungere individuelt – altså tabber man til hver enkelt sjekkboks, og man bruker ikke piltaster for navigasjon.

Gruppen skal heller ikke "lagre" valgte verdier i en property/attribute (i motsetning til radiogruppen). Grunnen er at radio kun kan ha én valgt verdi, så der gir det mer mening å reflektere verdien i et attributt. For sjekkbokser, hvor flere valg er mulig, ser jeg ikke samme behov for refleksjon. Valgte sjekkbokser skal styres i appen der komponenten brukes. Jeg skal også oppdatere comboboxen til å fungere på samme måte.

`_selectedValues` brukes kun for å sjekke om noe er valgt, slik at for eksempel `required`-validering (som kommer senere) fungerer pålitelig for sjekkboksgruppen.
