### PR TITLE
feat(nve-aspect-rose): Ny komponent for utsatte himmelretninger

### DIFF
--- a/doc-site/components/Komponentoversikt.md
+++ b/doc-site/components/Komponentoversikt.md
@@ -29,7 +29,7 @@ nodeId er ID til komponent-sida i Figma. Den ligger som en parameter i URL'en ti
   },
   {
     name: 'nve-aspect-rose',
-    nodeId: 'TODO',
+    nodeId: undefined,
     description: undefined,
     statusDesign: 'Ferdig',
     statusCode: 'Ferdig'

--- a/doc-site/components/Komponentoversikt.md
+++ b/doc-site/components/Komponentoversikt.md
@@ -28,6 +28,13 @@ nodeId er ID til komponent-sida i Figma. Den ligger som en parameter i URL'en ti
     statusCode: 'Ferdig'
   },
   {
+    name: 'nve-aspect-rose',
+    nodeId: 'TODO',
+    description: undefined,
+    statusDesign: 'Ferdig',
+    statusCode: 'Ferdig'
+  },
+  {
     name: 'nve-attachments',
     nodeId: '647-192139',
     description: 'Viser liste over opplastede vedlegg',

--- a/doc-site/components/nve-aspect-rose.md
+++ b/doc-site/components/nve-aspect-rose.md
@@ -15,14 +15,21 @@ outline: [2, 3]
 
 ### Utsatte himmelretninger
 
-Bruk `value` for å sette hvilke himmelretninger som er utsatt (farlige).
-<CodeExamplePreview>
+Bruk `value` for å sette hvilke himmelretninger som er utsatt (farlige). `value` må være en tekst på 8 sifre som bare består av 0 og 1
+Første siffer angir nordlig sektor og går deretter med klokka.
+<CodeExamplePreview containerGridTemplateColumns="repeat(2, auto)">
 
 ```html
-<nve-aspect-rose></nve-aspect-rose> Ingen <nve-aspect-rose value="10000000"> </nve-aspect-rose> Kun nord
-<nve-aspect-rose value="00111100"></nve-aspect-rose> øst, sør-øst, sør og sør-vest
-<nve-aspect-rose value="11111111"></nve-aspect-rose> Alle <nve-aspect-rose value="1111111"></nve-aspect-rose> Verdien
-blir ignorert hvis vi ikke har eksakt 8 sifre
+<nve-aspect-rose></nve-aspect-rose>
+<p>Ingen</p>
+<nve-aspect-rose value="10000000"> </nve-aspect-rose>
+<p>Kun nord</p>
+<nve-aspect-rose value="00111100"></nve-aspect-rose>
+<p>øst, sør-øst, sør og sør-vest</p>
+<nve-aspect-rose value="11111111"></nve-aspect-rose>
+<p>Alle</p>
+<nve-aspect-rose value="1111111"></nve-aspect-rose>
+<p>Verdien blir ignorert hvis vi ikke har eksakt 8 sifre</p>
 ```
 
 </CodeExamplePreview>
@@ -43,12 +50,16 @@ Bruk css-variabelen `--aspect-rose-size` for å endre bredde og høyde. 90px er 
 
 ### Språk
 
-Bruk `lang` for å angi språk for kompassretningene. `no` (norsk) er standard. Kun norsk og engelsk støttes.
-<CodeExamplePreview>
+Bruk `lang` for å angi språk for kompassretningene. Kun norsk og engelsk støttes, og norsk er standard. Sett `lang` til noe som starter på 'en' for å få engelsk språk.
+<CodeExamplePreview containerGridTemplateColumns="repeat(2, auto)">
 
 ```html
-<nve-aspect-rose value="00111110"></nve-aspect-rose> Norsk
-<nve-aspect-rose lang="en" value="00111110"></nve-aspect-rose> Engelsk
+<nve-aspect-rose value="00111110"></nve-aspect-rose>
+<p>Norsk</p>
+<nve-aspect-rose lang="en" value="00111110"></nve-aspect-rose>
+<p>Engelsk</p>
+<nve-aspect-rose lang="en-GB" value="00111110"></nve-aspect-rose>
+<p>Også engelsk</p>
 ```
 
 </CodeExamplePreview>
@@ -57,7 +68,7 @@ Bruk `lang` for å angi språk for kompassretningene. `no` (norsk) er standard. 
 
 Bruk `label` for å overstyre standard-tekstene for aria-label og svg title.
 
-<CodeExamplePreview>
+<CodeExamplePreview >
 
 ```html
 Hold muspeker over for å se label.<br />

--- a/doc-site/components/nve-aspect-rose.md
+++ b/doc-site/components/nve-aspect-rose.md
@@ -15,7 +15,7 @@ outline: [2, 3]
 
 ### Utsatte himmelretninger
 
-Bruk `value` for å sette hvilke himmelretninger som er eksponert.
+Bruk `value` for å sette hvilke himmelretninger som er utsatt (farlige).
 <CodeExamplePreview>
 
 ```html

--- a/doc-site/components/nve-aspect-rose.md
+++ b/doc-site/components/nve-aspect-rose.md
@@ -1,0 +1,70 @@
+---
+layout: component
+outline: [2, 3]
+---
+
+<CodeExamplePreview>
+
+```html
+<nve-aspect-rose value="11000001"></nve-aspect-rose>
+```
+
+</CodeExamplePreview>
+
+## Eksempler
+
+Legg eksempler på funksjonalitet her. Hvert tema skal ha egen overskrift på nivå 3.
+
+### Utsatte himmelretninger
+
+Bruk `value` for å sette hvilke himmelretninger som er eksponert.
+<CodeExamplePreview>
+
+```html
+<nve-aspect-rose></nve-aspect-rose> Ingen <nve-aspect-rose value="10000000"> </nve-aspect-rose> Kun nord
+<nve-aspect-rose value="001111000"></nve-aspect-rose> øst, sør-øst, sør og sør-vest
+<nve-aspect-rose value="111111111"></nve-aspect-rose> Alle
+```
+
+</CodeExamplePreview>
+
+### Størrelse
+
+Bruk css-variabelen `--aspect-rose-size` for å endre bredde og høyde. 90px er standard.
+
+<CodeExamplePreview>
+
+```html
+<nve-aspect-rose style="--aspect-rose-size: 60px" value="00111110"></nve-aspect-rose> 60px
+<nve-aspect-rose value="00111110"></nve-aspect-rose> 90px (standard)
+<nve-aspect-rose style="--aspect-rose-size: 120px" value="00111110"></nve-aspect-rose> 120px
+```
+
+</CodeExamplePreview>
+
+### Språk
+
+Bruk `lang` for å angi språk for kompassretningene. `no` (norsk) er standard. Kun norsk og engelsk støttes.
+<CodeExamplePreview>
+
+```html
+<nve-aspect-rose value="00111110"></nve-aspect-rose> Norsk
+<nve-aspect-rose lang="en" value="00111110"></nve-aspect-rose> Engelsk
+```
+
+</CodeExamplePreview>
+
+### Aria-label og svg-title
+
+Bruk `label` for å overstyre standard-tekstene for aria-label og svg title.
+
+<CodeExamplePreview>
+
+```html
+Hold muspeker over for å se label.<br />
+<nve-aspect-rose value="00111110"></nve-aspect-rose>Med standard norsk tekst
+<nve-aspect-rose lang="en" value="00111110"></nve-aspect-rose>Med standard engelsk tekst
+<nve-aspect-rose label="merkelapp" value="00111110"></nve-aspect-rose>Overstyrt tekst
+```
+
+</CodeExamplePreview>

--- a/doc-site/components/nve-aspect-rose.md
+++ b/doc-site/components/nve-aspect-rose.md
@@ -13,8 +13,6 @@ outline: [2, 3]
 
 ## Eksempler
 
-Legg eksempler på funksjonalitet her. Hvert tema skal ha egen overskrift på nivå 3.
-
 ### Utsatte himmelretninger
 
 Bruk `value` for å sette hvilke himmelretninger som er eksponert.
@@ -22,8 +20,9 @@ Bruk `value` for å sette hvilke himmelretninger som er eksponert.
 
 ```html
 <nve-aspect-rose></nve-aspect-rose> Ingen <nve-aspect-rose value="10000000"> </nve-aspect-rose> Kun nord
-<nve-aspect-rose value="001111000"></nve-aspect-rose> øst, sør-øst, sør og sør-vest
-<nve-aspect-rose value="111111111"></nve-aspect-rose> Alle
+<nve-aspect-rose value="00111100"></nve-aspect-rose> øst, sør-øst, sør og sør-vest
+<nve-aspect-rose value="11111111"></nve-aspect-rose> Alle <nve-aspect-rose value="1111111"></nve-aspect-rose> Verdien
+blir ignorert hvis vi ikke har eksakt 8 sifre
 ```
 
 </CodeExamplePreview>
@@ -65,6 +64,21 @@ Hold muspeker over for å se label.<br />
 <nve-aspect-rose value="00111110"></nve-aspect-rose>Med standard norsk tekst
 <nve-aspect-rose lang="en" value="00111110"></nve-aspect-rose>Med standard engelsk tekst
 <nve-aspect-rose label="merkelapp" value="00111110"></nve-aspect-rose>Overstyrt tekst
+```
+
+</CodeExamplePreview>
+
+### Farger
+
+Bruk css-variablene`--aspect-rose-outline-color`, `--aspect-rose-affected-color`og`--aspect-rose-unaffected-color` for å overstyre fargene.
+
+<CodeExamplePreview>
+
+```html
+<nve-aspect-rose
+  style="--aspect-rose-outline-color: green; --aspect-rose-affected-color: black;--aspect-rose-unaffected-color: white"
+  value="00111110"
+></nve-aspect-rose>
 ```
 
 </CodeExamplePreview>

--- a/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
@@ -1,0 +1,93 @@
+import { html, svg, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { INveComponent } from '@interfaces/NveComponent.interface';
+import styles from './nve-aspect-rose.styles';
+
+/**
+ * Viser utsatte himmelretninger som en kompassrose.
+ * Rosen er delt opp i 8 sektorer. Utsatte sektorer vises i rødt.
+ */
+@customElement('nve-aspect-rose')
+export default class NveAspectRose extends LitElement implements INveComponent {
+  @property({ type: String }) testId: string | undefined = undefined;
+
+  /**
+   * 8-tegns binærtekst som representerer utsatte sektorer.
+   * Starter med nordlig sektor og går deretter med klokka.
+   * Eksempel: "00111110"
+   */
+  @property({ type: String }) value: string = '00000000';
+
+  /** Språk for himmelretningene. 'no' for norsk, 'en' for engelsk. */
+  @property({ type: String }) lang: 'no' | 'en' = 'no';
+
+  /**
+   * Tilgjengelig tittel.
+   * Vises som aria-label på SVG-elementet og som <title> i SVG.
+   * Standardverdi avhenger av språket: 'Eksponerte sektorer' for norsk, 'Affected aspects' for engelsk.
+   * Du kan overstyre denne teksten.
+   */
+  @property({ type: String }) label: string | undefined = undefined;
+
+  static styles = [styles];
+
+  private get effectiveLabel() {
+    return this.label ?? (this.lang === 'no' ? 'Eksponerte sektorer' : 'Affected aspects');
+  }
+
+  // Etiketter for de fire himmelretningene. Brukes til å plassere sirklene og teksten inni dem.
+  private get directions() {
+    return [
+      { cx: 45, cy: 9, label: 'N' },
+      { cx: 81, cy: 45, label: this.lang === 'no' ? 'Ø' : 'E' },
+      { cx: 45, cy: 81, label: 'S' },
+      { cx: 9, cy: 45, label: this.lang === 'no' ? 'V' : 'W' },
+    ];
+  }
+
+  // Gradene for å rotere sektorene slik at de dekker riktig himmelretning. Starter med nordlig sektor og går deretter med klokka.
+  private readonly rotations = [-22.5, 22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5];
+
+  render() {
+    return html`
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 90 90"
+        width="100%"
+        height="100%"
+        role="img"
+        aria-label=${this.effectiveLabel}
+      >
+        ${svg`<title>${this.effectiveLabel}</title>`}
+        <g>
+          ${this.rotations.map(
+            (rot, i) => svg`
+              <path
+                d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z"
+                transform="rotate(${rot} 45 45)"
+                stroke-width="1"
+                stroke="#c6c6c5"
+                class=${this.value[i] === '1' ? 'sector--affected' : 'sector--unaffected'}
+              ></path>
+            `
+          )}
+          <circle cx="45" cy="45" r="36" fill="none" stroke-width="1" class="circle-outline"></circle>
+        </g>
+        ${this.directions.map(
+          ({ cx, cy, label }) => svg`
+            <g>
+              <circle cx=${cx} cy=${cy} r="7.2" stroke-width="1" stroke="#69797a" fill="#fff"></circle>
+              <text x=${cx} y=${cy} dy="3.168" font-size="7.92" text-anchor="middle" fill="#6a7a7b">${label}</text>
+            </g>
+          `
+        )}
+      </svg>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'nve-aspect-rose': NveAspectRose;
+  }
+}

