### PR TITLE
fix(docs): profil og primitiver får sin egen side

### DIFF
--- a/doc-site/.vitepress/config.mts
+++ b/doc-site/.vitepress/config.mts
@@ -60,7 +60,7 @@ export default defineConfig({
               { text: 'Commit-meldinger', link: '/introduction/forDesigner/commitMessages' },
             ],
           },
-                    {
+          {
             text: 'Designelementer',
             items: [
               { text: 'Tokens', link: '/introduction/designelementer/tokens' },
@@ -71,6 +71,7 @@ export default defineConfig({
               { text: 'Animasjoner', link: '/introduction/designelementer/animasjoner' },
             ],
           },
+          { text: 'Profil og primitiver', link: '/introduction/profilOgPrimitiver' },
           { text: 'Universell Utforming', link: '/introduction/universellUtforming' },
         ],
       },

--- a/doc-site/introduction/designelementer/tokens.md
+++ b/doc-site/introduction/designelementer/tokens.md
@@ -28,25 +28,18 @@ Dataen knyttet til token-navnet. Dette er ikke tokens men endelig verdier (for e
 
 ### Global tokens (base-tokens)
 
-Global tokens (base-tokens)
 En token brukt på tvers av designsystemet. Dette er det motsatte av en komponentspesifikk token.
 
 ### Alias tokens
 
-Alias tokens
 En token som refererer til en annen token, i stedet for å referere til en hardkodet verdi.
 
 ### Component specific tokens
 
-Component specific tokens
 En token brukt for en bestemt komponent.
 
 ### Private tokens
 
-Private tokens
 Tokenene i denne nivået lagrer vi ekstra rå verdiene vi ikke bruker og bygger oss en bank med verdier som kan brukes for videre ekspansjon og endringer.
 
 <hr>
-
-**Les om fler designelementer på**
-<LinkButton URL="https://nve.frontify.com/" text="Profil og primitiver" :openInNewTab="true"/>

--- a/doc-site/introduction/profilOgPrimitiver.md
+++ b/doc-site/introduction/profilOgPrimitiver.md
@@ -1,0 +1,24 @@
+<PageHeader title="Profil og primitiver" imagePath="intro" pageLevel=1></PageHeader>
+
+I tillegg til dokumentasjonen i designsystemet finner du NVEs visuelle profilmanual i [Frontify](https://nve.frontify.com/d/n2ujvoktZ3dr/nve-profil#/introduksjon/profilmanual). Der finner du blant annet:
+
+- Retningslinjer for bruk av logo
+- Fargepaletter
+- Typografi
+- Grafiske elementer
+- Ikoner
+- Illustrasjoner
+- Malverk
+
+---
+
+Har du spørsmål om profilmanualen ber vi deg ta kontakt med KOM, seksjon for kommunikasjon. KOM har det overordnede ansvaret for NVEs interne og eksterne kommunikasjon, inkludert grafisk arbeid.
+
+Mer informasjon finner du under:
+<nve-button
+    variant="tertiary"
+    href="https://nve.frontify.com/d/n2ujvoktZ3dr/nve-profil#/introduksjon/profilmanual"
+    target="_blank"
+    >Profil og primitiver
+<nve-icon name="open_in_new" slot="end"></nve-icon>
+</nve-button>


### PR DESCRIPTION
- Fjernet utdatert lenke til Frontify. 
- La til egen side for "Profil og primitiver" under sidemenyen på venstre side etter ønske fra KOM/DS-gruppa. Nå skal det være enklere å finne frem til Frontify fra dokumentasjonssiden.

Ta gjerne en titt på teksten, fant informasjon om KOM på intranettet.
