### PR TITLE
fix(package.json): fjerner engines siden de tvinger alle konsumerende…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
   "homepage": "https://github.com/NVE/Designsystem/",
   "version": "4.4.0",
   "customElements": "dist/custom-elements.json",
-  "engines": {
-    "node": "^24.16.0"
-  },
   "exports": {
     ".": {
       "import": "./nve-designsystem.js",


### PR DESCRIPTION
Vi må fjerne engines fra package.json ellers tvinger vi alle konsumerende applikasjoner til å bruke den nyeste node versjon. Antar det er mange prosjekter som fortsatt bruker eldre node versjoner og kjører ds, og de bør ikke ignoreres.