--- a/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
@@ -84,7 +84,7 @@ export default class NveAspectRose extends LitElement implements INveComponent {
           ({ cx, cy, label }) => svg`
             <g>
               <circle cx=${cx} cy=${cy} r="7.2" stroke-width="1" stroke="var(--aspect-rose-outline-color, #c6c6c5)" fill="#fff"></circle>
-              <text x=${cx} y=${cy} dy="3.168" font-size="7.92" text-anchor="middle" fill="#6a7a7b">${label}</text>
+              <text x=${cx} y=${cy} dy="3.168" text-anchor="middle" fill="#6a7a7b">${label}</text>
             </g>
           `
         )}

--- a/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
@@ -7,6 +7,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 /**
  * Viser utsatte himmelretninger som en kompassrose.
  * Rosen er delt opp i 8 sektorer. Utsatte sektorer vises i rødt.
+ * Er laget for å vise hvilke himmelretninger et skredproblem gjelder for, men kan selvfølgelig også brukes til andre ting.
  * @cssproperty --aspect-rose-size - Høyde og bredde på komponenten. 90px er standard.
  * @cssproperty --aspect-rose-outline-color - Farge på sirkelens omriss. Standard er #c6c6c5.
  * @cssproperty --aspect-rose-affected-color - Farge på utsatte sektorer. Standard er #d21523.

--- a/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
@@ -23,30 +23,34 @@ export default class NveAspectRose extends LitElement implements INveComponent {
    */
   @property({ type: String }) value: string = '00000000';
 
-  /** Språk for himmelretningene. 'no' for norsk, 'en' for engelsk. */
-  @property({ type: String }) lang: 'no' | 'en' = 'no';
+  /** Språk for himmelretningene. Blir satt til engelsk om lang starter på 'en'. Standard er norsk. */
+  @property({ type: String }) lang: string = 'no';
 
   /**
    * Tilgjengelig tittel.
    * Vises som aria-label på SVG-elementet og som <title> i SVG.
-   * Standardverdi avhenger av språket: 'Eksponerte sektorer' for norsk, 'Affected aspects' for engelsk.
+   * Standardverdi avhenger av språket: 'Utsatte sektorer' for norsk, 'Affected aspects' for engelsk.
    * Du kan overstyre denne teksten.
    */
   @property({ type: String }) label: string | undefined = undefined;
 
   static styles = [styles];
 
+  private isEnglish() {
+    return this.lang.toLowerCase().startsWith('en');
+  }
+
   private get effectiveLabel() {
-    return this.label ?? (this.lang === 'en' ? 'Affected aspects' : 'Eksponerte sektorer');
+    return this.label ?? (this.isEnglish() ? 'Affected aspects' : 'Utsatte sektorer');
   }
 
   // Etiketter for de fire himmelretningene. Brukes til å plassere sirklene og teksten inni dem.
   private get directions() {
     return [
       { cx: 45, cy: 9, label: 'N' },
-      { cx: 81, cy: 45, label: this.lang === 'en' ? 'E' : 'Ø' },
+      { cx: 81, cy: 45, label: this.isEnglish() ? 'E' : 'Ø' },
       { cx: 45, cy: 81, label: 'S' },
-      { cx: 9, cy: 45, label: this.lang === 'en' ? 'W' : 'V' },
+      { cx: 9, cy: 45, label: this.isEnglish() ? 'W' : 'V' },
     ];
   }
 

--- a/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.component.ts
@@ -2,10 +2,15 @@ import { html, svg, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { INveComponent } from '@interfaces/NveComponent.interface';
 import styles from './nve-aspect-rose.styles';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 /**
  * Viser utsatte himmelretninger som en kompassrose.
  * Rosen er delt opp i 8 sektorer. Utsatte sektorer vises i rødt.
+ * @cssproperty --aspect-rose-size - Høyde og bredde på komponenten. 90px er standard.
+ * @cssproperty --aspect-rose-outline-color - Farge på sirkelens omriss. Standard er #c6c6c5.
+ * @cssproperty --aspect-rose-affected-color - Farge på utsatte sektorer. Standard er #d21523.
+ * @cssproperty --aspect-rose-unaffected-color - Farge på ikke-utsatte sektorer. Standard er #e3e3e3.
  */
 @customElement('nve-aspect-rose')
 export default class NveAspectRose extends LitElement implements INveComponent {
@@ -32,16 +37,16 @@ export default class NveAspectRose extends LitElement implements INveComponent {
   static styles = [styles];
 
   private get effectiveLabel() {
-    return this.label ?? (this.lang === 'no' ? 'Eksponerte sektorer' : 'Affected aspects');
+    return this.label ?? (this.lang === 'en' ? 'Affected aspects' : 'Eksponerte sektorer');
   }
 
   // Etiketter for de fire himmelretningene. Brukes til å plassere sirklene og teksten inni dem.
   private get directions() {
     return [
       { cx: 45, cy: 9, label: 'N' },
-      { cx: 81, cy: 45, label: this.lang === 'no' ? 'Ø' : 'E' },
+      { cx: 81, cy: 45, label: this.lang === 'en' ? 'E' : 'Ø' },
       { cx: 45, cy: 81, label: 'S' },
-      { cx: 9, cy: 45, label: this.lang === 'no' ? 'V' : 'W' },
+      { cx: 9, cy: 45, label: this.lang === 'en' ? 'W' : 'V' },
     ];
   }
 
@@ -49,6 +54,7 @@ export default class NveAspectRose extends LitElement implements INveComponent {
   private readonly rotations = [-22.5, 22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5];
 
   render() {
+    const value = /^[01]{8}$/.test(this.value) ? this.value : '00000000'; // Ignorer value hvis den ikke er gyldig
     return html`
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -57,6 +63,7 @@ export default class NveAspectRose extends LitElement implements INveComponent {
         height="100%"
         role="img"
         aria-label=${this.effectiveLabel}
+        testid=${ifDefined(this.testId)}
       >
         ${svg`<title>${this.effectiveLabel}</title>`}
         <g>
@@ -66,8 +73,8 @@ export default class NveAspectRose extends LitElement implements INveComponent {
                 d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z"
                 transform="rotate(${rot} 45 45)"
                 stroke-width="1"
-                stroke="#c6c6c5"
-                class=${this.value[i] === '1' ? 'sector--affected' : 'sector--unaffected'}
+                stroke="var(--aspect-rose-outline-color, #c6c6c5)"
+                class=${value[i] === '1' ? 'sector-affected' : 'sector-unaffected'}
               ></path>
             `
           )}
@@ -76,7 +83,7 @@ export default class NveAspectRose extends LitElement implements INveComponent {
         ${this.directions.map(
           ({ cx, cy, label }) => svg`
             <g>
-              <circle cx=${cx} cy=${cy} r="7.2" stroke-width="1" stroke="#69797a" fill="#fff"></circle>
+              <circle cx=${cx} cy=${cy} r="7.2" stroke-width="1" stroke="var(--aspect-rose-outline-color, #c6c6c5)" fill="#fff"></circle>
               <text x=${cx} y=${cy} dy="3.168" font-size="7.92" text-anchor="middle" fill="#6a7a7b">${label}</text>
             </g>
           `

--- a/src/components/nve-aspect-rose/nve-aspect-rose.styles.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.styles.ts
@@ -13,14 +13,12 @@ export default css`
   }
 
   .circle-outline {
-    stroke: #c6c6c5;
+    stroke: var(--aspect-rose-outline-color, #c6c6c5);
   }
-
-  .sector--affected {
-    fill: #d21523;
+  .sector-affected {
+    fill: var(--aspect-rose-affected-color, #d21523);
   }
-
-  .sector--unaffected {
-    fill: #e3e3e3;
+  .sector-unaffected {
+    fill: var(--aspect-rose-unaffected-color, #e3e3e3);
   }
 `;

--- a/src/components/nve-aspect-rose/nve-aspect-rose.styles.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.styles.ts
@@ -10,6 +10,7 @@ export default css`
   text {
     font-family: 'Source Sans 3', sans-serif;
     font-weight: var(--font-weight-regular);
+    font-size: 0.67rem;
   }
 
   .circle-outline {

--- a/src/components/nve-aspect-rose/nve-aspect-rose.styles.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.styles.ts
@@ -1,0 +1,26 @@
+import { css } from 'lit';
+
+export default css`
+  :host {
+    display: inline-block;
+    width: var(--aspect-rose-size, 90px);
+    height: var(--aspect-rose-size, 90px);
+  }
+
+  text {
+    font-family: 'Source Sans 3', sans-serif;
+    font-weight: var(--font-weight-regular);
+  }
+
+  .circle-outline {
+    stroke: #c6c6c5;
+  }
+
+  .sector--affected {
+    fill: #d21523;
+  }
+
+  .sector--unaffected {
+    fill: #e3e3e3;
+  }
+`;

--- a/src/components/nve-aspect-rose/nve-aspect-rose.test.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.test.ts
@@ -83,7 +83,7 @@ describe('nve-aspect-rose', () => {
   });
 
   it('shows english direction labels when lang is en', async () => {
-    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose lang="en"></nve-aspect-rose>`);
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose lang="en-GB"></nve-aspect-rose>`);
     const texts = el.shadowRoot?.querySelectorAll('text');
     const labels = Array.from(texts ?? []).map((t) => t.textContent);
     expect(labels).toContain('N');
@@ -101,13 +101,13 @@ describe('nve-aspect-rose', () => {
   it('uses default norwegian label when no label is set', async () => {
     const el = await fixture<NveAspectRose>(html`<nve-aspect-rose></nve-aspect-rose>`);
     const svg = el.shadowRoot?.querySelector('svg');
-    expect(svg?.getAttribute('aria-label')).toBe('Eksponerte sektorer');
+    expect(svg?.getAttribute('aria-label')).toBe('Utsatte sektorer');
   });
 
   it('uses default norwegian label when no label is set even if lang is set to something else', async () => {
     const el = await fixture<NveAspectRose>(html`<nve-aspect-rose lang="fr"></nve-aspect-rose>`);
     const svg = el.shadowRoot?.querySelector('svg');
-    expect(svg?.getAttribute('aria-label')).toBe('Eksponerte sektorer');
+    expect(svg?.getAttribute('aria-label')).toBe('Utsatte sektorer');
   });
 
   it('uses default english label when lang is en and no label is set', async () => {

--- a/src/components/nve-aspect-rose/nve-aspect-rose.test.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.test.ts
@@ -33,16 +33,16 @@ describe('nve-aspect-rose', () => {
   it('marks affected sectors with correct css class', async () => {
     const el = await fixture<NveAspectRose>(html`<nve-aspect-rose value="10000001"></nve-aspect-rose>`);
     const paths = el.shadowRoot?.querySelectorAll('path');
-    expect(paths?.[0].classList.contains('sector--affected')).toBe(true);
-    expect(paths?.[1].classList.contains('sector--unaffected')).toBe(true);
-    expect(paths?.[7].classList.contains('sector--affected')).toBe(true);
+    expect(paths?.[0].classList.contains('sector-affected')).toBe(true);
+    expect(paths?.[1].classList.contains('sector-unaffected')).toBe(true);
+    expect(paths?.[7].classList.contains('sector-affected')).toBe(true);
   });
 
   it('marks all sectors as unaffected when value is all zeros', async () => {
     const el = await fixture<NveAspectRose>(html`<nve-aspect-rose value="00000000"></nve-aspect-rose>`);
     const paths = el.shadowRoot?.querySelectorAll('path');
     paths?.forEach((path) => {
-      expect(path.classList.contains('sector--unaffected')).toBe(true);
+      expect(path.classList.contains('sector-unaffected')).toBe(true);
     });
   });
 
@@ -50,12 +50,30 @@ describe('nve-aspect-rose', () => {
     const el = await fixture<NveAspectRose>(html`<nve-aspect-rose value="11111111"></nve-aspect-rose>`);
     const paths = el.shadowRoot?.querySelectorAll('path');
     paths?.forEach((path) => {
-      expect(path.classList.contains('sector--affected')).toBe(true);
+      expect(path.classList.contains('sector-affected')).toBe(true);
+    });
+  });
+
+  it('marks all sectors as unaffected when value is not valid', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose value="1"></nve-aspect-rose>`);
+    const paths = el.shadowRoot?.querySelectorAll('path');
+    paths?.forEach((path) => {
+      expect(path.classList.contains('sector-unaffected')).toBe(true);
     });
   });
 
   it('shows norwegian direction labels by default', async () => {
     const el = await fixture<NveAspectRose>(html`<nve-aspect-rose></nve-aspect-rose>`);
+    const texts = el.shadowRoot?.querySelectorAll('text');
+    const labels = Array.from(texts ?? []).map((t) => t.textContent);
+    expect(labels).toContain('N');
+    expect(labels).toContain('Ø');
+    expect(labels).toContain('S');
+    expect(labels).toContain('V');
+  });
+
+  it('shows norwegian direction labels by default even if lang is set to something else', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose lang="fr"></nve-aspect-rose>`);
     const texts = el.shadowRoot?.querySelectorAll('text');
     const labels = Array.from(texts ?? []).map((t) => t.textContent);
     expect(labels).toContain('N');
@@ -82,6 +100,12 @@ describe('nve-aspect-rose', () => {
 
   it('uses default norwegian label when no label is set', async () => {
     const el = await fixture<NveAspectRose>(html`<nve-aspect-rose></nve-aspect-rose>`);
+    const svg = el.shadowRoot?.querySelector('svg');
+    expect(svg?.getAttribute('aria-label')).toBe('Eksponerte sektorer');
+  });
+
+  it('uses default norwegian label when no label is set even if lang is set to something else', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose lang="fr"></nve-aspect-rose>`);
     const svg = el.shadowRoot?.querySelector('svg');
     expect(svg?.getAttribute('aria-label')).toBe('Eksponerte sektorer');
   });

--- a/src/components/nve-aspect-rose/nve-aspect-rose.test.ts
+++ b/src/components/nve-aspect-rose/nve-aspect-rose.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { fixture, fixtureCleanup } from '@open-wc/testing';
+import { html } from 'lit';
+import NveAspectRose from './nve-aspect-rose.component';
+
+if (!customElements.get('nve-aspect-rose')) {
+  customElements.define('nve-aspect-rose', NveAspectRose);
+}
+
+describe('nve-aspect-rose', () => {
+  afterAll(() => {
+    fixtureCleanup();
+  });
+
+  it('is attached to the DOM', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose></nve-aspect-rose>`);
+    expect(document.body.contains(el)).toBe(true);
+  });
+
+  it('has correct default properties', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose></nve-aspect-rose>`);
+    expect(el.value).toBe('00000000');
+    expect(el.lang).toBe('no');
+    expect(el.label).toBeUndefined();
+  });
+
+  it('renders 8 sectors', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose></nve-aspect-rose>`);
+    const paths = el.shadowRoot?.querySelectorAll('path');
+    expect(paths?.length).toBe(8);
+  });
+
+  it('marks affected sectors with correct css class', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose value="10000001"></nve-aspect-rose>`);
+    const paths = el.shadowRoot?.querySelectorAll('path');
+    expect(paths?.[0].classList.contains('sector--affected')).toBe(true);
+    expect(paths?.[1].classList.contains('sector--unaffected')).toBe(true);
+    expect(paths?.[7].classList.contains('sector--affected')).toBe(true);
+  });
+
+  it('marks all sectors as unaffected when value is all zeros', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose value="00000000"></nve-aspect-rose>`);
+    const paths = el.shadowRoot?.querySelectorAll('path');
+    paths?.forEach((path) => {
+      expect(path.classList.contains('sector--unaffected')).toBe(true);
+    });
+  });
+
+  it('marks all sectors as affected when value is all ones', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose value="11111111"></nve-aspect-rose>`);
+    const paths = el.shadowRoot?.querySelectorAll('path');
+    paths?.forEach((path) => {
+      expect(path.classList.contains('sector--affected')).toBe(true);
+    });
+  });
+
+  it('shows norwegian direction labels by default', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose></nve-aspect-rose>`);
+    const texts = el.shadowRoot?.querySelectorAll('text');
+    const labels = Array.from(texts ?? []).map((t) => t.textContent);
+    expect(labels).toContain('N');
+    expect(labels).toContain('Ø');
+    expect(labels).toContain('S');
+    expect(labels).toContain('V');
+  });
+
+  it('shows english direction labels when lang is en', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose lang="en"></nve-aspect-rose>`);
+    const texts = el.shadowRoot?.querySelectorAll('text');
+    const labels = Array.from(texts ?? []).map((t) => t.textContent);
+    expect(labels).toContain('N');
+    expect(labels).toContain('E');
+    expect(labels).toContain('S');
+    expect(labels).toContain('W');
+  });
+
+  it('uses custom label as aria-label', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose label="Min tittel"></nve-aspect-rose>`);
+    const svg = el.shadowRoot?.querySelector('svg');
+    expect(svg?.getAttribute('aria-label')).toBe('Min tittel');
+  });
+
+  it('uses default norwegian label when no label is set', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose></nve-aspect-rose>`);
+    const svg = el.shadowRoot?.querySelector('svg');
+    expect(svg?.getAttribute('aria-label')).toBe('Eksponerte sektorer');
+  });
+
+  it('uses default english label when lang is en and no label is set', async () => {
+    const el = await fixture<NveAspectRose>(html`<nve-aspect-rose lang="en"></nve-aspect-rose>`);
+    const svg = el.shadowRoot?.querySelector('svg');
+    expect(svg?.getAttribute('aria-label')).toBe('Affected aspects');
+  });
+});

--- a/src/nve-designsystem.ts
+++ b/src/nve-designsystem.ts
@@ -1,8 +1,10 @@
 /** Alle komponenter som er tilgjengelige, i alfabetisk rekkefølge. */
 /** Denne filen blir genererert av pnpm run add-component */
+
 export { default as NveAccordion } from './components/nve-accordion/nve-accordion.component';
 export { default as NveAccordionItem } from './components/nve-accordion-item/nve-accordion-item.component';
 export { default as NveAlert } from './components/nve-alert/nve-alert.component';
+export { default as NveAspectRose } from './components/nve-aspect-rose/nve-aspect-rose.component';
 export { default as NveBadge } from './components/nve-badge/nve-badge.component';
 export { default as NveButton } from './components/nve-button/nve-button.component';
 export { default as NveCarousel } from './components/nve-carousel/nve-carousel.component';


### PR DESCRIPTION
Denne komponenten trenger vi på ny varsom.no og også i Regobs/Varsom-appen når vi skriver om dette til designsystemet.
Siden varsom.no bruker React og Regobs bruker Angular, ønsker vi å bruke en felles web-komponent for dette.
Her er link til saken for de som har tilgang: https://nveprojects.atlassian.net/browse/VAR-591

Jeg har tatt utgangspunkt i dagens [Angular/svg-komponent i Regobs](https://github.com/NVE/regObs4/tree/develop/src/app/components/observation/graphics/exposition), forenklet koden og gjort den litt mer fleksibel.
Jeg byttet ut skrifttypen med en vi bruker i desigsystemet, ellers har jeg beholdt fargene fra Regobs. Bruker gjerne mer offisielle farger fra Designsystemet, men da hadde det vært kjekt å se skissene i Figma først. Har spurt designerne om dette.

Håper denne komponenten kan få bo i designsystemet inntil vi finner en bedre plass!